### PR TITLE
feat: allow a custom out dir from forge config

### DIFF
--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -94,7 +94,7 @@ export default async ({
     forgeConfig = await getForgeConfig(dir);
   });
 
-  const actualOutDir = outDir || getCurrentOutDir(dir, forgeConfig);
+  const actualOutDir = outDir || forgeConfig.outDir || getCurrentOutDir(dir, forgeConfig);
 
   const actualTargetPlatform = platform;
   platform = platform === 'mas' ? 'darwin' : platform;

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -98,7 +98,7 @@ export default async ({
     throw new Error('packageJSON.main must be set to a valid entry point for your Electron app');
   }
 
-  const calculatedOutDir = outDir || getCurrentOutDir(dir, forgeConfig);
+  const calculatedOutDir = outDir || forgeConfig.outDir || getCurrentOutDir(dir, forgeConfig);
   let packagerSpinner: OraImpl | undefined;
 
   const pruneEnabled = !('prune' in forgeConfig.packagerConfig) || forgeConfig.packagerConfig.prune;

--- a/packages/api/core/src/api/publish.ts
+++ b/packages/api/core/src/api/publish.ts
@@ -82,7 +82,7 @@ const publish = async ({
 
   const forgeConfig = await getForgeConfig(dir);
 
-  const calculatedOutDir = outDir || getCurrentOutDir(dir, forgeConfig);
+  const calculatedOutDir = outDir || forgeConfig.outDir || getCurrentOutDir(dir, forgeConfig);
   const dryRunDir = path.resolve(calculatedOutDir, 'publish-dry-run');
 
   if (dryRunResume) {

--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -25,6 +25,7 @@ export interface ForgeConfig {
    * If a function is provided, it must synchronously return the buildIdentifier
    */
   buildIdentifier?: string | (() => string);
+  outDir?: string,
   hooks?: {
     [hookName: string]: ForgeHookFn;
   };


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [X] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [X] The changes have sufficient test coverage (if applicable).
- [X] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This PR allows using a custom outDir when packaging and making an app.
A new top-level `outDir` optional string property is added to the forgeConfig object to do so.

This PR aims to:
- help people who don't like (or are not allowed) to mix binaries with code 
- help Windows users to manage the ~~electron-winstaller~~ Squirrel infamous issue with long paths since files can be relocated easily
- help monorepo users who can't use asar to solve the long path issue because of symlink issues (which should anyway be a design decision)

Related issues:
- https://github.com/electron-userland/electron-forge/issues/1041
- https://github.com/electron-userland/electron-forge/issues/214
- https://github.com/electron/windows-installer/issues/219
- https://github.com/electron/windows-installer/issues/301 

