### PR TITLE
fix(publisher-s3): ensure files are on disk before publishing

### DIFF
--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -31,12 +31,14 @@ export default class PublisherS3 extends PublisherBase<PublisherS3Config> {
 
     for (const makeResult of makeResults) {
       artifacts.push(
-        ...makeResult.artifacts.map((artifact) => ({
-          path: artifact,
-          keyPrefix: this.config.folder || makeResult.packageJSON.version,
-          platform: makeResult.platform,
-          arch: makeResult.arch,
-        }))
+        ...makeResult.artifacts
+          .filter((artifact) => fs.existsSync(artifact))
+          .map((artifact) => ({
+            path: artifact,
+            keyPrefix: this.config.folder || makeResult.packageJSON.version,
+            platform: makeResult.platform,
+            arch: makeResult.arch,
+          }))
       );
     }
 


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

When making with windows.squirrel and the noDelta options selected, the
delta package will end up in the artifacts list and kill the publishing
phase. Although unrelated, this will only publish files that are
actually on disk at the time of publishing.