### PR TITLE
feat(plugin-webpack): Package all webpack `externals` and their dependencies

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import webpack, { Configuration, WebpackPluginInstance } from 'webpack';
 import { merge as webpackMerge } from 'webpack-merge';
 import { WebpackPluginConfig, WebpackPluginEntryPoint, WebpackPreloadEntryPoint } from './Config';
+import { getExternalsFromConfig } from './util/Externals';
 
 type EntryType = string | string[] | Record<string, string | string[]>;
 
@@ -124,6 +125,13 @@ export default class WebpackConfigGenerator {
     return defines;
   }
 
+  getExternals(entryPoints: WebpackPluginEntryPoint[]): string[] {
+    const mainExternals = getExternalsFromConfig(this.getMainConfig());
+    const rendererExternals = getExternalsFromConfig(this.getRendererConfig(entryPoints));
+
+    return Array.from(new Set([...mainExternals, ...rendererExternals]));
+  }
+
   sourceMapOption() {
     return this.isProd ? 'source-map' : 'eval-source-map';
   }
@@ -199,7 +207,7 @@ export default class WebpackConfigGenerator {
     { target: 'electron-preload' });
   }
 
-  async getRendererConfig(entryPoints: WebpackPluginEntryPoint[]) {
+  getRendererConfig(entryPoints: WebpackPluginEntryPoint[]) {
     const rendererConfig = this.resolveConfig(this.pluginConfig.renderer.config);
     const entry: webpack.Entry = {};
     for (const entryPoint of entryPoints) {

--- a/packages/plugin/webpack/src/util/Externals.ts
+++ b/packages/plugin/webpack/src/util/Externals.ts
@@ -1,0 +1,60 @@
+import webpack from 'webpack';
+import { Walker, DepType } from 'flora-colossus';
+import * as path from 'path';
+
+const IGNORED_MODULES = ['electron'];
+
+// eslint-disable-next-line import/prefer-default-export
+export function getExternalsFromConfig(config: webpack.Configuration): string[] {
+  const modules: string[] = [];
+
+  if (config.externals) {
+    if (Array.isArray(config.externals)) {
+      for (const external of config.externals) {
+        if (typeof external === 'string') {
+          modules.push(external);
+        }
+      }
+
+      return modules;
+    }
+
+    if (typeof config.externals === 'object') {
+      return Object.keys(config.externals);
+    }
+  }
+
+  return [];
+}
+
+async function getDependenciesForModule(rootDir: string, mod: string): Promise<string[]> {
+  if (IGNORED_MODULES.includes(mod)) {
+    return [];
+  }
+
+  try {
+    const moduleRoot = path.dirname(
+      require.resolve(`${mod}/package.json`, { paths: [rootDir] }),
+    );
+
+    const walker = new Walker(moduleRoot) as any;
+
+    // These are private so it's quite nasty for now!
+    walker.modules = [];
+    await walker.walkDependenciesForModule(moduleRoot, DepType.PROD);
+    return walker.modules.map((dep: { name: string }) => dep.name);
+  } catch (_) {
+    return [];
+  }
+}
+
+export async function getDependenciesForModules(
+  rootDir: string,
+  modules: string[],
+): Promise<string[]> {
+  const dependencies = await Promise.all(
+    modules.map((mod) => getDependenciesForModule(rootDir, mod)),
+  );
+
+  return Array.from(new Set(modules.concat(...dependencies)));
+}


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [ ] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

This brings the functionality of [this plugin](https://www.npmjs.com/package/@timfish/forge-externals-plugin) and enables it by default.

- Collects Webpack [`externals`](https://webpack.js.org/configuration/externals/) from both main and renderer configs
- Finds all their dependencies using `flora-colossus`
- Ensures the correct directories in `node_modules` get included in the packaged app

This makes it particularly easy to get native modules working if they don't work well with Webpack. You just add them to Webpack externals and everything should work.

Notes:
- This doesn't work with monorepos with hoisted modules
- It currently uses private fields and methods of `flora-colossus`
- Not yet tested in combination with Vercel loader



