### PR TITLE
fix(resolve-dir): correctly detect working dir when use config file

### DIFF
--- a/packages/api/core/src/util/resolve-dir.ts
+++ b/packages/api/core/src/util/resolve-dir.ts
@@ -20,6 +20,8 @@ export default async (dir: string): Promise<string | null> => {
   while (prevDir !== mDir) {
     prevDir = mDir;
     const testPath = path.resolve(mDir, 'package.json');
+    const tsConfigFilePath = path.resolve(mDir, 'forge.config.ts');
+    const jsConfigFilePath = path.resolve(mDir, 'forge.config.js');
     d('searching for project in:', mDir);
     if (await fs.pathExists(testPath)) {
       const packageJSON = await readRawPackageJson(mDir);
@@ -34,8 +36,8 @@ export default async (dir: string): Promise<string | null> => {
         }
       }
 
-      if (packageJSON.config && packageJSON.config.forge) {
-        d('electron-forge compatible package.json found in', testPath);
+      if ((packageJSON.config && packageJSON.config.forge) || (await fs.pathExists(tsConfigFilePath)) || (await fs.pathExists(jsConfigFilePath))) {
+        d('electron-forge compatible config found in', testPath);
         return mDir;
       }
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

When use forge config file, such as `forge.config.ts` and `forge.config.js`, forge cannot correctly resolve working dir. Because forge only treat `config.forge` exists in `package.json` as a matched forge working dir. This PR fix this problem.
