### PR TITLE
fix(publish): ignore unnecessary files when publishing to npm

### DIFF
--- a/tools/publish.js
+++ b/tools/publish.js
@@ -60,12 +60,22 @@ const publisher = new Listr([
             return {
               title: `Publishing: ${chalk.cyan(`${name}@${version}`)} (beta=${isBeta ? chalk.green('true') : chalk.red('false')})`,
               task: async () => {
+                const npmIgnorePath = path.join(dir, '.npmignore');
+                let writtenNpmIgnore = false;
+
                 try {
+                  await fs.promises.writeFile(npmIgnorePath, ['*.ts', '!*.d.ts', '*.tsbuildinfo', 'tsconfig.json', '*.map', '/test'].join('\n'));
+                  writtenNpmIgnore = true;
+
                   await spawn('npm', ['publish', '--access=public', ...(isBeta ? ['--tag=beta'] : []), `--otp=${ctx.otp}`], {
                     cwd: dir,
                   });
                 } catch (err) {
                   throw new Error(`Failed to publish ${chalk.cyan(`${name}@${version}`)} \n${err.stderr.toString()}`);
+                } finally {
+                  if (writtenNpmIgnore) {
+                    await fs.promises.rm(npmIgnorePath);
+                  }
                 }
               },
             };


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Currently, a large number of source/development files (`.ts`/`.map`/etc.) from most packages is being published to npm.

![image](https://user-images.githubusercontent.com/19478575/198894342-0e87d411-c087-4dd8-ae72-75fcccc4fc18.png)

The `plugin-webpack` package is even publishing its entire `test` folder with a test app, including its `node_modules`:

![image](https://user-images.githubusercontent.com/19478575/198894454-dbde5ac3-2f32-4285-91df-d33ac374e09f.png)

This PR addresses the problem by writing a `.npmignore` file to each package folder before publishing, and then removing the file afterwards. `.ts` (except `.d.ts` type definitions), `tsconfig.json`, `.map` and `.tsbuildinfo` files, as well as any `/test` folders, are now ignored.

Since the `.gitignore` in the project root has `.npmignore`, I thought writing and then deleting the files would be an acceptable approach (not to mention easier to review), but actually adding the `.npmignore` files to Git would be trivial if necessary.