### PR TITLE
fix(plugin-webpack): keep `devDependencies`, `dependencies`, `optionalDependencies` and `peerDependencies` in the distributed package.json

### DIFF
--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -227,10 +227,6 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}`);
     if (pj.config) {
       delete pj.config.forge;
     }
-    pj.devDependencies = {};
-    pj.dependencies = {};
-    pj.optionalDependencies = {};
-    pj.peerDependencies = {};
 
     await fs.writeJson(path.resolve(buildPath, 'package.json'), pj, {
       spaces: 2,


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron-userland/electron-forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

As mentioned in https://github.com/electron/forge/issues/2818#issuecomment-1207299969, the Webpack plugin sets the `devDependencies`, `dependencies`, `optionalDependencies` and `peerDependencies` objects to `{}` in the distributed package.json. If any other plugin runs after the Webpack plugin and tries to read one of these objects, it will get an empty object instead of the actual dependencies, which seems like an unexpected side-effect.

Fixes https://github.com/electron/forge/issues/2818.