### PR TITLE
chore: bump electron-wix-msi to 5.0.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,18 @@ Here are some things to keep in mind as you file pull requests to fix bugs, add 
 
 ### Release process
 
+When updating a dependency, we also need to make sure that the package is updated in all of the modules where
+the packages is needed. To do this, run:
+
+```
+bolt upgrade {package-name}@latest
+
+// i.e.
+bolt upgrade electron-wix-msi@latest
+```
+
+### Release process
+
 - Make sure the tests pass
 - `$ ./tools/bump.ts $NEW_VERSION`
   - This will commit the changes automatically. Run `git log` to confirm that the changes have been

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "electron-installer-snap": "^5.1.0",
     "electron-windows-store": "^2.1.0",
     "electron-winstaller": "^5.0.0",
-    "electron-wix-msi": "^4.0.0"
+    "electron-wix-msi": "^5.0.0"
   },
   "lint-staged": {
     "*.{html,json,md,yml}": "prettier --write",

--- a/packages/maker/wix/package.json
+++ b/packages/maker/wix/package.json
@@ -18,7 +18,7 @@
     "@electron-forge/maker-base": "6.0.0-beta.68",
     "@electron-forge/shared-types": "6.0.0-beta.68",
     "chalk": "^4.0.0",
-    "electron-wix-msi": "^4.0.0",
+    "electron-wix-msi": "^5.0.0",
     "log-symbols": "^4.0.0",
     "parse-author": "^2.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3967,10 +3967,10 @@ electron-winstaller@^5.0.0:
     lodash.template "^4.2.2"
     temp "^0.9.0"
 
-electron-wix-msi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/electron-wix-msi/-/electron-wix-msi-4.0.0.tgz#31bd82c2d717e40f63a5c22ef20f410224e0fab3"
-  integrity sha512-LEQr5IQc8w7efIVt5tIQA0efew4slffW6tfDmbfpWDSR74HnfTkkfwBAwj9vMLT4q62cO4NnkVTEuMe7FxWMTw==
+electron-wix-msi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/electron-wix-msi/-/electron-wix-msi-5.0.0.tgz#6899beabb59180fbe71dede79e9ae805779497a5"
+  integrity sha512-CfcakpocoGGtzXElHwiSqB5nSlscyZYPBDTj7s+kfw2jXby3Nzzso7vIA+6EiPebn704D4JyKaJ7O4GCY2h5KQ==
   dependencies:
     debug "^4.3.4"
     fs-extra "^10.0.1"


### PR DESCRIPTION
Incorporates breaking icon name changes.