### PR TITLE
fix(template-webpack): only run asset relocator loader on `node_modules` folder

### DIFF
--- a/packages/plugin/webpack/test/fixtures/apps/native-modules/webpack.rules.js
+++ b/packages/plugin/webpack/test/fixtures/apps/native-modules/webpack.rules.js
@@ -1,6 +1,6 @@
 module.exports = [
   {
-    test: /\.(m?js|node)$/,
+    test: /\/node_modules\/.*\.(m?js|node)$/,
     parser: { amd: false },
     use: {
       loader: '@vercel/webpack-asset-relocator-loader',

--- a/packages/plugin/webpack/test/fixtures/apps/native-modules/webpack.rules.js
+++ b/packages/plugin/webpack/test/fixtures/apps/native-modules/webpack.rules.js
@@ -1,6 +1,18 @@
+const path = require('path');
+
+// platform-aware path separator for loader test regex
+const sep = '\\' + path.sep;
+
 module.exports = [
+  // Add support for native node modules
   {
-    test: /\/node_modules\/.*\.(m?js|node)$/,
+    // We're specifying native_modules in the test because the asset relocator loader generates a
+    // "fake" .node file which is really a cjs file.
+    test: new RegExp(`native_modules${sep}.+\\.node$`),
+    use: 'node-loader',
+  },
+  {
+    test: new RegExp(`${sep}node_modules${sep}.+\\.(m?js|node)$`),
     parser: { amd: false },
     use: {
       loader: '@vercel/webpack-asset-relocator-loader',

--- a/packages/plugin/webpack/test/fixtures/apps/native-modules/webpack.rules.js
+++ b/packages/plugin/webpack/test/fixtures/apps/native-modules/webpack.rules.js
@@ -4,15 +4,15 @@ module.exports = [
     // We're specifying native_modules in the test because the asset relocator loader generates a
     // "fake" .node file which is really a cjs file.
     test: /native_modules[/\\].+\.node$/,
-    use: "node-loader",
+    use: 'node-loader',
   },
   {
     test: /[/\\]node_modules[/\\].+\.(m?js|node)$/,
     parser: { amd: false },
     use: {
-      loader: "@vercel/webpack-asset-relocator-loader",
+      loader: '@vercel/webpack-asset-relocator-loader',
       options: {
-        outputAssetBase: "native_modules",
+        outputAssetBase: 'native_modules',
       },
     },
   },

--- a/packages/plugin/webpack/test/fixtures/apps/native-modules/webpack.rules.js
+++ b/packages/plugin/webpack/test/fixtures/apps/native-modules/webpack.rules.js
@@ -1,23 +1,18 @@
-const path = require('path');
-
-// platform-aware path separator for loader test regex
-const sep = '\\' + path.sep;
-
 module.exports = [
   // Add support for native node modules
   {
     // We're specifying native_modules in the test because the asset relocator loader generates a
     // "fake" .node file which is really a cjs file.
-    test: new RegExp(`native_modules${sep}.+\\.node$`),
-    use: 'node-loader',
+    test: /native_modules[/\\].+\.node$/,
+    use: "node-loader",
   },
   {
-    test: new RegExp(`${sep}node_modules${sep}.+\\.(m?js|node)$`),
+    test: /[/\\]node_modules[/\\].+\.(m?js|node)$/,
     parser: { amd: false },
     use: {
-      loader: '@vercel/webpack-asset-relocator-loader',
+      loader: "@vercel/webpack-asset-relocator-loader",
       options: {
-        outputAssetBase: 'native_modules',
+        outputAssetBase: "native_modules",
       },
     },
   },

--- a/packages/template/webpack-typescript/tmpl/webpack.rules.ts
+++ b/packages/template/webpack-typescript/tmpl/webpack.rules.ts
@@ -1,20 +1,20 @@
-import type { ModuleOptions } from "webpack";
+import type { ModuleOptions } from 'webpack';
 
-export const rules: Required<ModuleOptions>["rules"] = [
+export const rules: Required<ModuleOptions>['rules'] = [
   // Add support for native node modules
   {
     // We're specifying native_modules in the test because the asset relocator loader generates a
     // "fake" .node file which is really a cjs file.
     test: /native_modules[/\\].+\.node$/,
-    use: "node-loader",
+    use: 'node-loader',
   },
   {
     test: /[/\\]node_modules[/\\].+\.(m?js|node)$/,
     parser: { amd: false },
     use: {
-      loader: "@vercel/webpack-asset-relocator-loader",
+      loader: '@vercel/webpack-asset-relocator-loader',
       options: {
-        outputAssetBase: "native_modules",
+        outputAssetBase: 'native_modules',
       },
     },
   },
@@ -22,7 +22,7 @@ export const rules: Required<ModuleOptions>["rules"] = [
     test: /\.tsx?$/,
     exclude: /(node_modules|\.webpack)/,
     use: {
-      loader: "ts-loader",
+      loader: 'ts-loader',
       options: {
         transpileOnly: true,
       },

--- a/packages/template/webpack-typescript/tmpl/webpack.rules.ts
+++ b/packages/template/webpack-typescript/tmpl/webpack.rules.ts
@@ -1,24 +1,20 @@
-import type { ModuleOptions } from 'webpack';
-import path from 'path';
+import type { ModuleOptions } from "webpack";
 
-// platform-aware path separator for loader test regex
-const sep = '\\' + path.sep;
-
-export const rules: Required<ModuleOptions>['rules'] = [
+export const rules: Required<ModuleOptions>["rules"] = [
   // Add support for native node modules
   {
     // We're specifying native_modules in the test because the asset relocator loader generates a
     // "fake" .node file which is really a cjs file.
-    test: new RegExp(`native_modules${sep}.+\\.node$`),
-    use: 'node-loader',
+    test: /native_modules[/\\].+\.node$/,
+    use: "node-loader",
   },
   {
-    test: new RegExp(`${sep}node_modules${sep}.+\\.(m?js|node)$`),
+    test: /[/\\]node_modules[/\\].+\.(m?js|node)$/,
     parser: { amd: false },
     use: {
-      loader: '@vercel/webpack-asset-relocator-loader',
+      loader: "@vercel/webpack-asset-relocator-loader",
       options: {
-        outputAssetBase: 'native_modules',
+        outputAssetBase: "native_modules",
       },
     },
   },
@@ -26,7 +22,7 @@ export const rules: Required<ModuleOptions>['rules'] = [
     test: /\.tsx?$/,
     exclude: /(node_modules|\.webpack)/,
     use: {
-      loader: 'ts-loader',
+      loader: "ts-loader",
       options: {
         transpileOnly: true,
       },

--- a/packages/template/webpack-typescript/tmpl/webpack.rules.ts
+++ b/packages/template/webpack-typescript/tmpl/webpack.rules.ts
@@ -1,15 +1,19 @@
 import type { ModuleOptions } from 'webpack';
+import path from 'path';
+
+// platform-aware path separator for loader test regex
+const sep = '\\' + path.sep;
 
 export const rules: Required<ModuleOptions>['rules'] = [
   // Add support for native node modules
   {
     // We're specifying native_modules in the test because the asset relocator loader generates a
     // "fake" .node file which is really a cjs file.
-    test: /native_modules\/.+\.node$/,
+    test: new RegExp(`native_modules${sep}.+\\.node$`),
     use: 'node-loader',
   },
   {
-    test: /\/node_modules\/.*\.(m?js|node)$/,
+    test: new RegExp(`${sep}node_modules${sep}.+\\.(m?js|node)$`),
     parser: { amd: false },
     use: {
       loader: '@vercel/webpack-asset-relocator-loader',

--- a/packages/template/webpack-typescript/tmpl/webpack.rules.ts
+++ b/packages/template/webpack-typescript/tmpl/webpack.rules.ts
@@ -9,7 +9,7 @@ export const rules: Required<ModuleOptions>['rules'] = [
     use: 'node-loader',
   },
   {
-    test: /\.(m?js|node)$/,
+    test: /\/node_modules\/.*\.(m?js|node)$/,
     parser: { amd: false },
     use: {
       loader: '@vercel/webpack-asset-relocator-loader',

--- a/packages/template/webpack/tmpl/webpack.rules.js
+++ b/packages/template/webpack/tmpl/webpack.rules.js
@@ -7,7 +7,7 @@ module.exports = [
     use: 'node-loader',
   },
   {
-    test: /\.(m?js|node)$/,
+    test: /\/node_modules\/.*\.(m?js|node)$/,
     parser: { amd: false },
     use: {
       loader: '@vercel/webpack-asset-relocator-loader',

--- a/packages/template/webpack/tmpl/webpack.rules.js
+++ b/packages/template/webpack/tmpl/webpack.rules.js
@@ -4,15 +4,15 @@ module.exports = [
     // We're specifying native_modules in the test because the asset relocator loader generates a
     // "fake" .node file which is really a cjs file.
     test: /native_modules[/\\].+\.node$/,
-    use: "node-loader",
+    use: 'node-loader',
   },
   {
     test: /[/\\]node_modules[/\\].+\.(m?js|node)$/,
     parser: { amd: false },
     use: {
-      loader: "@vercel/webpack-asset-relocator-loader",
+      loader: '@vercel/webpack-asset-relocator-loader',
       options: {
-        outputAssetBase: "native_modules",
+        outputAssetBase: 'native_modules',
       },
     },
   },

--- a/packages/template/webpack/tmpl/webpack.rules.js
+++ b/packages/template/webpack/tmpl/webpack.rules.js
@@ -1,13 +1,18 @@
+const path = require('path');
+
+// platform-aware path separator for loader test regex
+const sep = '\\' + path.sep;
+
 module.exports = [
   // Add support for native node modules
   {
     // We're specifying native_modules in the test because the asset relocator loader generates a
     // "fake" .node file which is really a cjs file.
-    test: /native_modules\/.+\.node$/,
+    test: new RegExp(`native_modules${sep}.+\\.node$`),
     use: 'node-loader',
   },
   {
-    test: /\/node_modules\/.*\.(m?js|node)$/,
+    test: new RegExp(`${sep}node_modules${sep}.+\\.(m?js|node)$`),
     parser: { amd: false },
     use: {
       loader: '@vercel/webpack-asset-relocator-loader',

--- a/packages/template/webpack/tmpl/webpack.rules.js
+++ b/packages/template/webpack/tmpl/webpack.rules.js
@@ -1,23 +1,18 @@
-const path = require('path');
-
-// platform-aware path separator for loader test regex
-const sep = '\\' + path.sep;
-
 module.exports = [
   // Add support for native node modules
   {
     // We're specifying native_modules in the test because the asset relocator loader generates a
     // "fake" .node file which is really a cjs file.
-    test: new RegExp(`native_modules${sep}.+\\.node$`),
-    use: 'node-loader',
+    test: /native_modules[/\\].+\.node$/,
+    use: "node-loader",
   },
   {
-    test: new RegExp(`${sep}node_modules${sep}.+\\.(m?js|node)$`),
+    test: /[/\\]node_modules[/\\].+\.(m?js|node)$/,
     parser: { amd: false },
     use: {
-      loader: '@vercel/webpack-asset-relocator-loader',
+      loader: "@vercel/webpack-asset-relocator-loader",
       options: {
-        outputAssetBase: 'native_modules',
+        outputAssetBase: "native_modules",
       },
     },
   },


### PR DESCRIPTION
Fixes https://github.com/electron/forge/issues/3055

The reason this plugin does this is long and complicated but it's easy to just not run the plugin on app-code and limit it to `node_modules`.  If you have node_modules code that does this pattern of assuming webpack will make the worker (a) that's weird and (b) you can just exclude that module in a similar way.

This should fix it by default for like 99% of folks though.