### PR TITLE
fix(template-base): use minimum instead of exact version when replacing `ELECTRON_FORGE/VERSION` in templates

### DIFF
--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -25,7 +25,7 @@ export class BaseTemplate implements ForgeTemplate {
       if (packageDevDeps) {
         return Object.entries(packageDevDeps).map(([packageName, version]) => {
           if (version === 'ELECTRON_FORGE/VERSION') {
-            version = currentForgeVersion;
+            version = `^${currentForgeVersion}`;
           }
           return `${packageName}@${version}`;
         });


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
This PR ensures that the most recent compatible version of `@electron-forge/plugin-webpack` will be installed by `create-electron-app`. While the `package.json` might still show an older version when using `create-electron-app` (as outlined in https://github.com/electron/forge/issues/3019#issuecomment-1297307522), the version `yarn` / `npm` will actually install is the most recent.