### PR TITLE
fix(template-typescript-webpack): webpack entrypoint extensions

### DIFF
--- a/packages/template/typescript-webpack/tmpl/forge.config.ts
+++ b/packages/template/typescript-webpack/tmpl/forge.config.ts
@@ -29,10 +29,10 @@ module.exports = {
           entryPoints: [
             {
               html: './src/index.html',
-              js: './src/renderer.js',
+              js: './src/renderer.ts',
               name: 'main_window',
               preload: {
-                js: './src/preload.js',
+                js: './src/preload.ts',
               },
             },
           ],


### PR DESCRIPTION
ref https://github.com/electron/forge/pull/3012#issuecomment-1294420816

In https://github.com/electron/forge/pull/2991, I copy/pasted the webpack config over but failed to change the entrypoint extensions over from `.js` to `.ts`.