### PR TITLE
fix(maker-pkg): add targetArch to pkg name

### DIFF
--- a/packages/maker/pkg/src/MakerPKG.ts
+++ b/packages/maker/pkg/src/MakerPKG.ts
@@ -15,12 +15,12 @@ export default class MakerPKG extends MakerBase<MakerPKGConfig> {
     return process.platform === 'darwin';
   }
 
-  async make({ dir, makeDir, appName, packageJSON, targetPlatform }: MakerOptions): Promise<string[]> {
+  async make({ dir, makeDir, appName, packageJSON, targetPlatform, targetArch }: MakerOptions): Promise<string[]> {
     if (!this.isValidTargetPlatform(targetPlatform)) {
       throw new Error(`The pkg maker only supports targeting "mas" and "darwin" builds. You provided "${targetPlatform}".`);
     }
 
-    const outPath = path.resolve(makeDir, `${appName}-${packageJSON.version}.pkg`);
+    const outPath = path.resolve(makeDir, `${appName}-${packageJSON.version}-${targetArch}.pkg`);
 
     await this.ensureFile(outPath);
 

--- a/packages/maker/pkg/test/MakerPKG_spec.ts
+++ b/packages/maker/pkg/test/MakerPKG_spec.ts
@@ -69,7 +69,7 @@ describe('MakerPKG', () => {
     const opts = osxSignStub.firstCall.args[0];
     expect(opts).to.deep.equal({
       app: path.resolve(`${dir}/My Test App.app`),
-      pkg: path.resolve(`${dir.substr(0, dir.length - 4)}/make/My Test App-1.2.3.pkg`),
+      pkg: path.resolve(`${dir.substr(0, dir.length - 4)}/make/My Test App-1.2.3-${targetArch}.pkg`),
       platform: 'mas',
     });
   });


### PR DESCRIPTION
Supersedes #2726

there's some weirdness rebasing when pulling from the `master` branch of a fork I don't want to deal with.