### PR TITLE
build: add vscode config for better devxp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .nyc_output
-.vscode
 *.lcov
 /coverage
 dist

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode", "maty.vscode-mocha-sidebar"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,29 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "[typescript]": {
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": true
+    },
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.eslint": true
+    },
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "mocha.env": {
+    "TS_NODE_PROJECT": "tsconfig.test.json",
+    "TS_NODE_FILES": "1",
+    "TEST_FAST_ONLY": "1"
+  },
+  "mocha.files.glob": "packages/*/*/test/**/*_spec*.ts",
+  "mocha.requires": ["ts-node/register", "tools/test-setup.ts"],
+  "mocha.options": {
+    "extension": ["ts"],
+    "timeout": 800000,
+    "recursive": true
+  }
+}


### PR DESCRIPTION
This is a bit opinionated so happy to leave these gitignored 🤷 

* Adds reccomended workspace extensions for eslint, prettier and mocha
* Configures eslint + prettier to format on save
* Configures mocha so you can run single / debug single tests from the vscode UI (including step by step breakpoints)