### PR TITLE
fix: replace spaces with dot for comparison

### DIFF
--- a/packages/publisher/github/src/PublisherGithub.ts
+++ b/packages/publisher/github/src/PublisherGithub.ts
@@ -101,7 +101,7 @@ export default class PublisherGithub extends PublisherBase<PublisherGitHubConfig
           };
           const artifactName = path.basename(artifactPath);
           // eslint-disable-next-line max-len
-          if (release!.assets.find((asset: OctokitReleaseAsset) => asset.name === artifactName)) {
+          if (release!.assets.find((asset: OctokitReleaseAsset) => asset.name === artifactName.replace(/ /g, '.'))) {
             return done();
           }
           await github.getGitHub().repos.uploadReleaseAsset({


### PR DESCRIPTION
* [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
* [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
* [ ] The changes are appropriately documented (if applicable).
* [ ] The changes have sufficient test coverage (if applicable).
* [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Spaces are replaced with dots for Github release assets... A comparison in the publisher for github compares existing names and is support to skip any files already present. Becuase duplicate assets do not correspond the assets are sent again which will result in a 422 response and thus an error exit.
