### PR TITLE
fix(core): allow the `forge.config` property in `package.json` to point to a non-js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,8 @@
     "typedoc-plugin-missing-exports": "^1.0.0",
     "typedoc-plugin-rename-defaults": "^0.6.4",
     "typescript": "^4.6.3",
-    "xvfb-maybe": "^0.2.1"
+    "xvfb-maybe": "^0.2.1",
+    "yaml-hook": "^1.0.0"
   },
   "optionalDependencies": {
     "@malept/electron-installer-flatpak": "^0.11.2",

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -36,7 +36,8 @@
     "mocha": "^9.0.1",
     "proxyquire": "^2.1.3",
     "sinon": "^13.0.1",
-    "sinon-chai": "^3.6.0"
+    "sinon-chai": "^3.6.0",
+    "yaml-hook": "^1.0.0"
   },
   "dependencies": {
     "@electron-forge/core-utils": "^6.0.3",

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -109,8 +109,8 @@ export default async (dir: string): Promise<ResolvedForgeConfig> => {
   const packageJSON = await readRawPackageJson(dir);
   let forgeConfig: ForgeConfig | string | null = packageJSON.config && packageJSON.config.forge ? packageJSON.config.forge : null;
 
-  if (!forgeConfig) {
-    for (const extension of ['.js', ...Object.keys(interpret.extensions)]) {
+  if (!forgeConfig || typeof forgeConfig === 'string') {
+    for (const extension of ['.js', ...Object.keys(interpret.extensions), forgeConfig].filter(Boolean)) {
       const pathToConfig = path.resolve(dir, `forge.config${extension}`);
       if (await fs.pathExists(pathToConfig)) {
         rechoir.prepare(interpret.extensions, pathToConfig, dir);

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -110,7 +110,7 @@ export default async (dir: string): Promise<ResolvedForgeConfig> => {
   let forgeConfig: ForgeConfig | string | null = packageJSON.config && packageJSON.config.forge ? packageJSON.config.forge : null;
 
   if (!forgeConfig || typeof forgeConfig === 'string') {
-    for (const extension of ['.js', ...Object.keys(interpret.extensions), forgeConfig].filter(Boolean)) {
+    for (const extension of ['.js', ...Object.keys(interpret.extensions)]) {
       const pathToConfig = path.resolve(dir, `forge.config${extension}`);
       if (await fs.pathExists(pathToConfig)) {
         rechoir.prepare(interpret.extensions, pathToConfig, dir);

--- a/packages/api/core/test/fast/forge-config_spec.ts
+++ b/packages/api/core/test/fast/forge-config_spec.ts
@@ -114,6 +114,13 @@ describe('forge-config', () => {
     expect(conf.defaultResolved).to.equal(true);
   });
 
+  // @TODO make sure this test passes
+  it(`should resolve the yml config from forge.config.yml if it's specified in config.forge`, async () => {
+    type DefaultResolvedConfig = ResolvedForgeConfig;
+    const conf = (await findConfig(path.resolve(__dirname, '../fixture/dummy_ts_conf'))) as DefaultResolvedConfig;
+    expect(conf.buildIdentifier).to.equal('yml');
+  });
+
   it('should resolve the TS file exports of forge.config.ts if config.forge does not exist and the TS config exists', async () => {
     type DefaultResolvedConfig = ResolvedForgeConfig;
     const conf = (await findConfig(path.resolve(__dirname, '../fixture/dummy_default_ts_conf'))) as DefaultResolvedConfig;

--- a/packages/api/core/test/fast/forge-config_spec.ts
+++ b/packages/api/core/test/fast/forge-config_spec.ts
@@ -114,7 +114,6 @@ describe('forge-config', () => {
     expect(conf.defaultResolved).to.equal(true);
   });
 
-  // @TODO make sure this test passes
   it(`should resolve the yml config from forge.config.yml if it's specified in config.forge`, async () => {
     type DefaultResolvedConfig = ResolvedForgeConfig;
     const conf = (await findConfig(path.resolve(__dirname, '../fixture/dummy_ts_conf'))) as DefaultResolvedConfig;

--- a/packages/api/core/test/fixture/dummy_ts_conf/forge.config.yml
+++ b/packages/api/core/test/fixture/dummy_ts_conf/forge.config.yml
@@ -1,0 +1,1 @@
+buildIdentifier: 'yml'

--- a/packages/api/core/test/fixture/dummy_ts_conf/package.json
+++ b/packages/api/core/test/fixture/dummy_ts_conf/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "",
+  "productName": "",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "electron-forge start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "config": {
+    "forge": "./forge.config.yml"
+  },
+  "devDependencies": {
+    "@electron-forge/shared-types": "*",
+    "electron-prebuilt": "9.9.9"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7493,7 +7493,7 @@ js-yaml@4.1.0, js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-js-yaml@^3.10.0, js-yaml@^3.13.1:
+js-yaml@^3.10.0, js-yaml@^3.12.2, js-yaml@^3.13.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
@@ -11554,6 +11554,14 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml-hook@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yaml-hook/-/yaml-hook-1.0.0.tgz#14d682e949a9cf6f041e2af8278a4d349ccb52b7"
+  integrity sha512-iqSS5Mk1F3yBtrfx94hWzmEk0Wxs5QoBRvngAe39t0XA2JJ3jhQN6Snwv/shH1VoZr+ntdhf4EDLmW0WUWBjdQ==
+  dependencies:
+    js-yaml "^3.12.2"
+    pirates "^4.0.1"
 
 yaml@^1.10.0, yaml@^1.10.2:
   version "1.10.2"


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
This PR makes it possible to specify a config file of any extension in the `config.forge` property of `package.json`. While https://github.com/electron/forge/pull/2993 allows for config files in extensions other than .js, they're only interpreted correctly if you don't specify the `config.forge` property in your `package.json` - if you do, the file is interpreted as plain .js.

This seems unexpected and can get on the way if one tries to migrate to, say, a .ts config file just by changing the extension in the `package.json` like this...

```diff
   "config": {
-    "forge": "./forge.config.js"
+    "forge": "./forge.config.ts"
   },
 ```
... because Forge expects it to be .js and throws an error. Currently, the entire `config.forge` must be removed for Forge to use the correct loader for `forge.config.ts`:

```diff
-  "config": {
-    "forge": "./forge.config.js"
-  },
```

