### PR TITLE
fix(maker-squirrel): do not register the delta nupkg as an artifact when deltas are disabled

### DIFF
--- a/packages/maker/squirrel/src/MakerSquirrel.ts
+++ b/packages/maker/squirrel/src/MakerSquirrel.ts
@@ -41,7 +41,7 @@ export default class MakerSquirrel extends MakerBase<MakerSquirrelConfig> {
       path.resolve(outPath, `${winstallerConfig.name}-${nupkgVersion}-full.nupkg`),
     ];
     const deltaPath = path.resolve(outPath, `${winstallerConfig.name}-${nupkgVersion}-delta.nupkg`);
-    if (winstallerConfig.remoteReleases || (await fs.pathExists(deltaPath))) {
+    if ((winstallerConfig.remoteReleases && !winstallerConfig.noDelta) || (await fs.pathExists(deltaPath))) {
       artifacts.push(deltaPath);
     }
     const msiPath = path.resolve(outPath, winstallerConfig.setupMsi || `${appName}Setup.msi`);

--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -30,14 +30,12 @@ export default class PublisherS3 extends PublisherBase<PublisherS3Config> {
 
     for (const makeResult of makeResults) {
       artifacts.push(
-        ...makeResult.artifacts
-          .filter((artifact) => fs.existsSync(artifact))
-          .map((artifact) => ({
-            path: artifact,
-            keyPrefix: this.config.folder || makeResult.packageJSON.version,
-            platform: makeResult.platform,
-            arch: makeResult.arch,
-          }))
+        ...makeResult.artifacts.map((artifact) => ({
+          path: artifact,
+          keyPrefix: this.config.folder || makeResult.packageJSON.version,
+          platform: makeResult.platform,
+          arch: makeResult.arch,
+        }))
       );
     }
 


### PR DESCRIPTION
A better fix for f3d38e0dfbcb307355adfe5b2118ebedbdd91bcc that doesn't just drop all missing files for a single publisher, rather is ensures the maker does not erroneously add the file to the artifacts list in the first place.