### PR TITLE
fix: restore isProd in the webpack  plugin

### DIFF
--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -154,6 +154,7 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
   getHooks(): ForgeHookMap {
     return {
       prePackage: async (config, platform, arch) => {
+        this.isProd = true;
         await fs.remove(this.baseDir);
         await utils.rebuildHook(
           this.projectDir,


### PR DESCRIPTION
Per https://github.com/electron/forge/pull/2995#issuecomment-1296079778

This was lost accidentally, we need better webpack plugin tests 🤔 