### PR TITLE
fix: use @electron-forge/cli hint for project resolution

### DIFF
--- a/packages/api/core/src/util/resolve-dir.ts
+++ b/packages/api/core/src/util/resolve-dir.ts
@@ -39,6 +39,11 @@ export default async (dir: string): Promise<string | null> => {
         return mDir;
       }
 
+      if (packageJSON.devDependencies?.['@electron-forge/cli']) {
+        d('package.json with forge dependency found in', testPath);
+        return mDir;
+      }
+
       bestGuessDir = mDir;
     }
     mDir = path.dirname(mDir);


### PR DESCRIPTION
We were falling back to the "best guess" behavior for the forge.config.js scenario, we can do better than best guess and infer a forge project based on a forge dependency
