### PR TITLE
feat(template): enable asar by default in webpack-based templates

### DIFF
--- a/packages/template/base/tmpl/forge.config.js
+++ b/packages/template/base/tmpl/forge.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  packagerConfig: {},
+  packagerConfig: {
+    asar: true,
+  },
   rebuildConfig: {},
   makers: [
     {

--- a/packages/template/webpack-typescript/tmpl/forge.config.ts
+++ b/packages/template/webpack-typescript/tmpl/forge.config.ts
@@ -9,7 +9,9 @@ import { mainConfig } from './webpack.main.config';
 import { rendererConfig } from './webpack.renderer.config';
 
 const config: ForgeConfig = {
-  packagerConfig: {},
+  packagerConfig: {
+    asar: true,
+  },
   rebuildConfig: {},
   makers: [new MakerSquirrel({}), new MakerZIP({}, ['darwin']), new MakerRpm({}), new MakerDeb({})],
   plugins: [

--- a/packages/template/webpack/tmpl/forge.config.js
+++ b/packages/template/webpack/tmpl/forge.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  packagerConfig: {},
+  packagerConfig: {
+    asar: true,
+  },
   rebuildConfig: {},
   makers: [
     {


### PR DESCRIPTION

- [ ] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This PR adds `asar: true` by default to `template-webpack` and `template-typescript-webpack` and also adds the Auto Unpack Natives plugin for better native module compatibility with asar.

Ref https://github.com/electron/forge/issues/3069#issuecomment-1314112286


