### PR TITLE
feat: add stub package for electron-forge

### DIFF
--- a/packages/api/electron-forge/package.json
+++ b/packages/api/electron-forge/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "electron-forge",
+  "version": "6.0.0-beta.49",
+  "description": "A complete tool for building modern Electron applications",
+  "repository": "https://github.com/electron-userland/electron-forge",
+  "author": "Samuel Attard",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "dependencies": {
+    "@electron-forge/cli": "6.0.0-beta.49",
+    "@electron-forge/core": "6.0.0-beta.49"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
+  }
+}

--- a/packages/api/electron-forge/src/index.ts
+++ b/packages/api/electron-forge/src/index.ts
@@ -1,0 +1,1 @@
+export * from '@electron-forge/core';


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [ ] The changes are appropriately documented (if applicable).

**Summarize your changes:**

Adds a simple wrapper node module for the `electron-forge` package, to ease the transition. This is particularly useful for outdated blog articles which use that package name.

If approved, do not merge until just before 6.0.0 stable is released.

### TODO

* [ ] add migration? docs to the website?