### PR TITLE
fix(plugin-webpack): remove define plugin from renderer config

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -192,7 +192,6 @@ export default class WebpackConfigGenerator {
 
   async getRendererConfig(entryPoints: WebpackPluginEntryPoint[]): Promise<Configuration[]> {
     const rendererConfig = await this.resolveConfig(this.pluginConfig.renderer.config);
-    const defines = this.getDefines(false);
 
     return entryPoints.map((entryPoint) => {
       const baseConfig: webpack.Configuration = {
@@ -209,7 +208,7 @@ export default class WebpackConfigGenerator {
           __dirname: false,
           __filename: false,
         },
-        plugins: [new webpack.DefinePlugin(defines), new AssetRelocatorPatch(this.isProd, !!this.pluginConfig.renderer.nodeIntegration)],
+        plugins: [new AssetRelocatorPatch(this.isProd, !!this.pluginConfig.renderer.nodeIntegration)],
       };
 
       if (isLocalWindow(entryPoint)) {

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -442,7 +442,7 @@ describe('WebpackConfigGenerator', () => {
         publicPath: '/',
       });
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(webpackConfig[0].plugins!.length).to.equal(2);
+      expect(webpackConfig[0].plugins!.length).to.equal(1);
       expect(hasAssetRelocatorPatchPlugin(webpackConfig[0].plugins)).to.equal(true);
     });
 
@@ -464,7 +464,7 @@ describe('WebpackConfigGenerator', () => {
         main: ['rendererScript.js'],
       });
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(webpackConfig[0].plugins!.length).to.equal(3);
+      expect(webpackConfig[0].plugins!.length).to.equal(2);
       expect(hasAssetRelocatorPatchPlugin(webpackConfig[0].plugins)).to.equal(true);
     });
 
@@ -488,7 +488,7 @@ describe('WebpackConfigGenerator', () => {
         main: ['rendererScript.js'],
       });
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(webpackConfig[0].plugins!.length).to.equal(2);
+      expect(webpackConfig[0].plugins!.length).to.equal(1);
       expect(hasAssetRelocatorPatchPlugin(webpackConfig[0].plugins)).to.equal(true);
     });
 
@@ -516,7 +516,7 @@ describe('WebpackConfigGenerator', () => {
         globalObject: 'self',
       });
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(webpackConfig[0].plugins!.length).to.equal(2);
+      expect(webpackConfig[0].plugins!.length).to.equal(1);
       expect(hasAssetRelocatorPatchPlugin(webpackConfig[0].plugins)).to.equal(true);
     });
 
@@ -546,7 +546,7 @@ describe('WebpackConfigGenerator', () => {
         globalObject: 'self',
       });
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      expect(webpackConfig[0].plugins!.length).to.equal(2);
+      expect(webpackConfig[0].plugins!.length).to.equal(1);
       expect(hasAssetRelocatorPatchPlugin(webpackConfig[0].plugins)).to.equal(true);
     });
 


### PR DESCRIPTION
Ref https://github.com/electron/forge/issues/1590 and https://github.com/electron/forge/pull/3050#pullrequestreview-1173470995

Removes the DefinePlugin magic variables from the renderer process.

Associated docs change: https://app.gitbook.com/o/-LBKDRmeoAGTb1M5X51f/s/-LBKK1y7h_XWAtuRJG9X-4037718589/~/changes/V3yAgQ9u6bblHPLwO1bj/config/plugins/webpack