### PR TITLE
fix(template-typescript-webpack): properly load `forge.config.ts`

### DIFF
--- a/packages/template/typescript-webpack/tmpl/package.json
+++ b/packages/template/typescript-webpack/tmpl/package.json
@@ -1,16 +1,17 @@
 {
   "devDependencies": {
     "@electron-forge/plugin-webpack": "ELECTRON_FORGE/VERSION",
+    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "@typescript-eslint/parser": "^5.0.0",
     "@vercel/webpack-asset-relocator-loader": "1.7.3",
     "css-loader": "^6.0.0",
-    "node-loader": "^2.0.0",
-    "ts-loader": "^9.2.2",
-    "style-loader": "^3.0.0",
-    "typescript": "~4.5.4",
-    "fork-ts-checker-webpack-plugin": "^7.2.1",
     "eslint": "^8.0.1",
     "eslint-plugin-import": "^2.25.0",
-    "@typescript-eslint/eslint-plugin": "^5.0.0",
-    "@typescript-eslint/parser": "^5.0.0"
+    "fork-ts-checker-webpack-plugin": "^7.2.1",
+    "node-loader": "^2.0.0",
+    "style-loader": "^3.0.0",
+    "ts-loader": "^9.2.2",
+    "ts-node": "^10.0.0",
+    "typescript": "~4.5.4"
   }
 }


### PR DESCRIPTION
## Issue 

Our usage of `rechoir` introduced in #2993 was actually broken. Running the TypeScript Webpack template yields the following error when attempting to load `forge.config.ts` with `rechoir`.

```
An unhandled rejection has occurred inside Forge:
Error: Unable to use specified module loaders for ".ts".

Electron Forge was terminated. Location:
{}
error Command failed with exit code 1.
```

## Repro

Run the `init` command with `--template=typescript-webpack` and attempt to run `yarn start`.

## Solution

Add `ts-node` as a dev dependency for the template.

### Rationale

As per the [rechoir](https://github.com/gulpjs/rechoir) docs, rechoir needs a local installation of the ts -> js transformer to run.

> **Note**
> While rechoir will automatically load and register transpilers like coffee-script, you must provide a local installation. The transpilers are not bundled with this module.

A similar error was filed for `rechoir` usage in the webpack CLI in the past (https://github.com/webpack/webpack-cli/issues/1993) where the solution was to install `ts-node`.