### PR TITLE
feat!: prefer forge.config.js over package.json config

### DIFF
--- a/packages/api/core/src/api/import.ts
+++ b/packages/api/core/src/api/import.ts
@@ -82,10 +82,13 @@ export default async ({
   let importDevDeps = ([] as string[]).concat(devDeps);
   let importExactDevDeps = ([] as string[]).concat(exactDevDeps);
 
-  let packageJSON = await readRawPackageJson(dir);
+  const packageJSON = await readRawPackageJson(dir);
+  if (!packageJSON.version) {
+    warn(interactive, chalk.yellow(`Please set the ${chalk.green('"version"')} in your application's package.json`));
+  }
   if (packageJSON.config && packageJSON.config.forge) {
     if (packageJSON.config.forge.makers) {
-      warn(interactive, chalk.green('It looks like this project is already configured for Electron Forge'));
+      warn(interactive, chalk.green('Existing Electron Forge configuration detected'));
       if (typeof shouldContinueOnExisting === 'function') {
         if (!(await shouldContinueOnExisting())) {
           // TODO: figure out if we can just return early here
@@ -93,7 +96,7 @@ export default async ({
           process.exit(0);
         }
       }
-    } else if (typeof packageJSON.config.forge === 'string') {
+    } else if (!(typeof packageJSON.config.forge === 'object')) {
       warn(
         interactive,
         chalk.yellow(
@@ -187,23 +190,17 @@ export default async ({
     await installDepList(dir, importExactDevDeps, DepType.DEV, DepVersionRestriction.EXACT);
   });
 
-  packageJSON = await readRawPackageJson(dir);
+  await asyncOra('Creating forge.config.js configuration', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const templateConfig = require(path.resolve(baseTemplate.templateDir, 'forge.config.js'));
 
-  if (!packageJSON.version) {
-    warn(interactive, chalk.yellow('Please set the "version" in your application\'s package.json'));
-  }
-
-  packageJSON.config = packageJSON.config || {};
-  const templatePackageJSON = await readRawPackageJson(baseTemplate.templateDir);
-  if (packageJSON.config.forge) {
-    if (typeof packageJSON.config.forge !== 'string') {
-      packageJSON.config.forge = merge(templatePackageJSON.config.forge, packageJSON.config.forge);
+    if (packageJSON?.config?.forge && typeof packageJSON.config.forge === 'object') {
+      d('detected existing Forge config in package.json, merging with base template Forge config');
+      merge(templateConfig, packageJSON.config.forge); // mutates the templateConfig object
     }
-  } else {
-    packageJSON.config.forge = templatePackageJSON.config.forge;
-  }
 
-  await writeChanges();
+    await writeChanges();
+  });
 
   await asyncOra('Fixing .gitignore', async () => {
     if (await fs.pathExists(path.resolve(dir, '.gitignore'))) {
@@ -218,8 +215,8 @@ export default async ({
     interactive,
     `
 
-We have ATTEMPTED to convert your app to be in a format that electron-forge understands.
+We have attempted to convert your app to be in a format that Electron Forge understands.
 
-Thanks for using ${chalk.green('Electron Forge')}!!!`
+Thanks for using ${chalk.green('Electron Forge')}!`
   );
 };

--- a/packages/api/core/src/api/init-scripts/init-git.ts
+++ b/packages/api/core/src/api/init-scripts/init-git.ts
@@ -6,7 +6,7 @@ import debug from 'debug';
 const d = debug('electron-forge:init:git');
 
 export default async (dir: string): Promise<void> => {
-  await asyncOra('Initializing Git Repository', async () => {
+  await asyncOra('Initializing Git repository', async () => {
     await new Promise<void>((resolve, reject) => {
       exec(
         'git rev-parse --show-toplevel',

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -16,15 +16,6 @@ const underscoreCase = (str: string) =>
     .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
     .toUpperCase();
 
-export type PackageJSONForInitialForgeConfig = {
-  name?: string;
-  config: {
-    forge: {
-      makers: Pick<IForgeResolvableMaker, 'name' | 'config'>[];
-    };
-  };
-};
-
 // Why: needs access to Object methods and also needs to be able to match any interface.
 // eslint-disable-next-line @typescript-eslint/ban-types
 type ProxiedObject = object;

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { ForgeConfig, IForgeResolvableMaker, ResolvedForgeConfig } from '@electron-forge/shared-types';
+import { ForgeConfig, ResolvedForgeConfig } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
 import * as interpret from 'interpret';
 import { template } from 'lodash';

--- a/packages/api/core/test/fast/forge-config_spec.ts
+++ b/packages/api/core/test/fast/forge-config_spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { ForgeConfig, IForgeResolvableMaker, ResolvedForgeConfig } from '@electron-forge/shared-types';
+import { ResolvedForgeConfig } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 
 import findConfig, { forgeConfigIsValidFilePath, renderConfigTemplate } from '../../src/util/forge-config';

--- a/packages/api/core/test/fast/forge-config_spec.ts
+++ b/packages/api/core/test/fast/forge-config_spec.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { ResolvedForgeConfig } from '@electron-forge/shared-types';
+import { ForgeConfig, IForgeResolvableMaker, ResolvedForgeConfig } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 
 import findConfig, { forgeConfigIsValidFilePath, renderConfigTemplate } from '../../src/util/forge-config';

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -203,6 +203,7 @@ for (const nodeInstaller of ['npm', 'yarn']) {
         await updatePackageJSON(dir, async (packageJSON) => {
           packageJSON.name = 'Name';
           packageJSON.productName = 'Product Name';
+          packageJSON.customProp = 'propVal';
         });
 
         await forge.import({ dir });

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -244,7 +244,10 @@ describe('Electron Forge API', () => {
           await fs.copy(path.join(__dirname, '..', 'fixture', 'bogus-private-key.pvk'), path.join(dir, 'default.pvk'));
           devCert = await createDefaultCertificate('CN=Test Author', { certFilePath: dir });
         } else if (process.platform === 'linux') {
-          packageJSON.config.forge.packagerConfig.executableName = 'testapp';
+          packageJSON.config.forge.packagerConfig = {
+            ...packageJSON.config.forge.packagerConfig,
+            executableName: 'testapp',
+          };
         }
         packageJSON.homepage = 'http://www.example.com/';
         packageJSON.author = 'Test Author';

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -79,6 +79,10 @@ for (const nodeInstaller of ['npm', 'yarn']) {
         expect(await fs.pathExists(path.resolve(dir, 'node_modules/@electron-forge/cli')), '@electron-forge/cli should exist').to.equal(true);
       });
 
+      it('should create a forge.config.js', async () => {
+        await expectProjectPathExists(dir, 'forge.config.js', 'file');
+      });
+
       describe('lint', () => {
         it('should initially pass the linting process', () => expectLintToPass(dir));
       });
@@ -199,7 +203,6 @@ for (const nodeInstaller of ['npm', 'yarn']) {
         await updatePackageJSON(dir, async (packageJSON) => {
           packageJSON.name = 'Name';
           packageJSON.productName = 'Product Name';
-          packageJSON.customProp = 'propVal';
         });
 
         await forge.import({ dir });
@@ -230,8 +233,13 @@ describe('Electron Forge API', () => {
         packageJSON.name = 'testapp';
         packageJSON.version = '1.0.0-beta.1';
         packageJSON.productName = 'Test-App';
-        assert(packageJSON.config.forge.packagerConfig);
-        packageJSON.config.forge.packagerConfig.asar = false;
+        packageJSON.config = packageJSON.config || {};
+        packageJSON.config.forge = {
+          ...packageJSON.config.forge,
+          packagerConfig: {
+            asar: false,
+          },
+        };
         if (process.platform === 'win32') {
           await fs.copy(path.join(__dirname, '..', 'fixture', 'bogus-private-key.pvk'), path.join(dir, 'default.pvk'));
           devCert = await createDefaultCertificate('CN=Test Author', { certFilePath: dir });

--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -39,7 +39,7 @@ export class BaseTemplate implements ForgeTemplate {
     await asyncOra('Copying Starter Files', async () => {
       d('creating directory:', path.resolve(directory, 'src'));
       await fs.mkdirs(path.resolve(directory, 'src'));
-      const rootFiles = ['_gitignore'];
+      const rootFiles = ['_gitignore', 'forge.config.js'];
       if (copyCIFiles) rootFiles.push(...['_travis.yml', '_appveyor.yml']);
       const srcFiles = ['index.css', 'index.js', 'index.html', 'preload.js'];
 

--- a/packages/template/base/tmpl/forge.config.js
+++ b/packages/template/base/tmpl/forge.config.js
@@ -1,0 +1,26 @@
+module.exports = {
+  "packagerConfig": {},
+  "rebuildConfig": {},
+  "makers": [
+    {
+      "name": "@electron-forge/maker-squirrel",
+      "config": {
+        "name": ""
+      }
+    },
+    {
+      "name": "@electron-forge/maker-zip",
+      "platforms": [
+        "darwin"
+      ]
+    },
+    {
+      "name": "@electron-forge/maker-deb",
+      "config": {}
+    },
+    {
+      "name": "@electron-forge/maker-rpm",
+      "config": {}
+    }
+  ]
+}

--- a/packages/template/base/tmpl/forge.config.js
+++ b/packages/template/base/tmpl/forge.config.js
@@ -1,26 +1,24 @@
 module.exports = {
-  "packagerConfig": {},
-  "rebuildConfig": {},
-  "makers": [
+  packagerConfig: {},
+  rebuildConfig: {},
+  makers: [
     {
-      "name": "@electron-forge/maker-squirrel",
-      "config": {
-        "name": ""
-      }
+      name: '@electron-forge/maker-squirrel',
+      config: {
+        name: '',
+      },
     },
     {
-      "name": "@electron-forge/maker-zip",
-      "platforms": [
-        "darwin"
-      ]
+      name: '@electron-forge/maker-zip',
+      platforms: ['darwin'],
     },
     {
-      "name": "@electron-forge/maker-deb",
-      "config": {}
+      name: '@electron-forge/maker-deb',
+      config: {},
     },
     {
-      "name": "@electron-forge/maker-rpm",
-      "config": {}
-    }
-  ]
-}
+      name: '@electron-forge/maker-rpm',
+      config: {},
+    },
+  ],
+};

--- a/packages/template/base/tmpl/forge.config.js
+++ b/packages/template/base/tmpl/forge.config.js
@@ -4,9 +4,7 @@ module.exports = {
   makers: [
     {
       name: '@electron-forge/maker-squirrel',
-      config: {
-        name: '',
-      },
+      config: {},
     },
     {
       name: '@electron-forge/maker-zip',

--- a/packages/template/base/tmpl/package.json
+++ b/packages/template/base/tmpl/package.json
@@ -12,30 +12,5 @@
   },
   "keywords": [],
   "author": "",
-  "license": "MIT",
-  "config": {
-    "forge": {
-      "packagerConfig": {},
-      "makers": [
-        {
-          "name": "@electron-forge/maker-squirrel",
-          "config": {}
-        },
-        {
-          "name": "@electron-forge/maker-zip",
-          "platforms": [
-            "darwin"
-          ]
-        },
-        {
-          "name": "@electron-forge/maker-deb",
-          "config": {}
-        },
-        {
-          "name": "@electron-forge/maker-rpm",
-          "config": {}
-        }
-      ]
-    }
-  }
+  "license": "MIT"
 }

--- a/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
+++ b/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
@@ -11,12 +11,11 @@ class TypeScriptWebpackTemplate extends BaseTemplate {
   async initializeTemplate(directory: string, options: InitTemplateOptions) {
     await super.initializeTemplate(directory, options);
     await asyncOra('Setting up Forge configuration', async () => {
-      const packageJSONPath = path.resolve(directory, 'package.json');
-      const packageJSON = await fs.readJson(packageJSONPath);
-
-      packageJSON.main = '.webpack/main';
-      packageJSON.config.forge.plugins = packageJSON.config.forge.plugins || [];
-      packageJSON.config.forge.plugins.push({
+      const forgeConfigPath = path.resolve(directory, 'forge.config.js');
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const forgeConfig = require(forgeConfigPath);
+      forgeConfig.plugins = forgeConfig.plugins || [];
+      forgeConfig.plugins.push({
         name: '@electron-forge/plugin-webpack',
         config: {
           mainConfig: './webpack.main.config.js',
@@ -35,13 +34,8 @@ class TypeScriptWebpackTemplate extends BaseTemplate {
           },
         },
       });
-
-      // Configure scripts for TS template
-      packageJSON.scripts.lint = 'eslint --ext .ts,.tsx .';
-
-      await fs.writeJson(packageJSONPath, packageJSON, { spaces: 2 });
+      await fs.writeFile(forgeConfigPath, `module.exports = ${JSON.stringify(forgeConfig, null, 2)}`);
     });
-
     await asyncOra('Setting up TypeScript configuration', async () => {
       const filePath = (fileName: string) => path.join(directory, 'src', fileName);
 
@@ -71,6 +65,18 @@ class TypeScriptWebpackTemplate extends BaseTemplate {
       // Remove preload.js and replace with preload.ts
       await fs.remove(filePath('preload.js'));
       await this.copyTemplateFile(path.join(directory, 'src'), 'preload.ts');
+
+      // update package.json
+      const packageJSONPath = path.resolve(directory, 'package.json');
+      const packageJSON = await fs.readJson(packageJSONPath);
+      packageJSON.main = '.webpack/main';
+      // Configure scripts for TS template
+      packageJSON.scripts.lint = 'eslint --ext .ts,.tsx .';
+      await fs.writeJson(packageJSONPath, packageJSON, {
+        spaces: 2,
+      });
+
+      await fs.writeJson(packageJSONPath, packageJSON, { spaces: 2 });
     });
   }
 }

--- a/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
+++ b/packages/template/typescript-webpack/src/TypeScriptWebpackTemplate.ts
@@ -11,30 +11,7 @@ class TypeScriptWebpackTemplate extends BaseTemplate {
   async initializeTemplate(directory: string, options: InitTemplateOptions) {
     await super.initializeTemplate(directory, options);
     await asyncOra('Setting up Forge configuration', async () => {
-      const forgeConfigPath = path.resolve(directory, 'forge.config.js');
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const forgeConfig = require(forgeConfigPath);
-      forgeConfig.plugins = forgeConfig.plugins || [];
-      forgeConfig.plugins.push({
-        name: '@electron-forge/plugin-webpack',
-        config: {
-          mainConfig: './webpack.main.config.js',
-          renderer: {
-            config: './webpack.renderer.config.js',
-            entryPoints: [
-              {
-                html: './src/index.html',
-                js: './src/renderer.ts',
-                name: 'main_window',
-                preload: {
-                  js: './src/preload.ts',
-                },
-              },
-            ],
-          },
-        },
-      });
-      await fs.writeFile(forgeConfigPath, `module.exports = ${JSON.stringify(forgeConfig, null, 2)}`);
+      await this.copyTemplateFile(directory, 'forge.config.ts');
     });
     await asyncOra('Setting up TypeScript configuration', async () => {
       const filePath = (fileName: string) => path.join(directory, 'src', fileName);

--- a/packages/template/typescript-webpack/tmpl/forge.config.ts
+++ b/packages/template/typescript-webpack/tmpl/forge.config.ts
@@ -1,0 +1,43 @@
+module.exports = {
+  packagerConfig: {},
+  rebuildConfig: {},
+  makers: [
+    {
+      name: '@electron-forge/maker-squirrel',
+      config: {},
+    },
+    {
+      name: '@electron-forge/maker-zip',
+      platforms: ['darwin'],
+    },
+    {
+      name: '@electron-forge/maker-deb',
+      config: {},
+    },
+    {
+      name: '@electron-forge/maker-rpm',
+      config: {},
+    },
+  ],
+  plugins: [
+    {
+      name: '@electron-forge/plugin-webpack',
+      config: {
+        mainConfig: './webpack.main.config.js',
+        renderer: {
+          config: './webpack.renderer.config.js',
+          entryPoints: [
+            {
+              html: './src/index.html',
+              js: './src/renderer.js',
+              name: 'main_window',
+              preload: {
+                js: './src/preload.js',
+              },
+            },
+          ],
+        },
+      },
+    },
+  ],
+};

--- a/packages/template/webpack/src/WebpackTemplate.ts
+++ b/packages/template/webpack/src/WebpackTemplate.ts
@@ -11,30 +11,7 @@ class WebpackTemplate extends BaseTemplate {
   public async initializeTemplate(directory: string, options: InitTemplateOptions) {
     await super.initializeTemplate(directory, options);
     await asyncOra('Setting up Forge configuration', async () => {
-      const forgeConfigPath = path.resolve(directory, 'forge.config.js');
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const forgeConfig = require(forgeConfigPath);
-      forgeConfig.plugins = forgeConfig.plugins || [];
-      forgeConfig.plugins.push({
-        name: '@electron-forge/plugin-webpack',
-        config: {
-          mainConfig: './webpack.main.config.js',
-          renderer: {
-            config: './webpack.renderer.config.js',
-            entryPoints: [
-              {
-                html: './src/index.html',
-                js: './src/renderer.js',
-                name: 'main_window',
-                preload: {
-                  js: './src/preload.js',
-                },
-              },
-            ],
-          },
-        },
-      });
-      await fs.writeFile(forgeConfigPath, `module.exports = ${JSON.stringify(forgeConfig, null, 2)}`);
+      await this.copyTemplateFile(directory, 'forge.config.js');
     });
     await asyncOra('Setting up webpack configuration', async () => {
       await this.copyTemplateFile(directory, 'webpack.main.config.js');

--- a/packages/template/webpack/src/WebpackTemplate.ts
+++ b/packages/template/webpack/src/WebpackTemplate.ts
@@ -11,11 +11,11 @@ class WebpackTemplate extends BaseTemplate {
   public async initializeTemplate(directory: string, options: InitTemplateOptions) {
     await super.initializeTemplate(directory, options);
     await asyncOra('Setting up Forge configuration', async () => {
-      const pjPath = path.resolve(directory, 'package.json');
-      const currentPJ = await fs.readJson(pjPath);
-      currentPJ.main = '.webpack/main';
-      currentPJ.config.forge.plugins = currentPJ.config.forge.plugins || [];
-      currentPJ.config.forge.plugins.push({
+      const forgeConfigPath = path.resolve(directory, 'forge.config.js');
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const forgeConfig = require(forgeConfigPath);
+      forgeConfig.plugins = forgeConfig.plugins || [];
+      forgeConfig.plugins.push({
         name: '@electron-forge/plugin-webpack',
         config: {
           mainConfig: './webpack.main.config.js',
@@ -34,9 +34,7 @@ class WebpackTemplate extends BaseTemplate {
           },
         },
       });
-      await fs.writeJson(pjPath, currentPJ, {
-        spaces: 2,
-      });
+      await fs.writeFile(forgeConfigPath, `module.exports = ${JSON.stringify(forgeConfig, null, 2)}`);
     });
     await asyncOra('Setting up webpack configuration', async () => {
       await this.copyTemplateFile(directory, 'webpack.main.config.js');
@@ -58,6 +56,14 @@ class WebpackTemplate extends BaseTemplate {
       await this.updateFileByLine(path.resolve(directory, 'src', 'index.html'), (line) => {
         if (line.includes('link rel="stylesheet"')) return '';
         return line;
+      });
+
+      // update package.json entry point
+      const pjPath = path.resolve(directory, 'package.json');
+      const currentPJ = await fs.readJson(pjPath);
+      currentPJ.main = '.webpack/main';
+      await fs.writeJson(pjPath, currentPJ, {
+        spaces: 2,
       });
     });
   }

--- a/packages/template/webpack/tmpl/forge.config.js
+++ b/packages/template/webpack/tmpl/forge.config.js
@@ -1,0 +1,43 @@
+module.exports = {
+  packagerConfig: {},
+  rebuildConfig: {},
+  makers: [
+    {
+      name: '@electron-forge/maker-squirrel',
+      config: {},
+    },
+    {
+      name: '@electron-forge/maker-zip',
+      platforms: ['darwin'],
+    },
+    {
+      name: '@electron-forge/maker-deb',
+      config: {},
+    },
+    {
+      name: '@electron-forge/maker-rpm',
+      config: {},
+    },
+  ],
+  plugins: [
+    {
+      name: '@electron-forge/plugin-webpack',
+      config: {
+        mainConfig: './webpack.main.config.js',
+        renderer: {
+          config: './webpack.renderer.config.js',
+          entryPoints: [
+            {
+              html: './src/index.html',
+              js: './src/renderer.js',
+              name: 'main_window',
+              preload: {
+                js: './src/preload.js',
+              },
+            },
+          ],
+        },
+      },
+    },
+  ],
+};


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This change affects the `init` and `import` commands. It changes these commands to create a `forge.config.js` rather than creating `config.forge` in your package.json.

This is considered a breaking change for any third-party templates because the base template no longer sets up a `config.forge` object, and any template-specific mutations to the Forge config should instead be performed on the `forge.config.js` file.

Ref #2973
