### PR TITLE
build: add icon property to MakerWixConfig

### DIFF
--- a/packages/maker/wix/src/Config.ts
+++ b/packages/maker/wix/src/Config.ts
@@ -15,6 +15,10 @@ export interface MakerWixConfig {
    * The name of the exe file
    */
   exe?: string;
+  /*
+   * The app's icon
+   */
+  icon?: string;
   /**
    * The [Microsoft Windows Language Code identifier](https://msdn.microsoft.com/en-us/library/cc233965.aspx) used by the installer.
    * Will use 1033 (English, United-States) if left undefined.

--- a/packages/maker/wix/src/MakerWix.ts
+++ b/packages/maker/wix/src/MakerWix.ts
@@ -52,4 +52,4 @@ export default class MakerWix extends MakerBase<MakerWixConfig> {
   }
 }
 
-export { MakerWix, MakerWixConfig };
+export { MakerWix, MakerWixConfig, MSICreatorOptions };


### PR DESCRIPTION
This PR exposes icon in the MakerWixConfig interface.

_Note: We should refactor how options are passed here, so we're not using a duplicated interface over MSICreatorOptions, but I'll avoid doing that right before stable release._
