### PR TITLE
chore(plugin-webpack): use trailing slash in dev mode entrypoint baseUrl

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -76,7 +76,7 @@ export default class WebpackConfigGenerator {
     }
     const baseUrl = `http://localhost:${this.port}/${entryPoint.name}/`;
     if (basename !== 'index.html') {
-      return new URL(basename, baseUrl).href;
+      return `'${new URL(basename, baseUrl).href}'`;
     }
     return `'${baseUrl}'`;
   }

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -74,9 +74,9 @@ export default class WebpackConfigGenerator {
     if (this.isProd) {
       return `\`file://$\{require('path').resolve(__dirname, '..', '${inRendererDir ? 'renderer' : '.'}', '${entryPoint.name}', '${basename}')}\``;
     }
-    const baseUrl = `http://localhost:${this.port}/${entryPoint.name}`;
+    const baseUrl = `http://localhost:${this.port}/${entryPoint.name}/`;
     if (basename !== 'index.html') {
-      return `'${baseUrl}/${basename}'`;
+      return new URL(basename, baseUrl).href;
     }
     return `'${baseUrl}'`;
   }

--- a/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
+++ b/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
@@ -49,7 +49,7 @@ function createSimpleDevServer(rendererOut: string): http.Server {
   return http
     .createServer(async (req, res) => {
       const url = req.url || '';
-      const file = url.endsWith('main_window') ? path.join(url, '/index.html') : url;
+      const file = url.endsWith('main_window/') ? path.join(url, 'index.html') : url;
       const fullPath = path.join(rendererOut, file);
       try {
         const data = await readFile(fullPath);


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/master/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/master/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This better reflects the reality that it's a directory, and it makes it easier to construct relative URLs via `new URL('foo/', window.location.href)` which would otherwise strip the entrypoint name.