### PR TITLE
docs: add READMEs to packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,6 @@ packages/**/yarn.lock
 packages/*/*/index.ts
 packages/.old
 packages/utils/types/index.d.ts
-packages/maker/**/README.md
-packages/publisher/**/README.md
-packages/plugin/**/README.md
 packages/api/cli/README.md
 !packages/**/base/README.md
 !/README.md

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "docs": "bolt build:full && bolt docs:generate",
     "docs:generate": "bolt docs:plugin && node --max-old-space-size=8192 -r ts-node/register ./tools/gen-docs.ts",
     "docs:plugin": "cd ./tools/doc-plugin && yarn build",
-    "docs:deploy:build": "ts-node tools/sync-readmes.ts && bolt docs",
+    "docs:deploy:build": "bolt docs",
     "lint": "prettier --check . && eslint .",
     "lint:fix": "prettier --write .",
     "test": "xvfb-maybe cross-env TS_NODE_PROJECT='./tsconfig.test.json' TS_NODE_FILES=1 mocha './tools/test-globber.ts'",
@@ -150,6 +150,7 @@
     "typedoc": "^0.22.15",
     "typedoc-plugin-missing-exports": "^1.0.0",
     "typedoc-plugin-rename-defaults": "^0.6.4",
+    "@knodes/typedoc-plugin-monorepo-readmes": "0.22.5",
     "typescript": "^4.6.3",
     "xvfb-maybe": "^0.2.1"
   },

--- a/packages/maker/appx/README.md
+++ b/packages/maker/appx/README.md
@@ -1,0 +1,18 @@
+## Electron Forge: Maker APPX
+
+`@electron-forge/maker-appx` builds `.appx` packages, which are designed to target the Windows Store.
+
+You can only build the AppX target on Windows machines with the Windows 10 SDK installed.
+
+Configuration options are documented in [MakerAppXConfig](https://js.electronforge.io/interfaces/_electron_forge_maker_appx.MakerAppXConfig.html).
+
+```
+{
+  name: '@electron-forge/maker-appx',
+  config: {
+    publisher: 'CN=developmentca',
+    devCert: 'C:\\devcert.pfx',
+    certPass: 'abcd'
+  }
+}
+```

--- a/packages/maker/appx/README.md
+++ b/packages/maker/appx/README.md
@@ -1,10 +1,10 @@
-## Electron Forge: Maker APPX
+## maker-appx
 
 `@electron-forge/maker-appx` builds `.appx` packages, which are designed to target the Windows Store.
 
 You can only build the AppX target on Windows machines with the Windows 10 SDK installed.
 
-Configuration options are documented in [MakerAppXConfig](https://js.electronforge.io/interfaces/_electron_forge_maker_appx.MakerAppXConfig.html).
+Configuration options are documented in [`MakerAppXConfig`](https://js.electronforge.io/interfaces/_electron_forge_maker_appx.MakerAppXConfig.html).
 
 ```
 {

--- a/packages/maker/deb/README.md
+++ b/packages/maker/deb/README.md
@@ -4,13 +4,15 @@
 
 Configuration options are documented in [MakerDebConfigOptions](https://js.electronforge.io/interfaces/_electron_forge_maker_deb._internal_.MakerDebConfigOptions.html).
 
+```
 {
   name: '@electron-forge/maker-deb',
   config: {
     options: {
-      maintainer: 'Joe Bloggs',
+      maintainer: 'The Forgers',
       homepage: 'https://example.com',
       icon: 'path/to/icon.svg'
     }
   }
 }
+```

--- a/packages/maker/deb/README.md
+++ b/packages/maker/deb/README.md
@@ -1,0 +1,16 @@
+## Electron Forge: Maker Deb
+
+`@electron-forge/maker-deb` builds .deb packages, which are the standard package format for Debian-based Linux distributions such as Ubuntu. You can only build the deb target on Linux or macOS machines with the fakeroot and dpkg packages installed.
+
+Configuration options are documented in [MakerDebConfigOptions](https://js.electronforge.io/interfaces/_electron_forge_maker_deb._internal_.MakerDebConfigOptions.html).
+
+{
+  name: '@electron-forge/maker-deb',
+  config: {
+    options: {
+      maintainer: 'Joe Bloggs',
+      homepage: 'https://example.com',
+      icon: 'path/to/icon.svg'
+    }
+  }
+}

--- a/packages/maker/deb/README.md
+++ b/packages/maker/deb/README.md
@@ -1,8 +1,8 @@
-## Electron Forge: Maker Deb
+## maker-deb
 
 `@electron-forge/maker-deb` builds .deb packages, which are the standard package format for Debian-based Linux distributions such as Ubuntu. You can only build the deb target on Linux or macOS machines with the fakeroot and dpkg packages installed.
 
-Configuration options are documented in [MakerDebConfigOptions](https://js.electronforge.io/interfaces/_electron_forge_maker_deb._internal_.MakerDebConfigOptions.html).
+Configuration options are documented in [`MakerDebConfigOptions`](https://js.electronforge.io/interfaces/_electron_forge_maker_deb._internal_.MakerDebConfigOptions.html).
 
 ```
 {

--- a/packages/maker/dmg/README.md
+++ b/packages/maker/dmg/README.md
@@ -1,0 +1,15 @@
+## Electron Forge: Maker DMG
+
+`@electron-forge/maker-dmg` builds `.dmg` files, which are the standard format for sharing macOS apps. You can only build the DMG target on macOS machines.
+
+Configuration options are documented in [`MakerDMGConfig`](https://js.electronforge.io/interfaces/_electron_forge_maker_dmg.MakerDMGConfig.html).
+
+```javascript
+{
+  name: '@electron-forge/maker-dmg',
+  config: {
+    background: './assets/dmg-background.png',
+    format: 'ULFO'
+  }
+}
+```

--- a/packages/maker/dmg/README.md
+++ b/packages/maker/dmg/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: Maker DMG
+## maker-dmg
 
 `@electron-forge/maker-dmg` builds `.dmg` files, which are the standard format for sharing macOS apps. You can only build the DMG target on macOS machines.
 

--- a/packages/maker/flatpak/README.md
+++ b/packages/maker/flatpak/README.md
@@ -1,0 +1,19 @@
+## Electron Forge: Maker Flatpak
+
+`@electron-forge/maker-flatpak` [`.flatpak` files](http://flatpak.org/), which is a packaging format for Linux distributions that allows for sandboxed installation of applications in isolation from the rest of their system.
+
+You can only build the Flatpak target if you have `flatpak`, `flatpak-builder`, and `eu-strip` _\(usually part of the `elfutils` package\)_ installed on your system.
+
+Configuration options are documented in [`MakerFlatpakOptionsConfig`](https://js.electronforge.io/interfaces/_electron_forge_maker_flatpak._internal_.MakerFlatpakOptionsConfig.html).
+
+```javascript
+{
+  name: '@electron-forge/maker-flatpak',
+  config: {
+    options: {
+      categories: ['Video'],
+      mimeType: ['video/h264']
+    }
+  }
+}
+```

--- a/packages/maker/flatpak/README.md
+++ b/packages/maker/flatpak/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: Maker Flatpak
+## maker-flatpak
 
 `@electron-forge/maker-flatpak` [`.flatpak` files](http://flatpak.org/), which is a packaging format for Linux distributions that allows for sandboxed installation of applications in isolation from the rest of their system.
 

--- a/packages/maker/pkg/README.md
+++ b/packages/maker/pkg/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: Maker PKG
+## maker-pkg
 
 `@electron-forge/maker-pkg` builds `.pkg` files for macOS. These are used to upload your application to the Mac App Store or just as an alternate distribution method for macOS users.  You can only build the Pkg target on macOS machines while targeting the `darwin`  or `mas` platforms.
 

--- a/packages/maker/pkg/README.md
+++ b/packages/maker/pkg/README.md
@@ -1,0 +1,14 @@
+## Electron Forge: Maker PKG
+
+`@electron-forge/maker-pkg` builds `.pkg` files for macOS. These are used to upload your application to the Mac App Store or just as an alternate distribution method for macOS users.  You can only build the Pkg target on macOS machines while targeting the `darwin`  or `mas` platforms.
+
+Configuration options are documented in [`MakerPkgConfig`](https://js.electronforge.io/interfaces/_electron_forge_maker_pkg.MakerPKGConfig.html).
+
+```javascript
+{
+  name: '@electron-forge/maker-pkg',
+  config: {
+    keychain: 'my-secret-ci-keychain'
+  }
+}
+```

--- a/packages/maker/rpm/README.md
+++ b/packages/maker/rpm/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: Maker RPM
+## maker-rpm
 
 `@electron-forge/maker-rpm` builds `.rpm` files, which is the standard package format for RedHat-based Linux distributions such as Fedora.
 

--- a/packages/maker/rpm/README.md
+++ b/packages/maker/rpm/README.md
@@ -1,0 +1,19 @@
+## Electron Forge: Maker RPM
+
+`@electron-forge/maker-rpm` builds `.rpm` files, which is the standard package format for RedHat-based Linux distributions such as Fedora.
+
+You can only build the RPM target on Linux machines with the `rpm` or `rpm-build` packages installed.
+
+Configuration options are documented in [`MakerRpmConfigOptions`](https://js.electronforge.io/interfaces/_electron_forge_maker_rpm._internal_.MakerRpmConfigOptions.html).
+
+```javascript
+{
+  name: '@electron-forge/maker-rpm',
+  config: {
+    options: {
+      name: 'QuickEdit',
+      homepage: 'http://example.com'
+    }
+  }
+}
+```

--- a/packages/maker/snap/README.md
+++ b/packages/maker/snap/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: Maker Snap
+## maker-snap
 
 `@electron-forge/maker-snap` builds `.snap` files, which is the packaging format created and sponsored by Canonical, the company behind Ubuntu. It is a sandboxed package format that lets users of various Linux distributions install your application in an isolated environment on their machine.
 

--- a/packages/maker/snap/README.md
+++ b/packages/maker/snap/README.md
@@ -1,0 +1,20 @@
+## Electron Forge: Maker Snap
+
+`@electron-forge/maker-snap` builds `.snap` files, which is the packaging format created and sponsored by Canonical, the company behind Ubuntu. It is a sandboxed package format that lets users of various Linux distributions install your application in an isolated environment on their machine.
+
+You can only build the Snapcraft target on Linux systems with the `snapcraft` package installed.
+
+```
+{
+  name: '@electron-forge/maker-snap',
+  config: {
+    version: "1.1.0",
+    features: {
+      audio: true,
+      mpris: 'com.example.mpris',
+      webgl: true
+    },
+    summary: 'My application'
+  }
+}
+```

--- a/packages/maker/squirrel/README.md
+++ b/packages/maker/squirrel/README.md
@@ -1,0 +1,19 @@
+## Electron Forge: Maker Squirrel
+
+`@electron-forge/maker-squirrel` builds a number of files required to distribute apps using the Squirrel.Windows framework. It generates a `{appName} Setup.exe` file which is the main installer for your application, `{appName}-full.nupkg` and a `RELEASES` file which you use to issue updates to your application.
+
+Pre-requisites:
+* Windows machine
+* MacOS /Linux machine with `mono` and `wine` installed.
+
+Configuration options are documented in [`MakerSquirrelConfigOptions`](https://js.electronforge.io/interfaces/_electron_forge_maker_squirrel._internal_.Options.html).
+
+```javascript
+{
+  "name": "@electron-forge/maker-squirrel",
+  "config": {
+    "certificateFile": "./cert.pfx",
+    "certificatePassword": "this-is-a-secret"
+  }
+}
+```

--- a/packages/maker/squirrel/README.md
+++ b/packages/maker/squirrel/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: Maker Squirrel
+## maker-squirrel
 
 `@electron-forge/maker-squirrel` builds a number of files required to distribute apps using the Squirrel.Windows framework. It generates a `{appName} Setup.exe` file which is the main installer for your application, `{appName}-full.nupkg` and a `RELEASES` file which you use to issue updates to your application.
 

--- a/packages/maker/wix/README.md
+++ b/packages/maker/wix/README.md
@@ -1,5 +1,5 @@
 
-## ## Electron Forge: Maker Wix MSI
+## maker-wix-msi
 
 The WiX MSI target builds `.msi` files, which are "traditional" Windows installer files.
 

--- a/packages/maker/wix/README.md
+++ b/packages/maker/wix/README.md
@@ -1,0 +1,19 @@
+
+## ## Electron Forge: Maker Wix MSI
+
+The WiX MSI target builds `.msi` files, which are "traditional" Windows installer files.
+
+Pre-requisites:
+* `light` and `candle` installed from [the WiX toolkit](https://github.com/felixrieseberg/electron-wix-msi#prerequisites).
+
+Configuration options are documented in [`MakerWixConfig`](https://js.electronforge.io/interfaces/_electron_forge_maker_wix.MakerWixConfig.html).
+
+```javascript
+{
+  name: '@electron-forge/maker-wix',
+  config: {
+    language: 1033,
+    manufacturer: 'My Awesome Company'
+  }
+}
+```

--- a/packages/maker/zip/README.md
+++ b/packages/maker/zip/README.md
@@ -1,0 +1,11 @@
+## Electron Forge: Maker Zip
+
+`@electron-forge/maker-zip` builds basic `.zip` files containing your packaged application. There are no platform specific dependencies for using this maker and it will run on any platform.
+
+Note: There are no configuration options for this target.
+
+```
+{
+  name: '@electron-forge/maker-zip'
+}
+```

--- a/packages/maker/zip/README.md
+++ b/packages/maker/zip/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: Maker Zip
+## maker-zip
 
 `@electron-forge/maker-zip` builds basic `.zip` files containing your packaged application. There are no platform specific dependencies for using this maker and it will run on any platform.
 

--- a/packages/plugin/auto-unpack-natives/README.md
+++ b/packages/plugin/auto-unpack-natives/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: Auto Unpack Native Modules
+## plugin-auto-unpack-natives
 
 This plugin will automatically add all native Node modules in your node_modules folder to the `asar.unpack` config option in your `packagerConfig`. If your app uses native Node modules, you should probably use this to reduce loading times and disk consumption on your users' machines.
 

--- a/packages/plugin/auto-unpack-natives/README.md
+++ b/packages/plugin/auto-unpack-natives/README.md
@@ -1,0 +1,15 @@
+## Electron Forge: Auto Unpack Native Modules
+
+This plugin will automatically add all native Node modules in your node_modules folder to the `asar.unpack` config option in your `packagerConfig`. If your app uses native Node modules, you should probably use this to reduce loading times and disk consumption on your users' machines.
+
+```
+// forge.config.js
+
+module.exports = {
+  plugins: [
+   {
+     name: '@electron-forge/plugin-auto-unpack-natives'
+   }
+  ]
+}
+```

--- a/packages/plugin/compile/README.md
+++ b/packages/plugin/compile/README.md
@@ -1,0 +1,3 @@
+## Electron Forge: Compile Plugin
+
+_Note: This plugin is deprecated in Forge 6.0.0 and is slated for removal._

--- a/packages/plugin/compile/README.md
+++ b/packages/plugin/compile/README.md
@@ -1,3 +1,3 @@
-## Electron Forge: Compile Plugin
+## plugin-compile
 
 _Note: This plugin is deprecated in Forge 6.0.0 and is slated for removal._

--- a/packages/plugin/compile/src/CompilePlugin.ts
+++ b/packages/plugin/compile/src/CompilePlugin.ts
@@ -6,7 +6,7 @@ import { ForgeHookFn } from '@electron-forge/shared-types';
 import { CompilePluginConfig } from './Config';
 import { createCompileHook } from './lib/compile-hook';
 
-export default class CompileElectronPlugin extends PluginBase<CompilePluginConfig> {
+export default class CompilePlugin extends PluginBase<CompilePluginConfig> {
   name = 'electron-compile';
 
   private dir!: string;

--- a/packages/plugin/compile/src/CompilePlugin.ts
+++ b/packages/plugin/compile/src/CompilePlugin.ts
@@ -6,7 +6,7 @@ import { ForgeHookFn } from '@electron-forge/shared-types';
 import { CompilePluginConfig } from './Config';
 import { createCompileHook } from './lib/compile-hook';
 
-export default class CompilePlugin extends PluginBase<CompilePluginConfig> {
+export default class CompileElectronPlugin extends PluginBase<CompilePluginConfig> {
   name = 'electron-compile';
 
   private dir!: string;

--- a/packages/plugin/electronegativity/README.md
+++ b/packages/plugin/electronegativity/README.md
@@ -1,0 +1,18 @@
+## Electron Forge: Electronegativity
+
+The Electronegativity plugin integrates Doyensec's Electronegativity tool into the Electron Forge workflow. After packaging your Electron app, it identifies any known misconfigurations and security anti-patterns.
+
+```
+// forge.config.js
+
+module.exports = {
+  plugins: [
+    [
+      '@electron-forge/plugin-electronegativity',
+      {
+        isSarif: true
+      }
+    ]
+  ]
+}
+```

--- a/packages/plugin/electronegativity/README.md
+++ b/packages/plugin/electronegativity/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: Electronegativity
+## plugin-electronegativity
 
 The Electronegativity plugin integrates Doyensec's Electronegativity tool into the Electron Forge workflow. After packaging your Electron app, it identifies any known misconfigurations and security anti-patterns.
 

--- a/packages/plugin/local-electron/README.md
+++ b/packages/plugin/local-electron/README.md
@@ -1,0 +1,16 @@
+## Electron Forge: Local Electron
+
+This plugin allows you to both run and build your app using a local build of Electron. This can be incredibly useful if you want to test a feature or a bug fix in your app before making a PR up to the Electron repository.
+
+_Note: This plugin should only be used by people who are building Electron locally themselves. If you want to set up a local build of Electron, you should check out [Electron Build Tools](https://github.com/electron/build-tools)._
+
+```
+// forge.config.js
+
+{
+    name: '@electron-forge/plugin-local-electron',
+    config: {
+    electronPath: '/Users/me/projects/electron/out/Testing',
+    },
+},
+```

--- a/packages/plugin/local-electron/README.md
+++ b/packages/plugin/local-electron/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: Local Electron
+## plugin-local-electron
 
 This plugin allows you to both run and build your app using a local build of Electron. This can be incredibly useful if you want to test a feature or a bug fix in your app before making a PR up to the Electron repository.
 

--- a/packages/plugin/webpack/README.md
+++ b/packages/plugin/webpack/README.md
@@ -1,8 +1,6 @@
-## Electron Forge: Local Electron
+## plugin-webpack
 
-This plugin allows you to both run and build your app using a local build of Electron. This can be incredibly useful if you want to test a feature or a bug fix in your app before making a PR up to the Electron repository.
-
-_Note: This plugin should only be used by people who are building Electron locally themselves. If you want to set up a local build of Electron, you should check out [Electron Build Tools](https://github.com/electron/build-tools)._
+This plugin makes it easy to set up standard webpack tooling to compile both your main process code and your renderer process code, with built-in support for Hot Module Replacement (HMR) in the renderer process and support for multiple renderers.
 
 ```
 // forge.config.js

--- a/packages/plugin/webpack/README.md
+++ b/packages/plugin/webpack/README.md
@@ -1,0 +1,31 @@
+## Electron Forge: Local Electron
+
+This plugin allows you to both run and build your app using a local build of Electron. This can be incredibly useful if you want to test a feature or a bug fix in your app before making a PR up to the Electron repository.
+
+_Note: This plugin should only be used by people who are building Electron locally themselves. If you want to set up a local build of Electron, you should check out [Electron Build Tools](https://github.com/electron/build-tools)._
+
+```
+// forge.config.js
+
+module.exports = {
+  plugins: [
+    {
+      name: '@electron-forge/plugin-webpack',
+      config: {
+        mainConfig: './webpack.main.config.js',
+        renderer: {
+          config: './webpack.renderer.config.js',
+          entryPoints: [{
+            name: 'main_window',
+            html: './src/renderer/index.html',
+            js: './src/renderer/index.js',
+            preload: {
+              js: './src/preload.js'
+            }
+          }],
+        }
+      }
+    }
+  ]
+}
+```

--- a/packages/publisher/bitbucket/README.md
+++ b/packages/publisher/bitbucket/README.md
@@ -1,0 +1,35 @@
+## Electron Forge: Publisher Bitbucket
+
+`@electron-forge/publisher-bitbucket` publishes your artifacts to Bitbucket where users will be able to download them.
+
+This publish target is for Bitbucket Cloud only and will not work with self hosted Bitbucket Server instances.
+
+Configuration options are documented in [`PublisherBitbucketConfig`](https://js.electronforge.io/interfaces/_electron_forge_publisher_bitbucket.PublisherBitbucketConfig.html).
+
+
+```javascript
+{
+  name: "@electron-forge/publisher-bitbucket",
+  config: {
+    repository: {
+      owner: "myusername",
+      name: "myreponame"
+    },
+    auth: {
+      username: "myusername",
+      appPassword: "mysecretapppassword"
+    }
+}
+```
+
+Alternatively you can (and should) use environment variables for the authentication
+
+```
+//env.sh
+BITBUCKET_USERNAME="myusername"
+BITBUCKET_APP_PASSWORD="mysecretapppassword"
+```
+
+```
+source env.sh
+```

--- a/packages/publisher/bitbucket/README.md
+++ b/packages/publisher/bitbucket/README.md
@@ -7,18 +7,23 @@ This publish target is for Bitbucket Cloud only and will not work with self host
 Configuration options are documented in [`PublisherBitbucketConfig`](https://js.electronforge.io/interfaces/_electron_forge_publisher_bitbucket.PublisherBitbucketConfig.html).
 
 
-```javascript
-{
-  name: "@electron-forge/publisher-bitbucket",
-  config: {
-    repository: {
-      owner: "myusername",
-      name: "myreponame"
-    },
-    auth: {
-      username: "myusername",
-      appPassword: "mysecretapppassword"
+```javascript title=forge.config.js
+module.exports = {
+  // ...
+  publishers: [
+    {
+      name: '@electron-forge/publisher-bitbucket',
+      config: {
+        repository: {
+          owner: 'myusername',
+          name: 'myreponame'
+        },
+        auth: {
+          username: 'myusername',
+          appPassword: 'mysecretapppassword'
+        }
     }
+  ]
 }
 ```
 

--- a/packages/publisher/bitbucket/README.md
+++ b/packages/publisher/bitbucket/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: Publisher Bitbucket
+## Electron Forge: publisher-bitbucket
 
 `@electron-forge/publisher-bitbucket` publishes your artifacts to Bitbucket where users will be able to download them.
 

--- a/packages/publisher/electron-release-server/README.md
+++ b/packages/publisher/electron-release-server/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: Publisher Electron Release Server
+## publisher-electron-release-server
 
 `@electron-forge/publisher-electron-release-server` publishes all your artifacts to a hosted instance of [Electron Release Server](https://github.com/ArekSredzki/electron-release-server) where users will be able to download them.
 

--- a/packages/publisher/electron-release-server/README.md
+++ b/packages/publisher/electron-release-server/README.md
@@ -7,13 +7,18 @@ Please note that Electron Release Server is a community powered project and is n
 Configuration options are documented in [`PublisherERSConfig`](https://js.electronforge.io/interfaces/_electron_forge_publisher_electron_release_server.PublisherERSConfig.html).
 
 
-```javascript
-{
-  name: '@electron-forge/publisher-electron-release-server',
-  config: {
-    baseUrl: 'https://update.server.com',
-    username: 'admin',
-    password: 'admin'
-  }
+```javascript title=forge.config.js
+module.exports = {
+  // ...
+  publishers: [
+    {
+      name: '@electron-forge/publisher-electron-release-server',
+      config: {
+        baseUrl: 'https://update.server.com',
+        username: 'admin',
+        password: 'admin'
+      }
+    }
+  ]
 }
 ```

--- a/packages/publisher/electron-release-server/README.md
+++ b/packages/publisher/electron-release-server/README.md
@@ -1,0 +1,19 @@
+## Electron Forge: Publisher Electron Release Server
+
+`@electron-forge/publisher-electron-release-server` publishes all your artifacts to a hosted instance of [Electron Release Server](https://github.com/ArekSredzki/electron-release-server) where users will be able to download them.
+
+Please note that Electron Release Server is a community powered project and is not associated with Electron Forge or the Electron project directly.
+
+Configuration options are documented in [`PublisherERSConfig`](https://js.electronforge.io/interfaces/_electron_forge_publisher_electron_release_server.PublisherERSConfig.html).
+
+
+```javascript
+{
+  name: '@electron-forge/publisher-electron-release-server',
+  config: {
+    baseUrl: 'https://update.server.com',
+    username: 'admin',
+    password: 'admin'
+  }
+}
+```

--- a/packages/publisher/github/README.md
+++ b/packages/publisher/github/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: GitHub
+## publisher-github
 
 `@electron-forge/publisher-github` publishes all your artifacts to GitHub releases, this allows your users to download the files straight from your repository or if your repository is open source you can use [update.electronjs.org](https://github.com/electron/update.electronjs.org) and get a free hosted update service.
 

--- a/packages/publisher/github/README.md
+++ b/packages/publisher/github/README.md
@@ -1,0 +1,19 @@
+## Electron Forge: GitHub
+
+`@electron-forge/publisher-github` publishes all your artifacts to GitHub releases, this allows your users to download the files straight from your repository or if your repository is open source you can use [update.electronjs.org](https://github.com/electron/update.electronjs.org) and get a free hosted update service.
+
+Configuration options are documented in [`PublisherGithubConfig`](https://js.electronforge.io/interfaces/_electron_forge_publisher_github.PublisherGitHubConfig.html).
+
+
+```javascript
+{
+  name: '@electron-forge/publisher-github',
+  config: {
+    repository: {
+      owner: 'me',
+      name: 'awesome-thing'
+    },
+    prerelease: true
+  }
+}
+```

--- a/packages/publisher/github/README.md
+++ b/packages/publisher/github/README.md
@@ -5,15 +5,21 @@
 Configuration options are documented in [`PublisherGithubConfig`](https://js.electronforge.io/interfaces/_electron_forge_publisher_github.PublisherGitHubConfig.html).
 
 
-```javascript
-{
-  name: '@electron-forge/publisher-github',
-  config: {
-    repository: {
-      owner: 'me',
-      name: 'awesome-thing'
-    },
-    prerelease: true
-  }
+```javascript title=forge.config.js
+module.exports = {
+  // ...
+  publishers: [
+    {
+      name: '@electron-forge/publisher-github',
+      config: {
+        repository: {
+          owner: 'me',
+          name: 'awesome-thing'
+        },
+        prerelease: true
+      }
+    }
+  ]
 }
+```
 ```

--- a/packages/publisher/nucleus/README.md
+++ b/packages/publisher/nucleus/README.md
@@ -8,15 +8,20 @@ Configuration options are documented in [`Publisher
 NucleusConfig](https://js.electronforge.io/interfaces/_electron_forge_publisher_nucleus.PublisherNucleusConfig.html).
 
 
-```javascript
-{
-  name: '@electron-forge/publisher-nucleus',
-  config: {
-    host: 'https://my-nucleus.mysite.com',
-    appId: 1,
-    channelId: 'abcdefg',
-    token: 'my-token'
-  }
+```javascript title=forge.config.js
+module.exports = {
+  // ...
+  publishers: [
+    {
+      name: '@electron-forge/publisher-nucleus',
+      config: {
+        host: 'https://my-nucleus.mysite.com',
+        appId: 1,
+        channelId: 'abcdefg',
+        token: 'my-token'
+      }
+    }
+  ]
 }
 ```
 

--- a/packages/publisher/nucleus/README.md
+++ b/packages/publisher/nucleus/README.md
@@ -1,0 +1,23 @@
+## Electron Forge: Publisher Nucleus
+
+`@electron-forge/publisher-nucleus` publishes all your artifacts to an instance of Nucleus Update Server where users will be able to download them. This update service supports all three platforms.
+
+Check out the README at [`atlassian/nucleus`](https://github.com/atlassian/nucleus) for more information on this project.
+
+Configuration options are documented in [`Publisher
+NucleusConfig](https://js.electronforge.io/interfaces/_electron_forge_publisher_nucleus.PublisherNucleusConfig.html).
+
+
+```javascript
+{
+  name: '@electron-forge/publisher-nucleus',
+  config: {
+    host: 'https://my-nucleus.mysite.com',
+    appId: 1,
+    channelId: 'abcdefg',
+    token: 'my-token'
+  }
+}
+```
+
+We recommend you set the `token`option using an environment variable, don't hard code into in your config.

--- a/packages/publisher/nucleus/README.md
+++ b/packages/publisher/nucleus/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: Publisher Nucleus
+## publisher-nucleus
 
 `@electron-forge/publisher-nucleus` publishes all your artifacts to an instance of Nucleus Update Server where users will be able to download them. This update service supports all three platforms.
 

--- a/packages/publisher/s3/README.md
+++ b/packages/publisher/s3/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: Publisher S3
+## publisher-s3
 
 `@electron-forge/publisher-s3` publishes all your artifacts to an Amazon S3 bucket where users will be able to download them.
 

--- a/packages/publisher/s3/README.md
+++ b/packages/publisher/s3/README.md
@@ -1,0 +1,26 @@
+## Electron Forge: Publisher S3
+
+`@electron-forge/publisher-s3` publishes all your artifacts to an Amazon S3 bucket where users will be able to download them.
+
+By default, all files are positioned at the following key:
+
+${config.folder || appVersion}/${artifactName}
+
+Configuration options are documented in [PublisherS3Config](https://js.electronforge.io/interfaces/_electron_forge_publisher_s3.PublisherS3Config.html).
+
+
+```javascript
+{
+  name: '@electron-forge/publisher-s3',
+  config: {
+    bucket: 'my-bucket',
+    public: true
+  }
+}
+```
+
+If you run publish twice with the same version on the same platform, it is possible for your old artifacts to get overwritten in S3. It is your responsibility to ensure that you don't overwrite your own releases.
+
+### Authentication
+
+It is recommended to follow the [Amazon AWS guide](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html) and set either a shared credentials guide or the proper environment variables. However, if that is not possible, the publisher config allows the setting of the accessKeyId and secretAccessKey configuration options.

--- a/packages/publisher/s3/README.md
+++ b/packages/publisher/s3/README.md
@@ -9,13 +9,18 @@ ${config.folder || appVersion}/${artifactName}
 Configuration options are documented in [PublisherS3Config](https://js.electronforge.io/interfaces/_electron_forge_publisher_s3.PublisherS3Config.html).
 
 
-```javascript
-{
-  name: '@electron-forge/publisher-s3',
-  config: {
-    bucket: 'my-bucket',
-    public: true
-  }
+```javascript title=forge.config.js
+module.exports = {
+  // ...
+  publishers: [
+    {
+      name: '@electron-forge/publisher-s3',
+      config: {
+        bucket: 'my-bucket',
+        public: true
+      }
+    }
+  ]
 }
 ```
 

--- a/packages/publisher/snapcraft/README.md
+++ b/packages/publisher/snapcraft/README.md
@@ -1,0 +1,17 @@
+## Electron Forge: Publisher Snapcraft
+
+The Snapcraft target publishes your .snap artifacts to the Snap Store. All configuration of your package is done via the Snapcraft maker.
+
+This target requires that the system has the snapcraft utility installed.
+
+Configuration options are documented in [PublisherSnapConfig](https://js.electronforge.io/interfaces/_electron_forge_publisher_snapcraft.PublisherSnapcraftConfig.htmls).
+
+
+```javascript
+{
+  name: '@electron-forge/publisher-snapcraft',
+  config: {
+    release: "1"
+  }
+}
+```

--- a/packages/publisher/snapcraft/README.md
+++ b/packages/publisher/snapcraft/README.md
@@ -7,11 +7,17 @@ This target requires that the system has the snapcraft utility installed.
 Configuration options are documented in [PublisherSnapConfig](https://js.electronforge.io/interfaces/_electron_forge_publisher_snapcraft.PublisherSnapcraftConfig.htmls).
 
 
-```javascript
-{
-  name: '@electron-forge/publisher-snapcraft',
-  config: {
-    release: "1"
-  }
+```javascript title=forge.config.js
+module.exports = {
+  // ...
+  publishers: [
+    {
+      name: '@electron-forge/publisher-snapcraft',
+      config: {
+        release: "latest/edge, insider/stable"
+      }
+    }
+  ]
 }
+```
 ```

--- a/packages/publisher/snapcraft/README.md
+++ b/packages/publisher/snapcraft/README.md
@@ -1,4 +1,4 @@
-## Electron Forge: Publisher Snapcraft
+## publisher-snapcraft
 
 The Snapcraft target publishes your .snap artifacts to the Snap Store. All configuration of your package is done via the Snapcraft maker.
 

--- a/tools/gen-docs.ts
+++ b/tools/gen-docs.ts
@@ -41,7 +41,7 @@ function generatedSidebarGroups(projReflection: typedoc.ProjectReflection) {
     hideGenerator: true,
     includeVersion: true,
     name: 'Electron Forge',
-    plugin: ['typedoc-plugin-rename-defaults', 'typedoc-plugin-missing-exports', './tools/doc-plugin/dist/index.js'],
+    plugin: ['typedoc-plugin-rename-defaults', 'typedoc-plugin-missing-exports', './tools/doc-plugin/dist/index.js', '@knodes/typedoc-plugin-monorepo-readmes'],
     theme: 'forge-theme',
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore (overloaded param `internalModule` lets us rename "<internal>"

--- a/tools/publish.js
+++ b/tools/publish.js
@@ -33,12 +33,6 @@ const prepare = new Listr([
         cwd: BASE_DIR,
       }),
   },
-  {
-    title: "Fetching README's",
-    // Why: somehow, referencing a TS file in a JS file works?
-    // eslint-disable-next-line node/no-missing-require
-    task: require('./sync-readmes'),
-  },
 ]);
 
 const publisher = new Listr([

--- a/yarn.lock
+++ b/yarn.lock
@@ -1278,6 +1278,23 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@knodes/typedoc-plugin-monorepo-readmes@0.22.5":
+  version "0.22.5"
+  resolved "https://registry.yarnpkg.com/@knodes/typedoc-plugin-monorepo-readmes/-/typedoc-plugin-monorepo-readmes-0.22.5.tgz#aae62c85ef5bd0040edf9939facafafce6c697af"
+  integrity sha512-SJcMSTbCXu3VUrmwaQvebQW0oyLLRqLQDQltRS0QR7RJ64NV0xYaCmFC4jFjAoAX6hXvlmdP9T0cLALNAYhV2Q==
+  dependencies:
+    "@knodes/typedoc-pluginutils" "~0.22.5"
+    find-up "^4.1.0"
+
+"@knodes/typedoc-pluginutils@~0.22.5":
+  version "0.22.7"
+  resolved "https://registry.yarnpkg.com/@knodes/typedoc-pluginutils/-/typedoc-pluginutils-0.22.7.tgz#a158d46f09909a95d7d71b97008ddc90ec5aa777"
+  integrity sha512-VAxpQNfyghintegU9Ky3vJLKQBSFXRP3rs6JclHpJloGKKAAGV6WweCDrFvFzZ4a08LkXSpqIMLmmuFjKLELOg==
+  dependencies:
+    lodash "^4.17.21"
+    pkg-up "^3.1.0"
+    semver "^7.3.5"
+
 "@malept/cross-spawn-promise@^1.0.0", "@malept/cross-spawn-promise@^1.1.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz#504af200af6b98e198bce768bc1730c6936ae01d"
@@ -4782,6 +4799,13 @@ find-up@^2.0.0:
   dependencies:
     locate-path "^2.0.0"
 
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -6383,6 +6407,14 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -7399,7 +7431,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.2.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -7419,6 +7451,13 @@ p-locate@^2.0.0:
   integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
   dependencies:
     p-limit "^1.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -7690,6 +7729,13 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pkg-up@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-3.1.0.tgz#100ec235cc150e4fd42519412596a28512a0def5"
+  integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
+  dependencies:
+    find-up "^3.0.0"
 
 plist@^3.0.0:
   version "3.0.5"


### PR DESCRIPTION
Co-authored-by: Keeley Hammond <vertedinde@electronjs.org>

This PR adds more detailed READMEs to each Forge module.

Deployed live here at https://add-readmes--marvelous-choux-77d0b7.netlify.app/

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [ ] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/main/CONTRIBUTING.md) for this project.
- [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
