### PR TITLE
fix(maker-pkg): add targetArch to pkg name

### DIFF
--- a/packages/maker/pkg/src/MakerPKG.ts
+++ b/packages/maker/pkg/src/MakerPKG.ts
@@ -14,12 +14,12 @@ export default class MakerDMG extends MakerBase<MakerPKGConfig> {
     return process.platform === 'darwin';
   }
 
-  async make({ dir, makeDir, appName, packageJSON, targetPlatform }: MakerOptions): Promise<string[]> {
+  async make({ dir, makeDir, appName, packageJSON, targetPlatform, targetArch }: MakerOptions): Promise<string[]> {
     if (!['darwin', 'mas'].includes(targetPlatform)) {
       throw new Error(`The pkg maker only supports targetting "mas" and "darwin" builds.  You provided "${targetPlatform}"`);
     }
 
-    const outPath = path.resolve(makeDir, `${appName}-${packageJSON.version}.pkg`);
+    const outPath = path.resolve(makeDir, `${appName}-${packageJSON.version}-${targetArch}.pkg`);
 
     await this.ensureFile(outPath);
 

--- a/packages/maker/pkg/test/MakerPKG_spec.ts
+++ b/packages/maker/pkg/test/MakerPKG_spec.ts
@@ -69,7 +69,7 @@ describe('MakerPKG', () => {
     const opts = eosStub.firstCall.args[0];
     expect(opts).to.deep.equal({
       app: path.resolve(`${dir}/My Test App.app`),
-      pkg: path.resolve(`${dir.substr(0, dir.length - 4)}/make/My Test App-1.2.3.pkg`),
+      pkg: path.resolve(`${dir.substr(0, dir.length - 4)}/make/My Test App-1.2.3-${targetArch}.pkg`),
       platform: 'mas',
     });
   });


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Made a minor change to added targetArch to pkg name to be consistent with dmg maker. 