### PR TITLE
fix(plugin-webpack): use proper preload define for renderer

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -89,10 +89,10 @@ export default class WebpackConfigGenerator {
     return `${entryPoint.name.toUpperCase().replace(/ /g, '_')}${suffix}`;
   }
 
-  getPreloadDefine(entryPoint: WebpackPluginEntryPoint): string {
+  getPreloadDefine(entryPoint: WebpackPluginEntryPoint, inRendererDir: boolean): string {
     if (!isNoWindow(entryPoint)) {
       if (this.isProd) {
-        return `require('path').resolve(__dirname, '../renderer', '${entryPoint.name}', 'preload.js')`;
+        return `require('path').resolve(__dirname, '..', '${inRendererDir ? 'renderer' : '.'}', '${entryPoint.name}', 'preload.js')`;
       }
       return `'${path.resolve(this.webpackDir, 'renderer', entryPoint.name, 'preload.js').replace(/\\/g, '\\\\')}'`;
     } else {
@@ -117,7 +117,7 @@ export default class WebpackConfigGenerator {
       defines[`process.env.${entryKey}`] = defines[entryKey];
 
       const preloadDefineKey = this.toEnvironmentVariable(entryPoint, true);
-      defines[preloadDefineKey] = this.getPreloadDefine(entryPoint);
+      defines[preloadDefineKey] = this.getPreloadDefine(entryPoint, inRendererDir);
       defines[`process.env.${preloadDefineKey}`] = defines[preloadDefineKey];
     }
 

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -175,7 +175,13 @@ describe('WebpackConfigGenerator', () => {
       it('should assign an expression to resolve the preload script in production', () => {
         const generator = new WebpackConfigGenerator(config, mockProjectDir, true, 3000);
         const defines = generator.getDefines();
-        expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.equal("require('path').resolve(__dirname, '../renderer', 'window', 'preload.js')");
+        expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.equal("require('path').resolve(__dirname, '..', 'renderer', 'window', 'preload.js')");
+      });
+
+      it('should assign an expression to resolve the preload script in production renderer scripts', () => {
+        const generator = new WebpackConfigGenerator(config, mockProjectDir, true, 3000);
+        const defines = generator.getDefines(false);
+        expect(defines.WINDOW_PRELOAD_WEBPACK_ENTRY).to.equal("require('path').resolve(__dirname, '..', '.', 'window', 'preload.js')");
       });
     });
   });


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Changes the preload define created for production renderer scripts so there is no longer a /renderer/renderer in the path.

Fixes #1590