### PR TITLE
feat(template): enable asar by default

### DIFF
--- a/packages/api/core/src/api/init-scripts/init-npm.ts
+++ b/packages/api/core/src/api/init-scripts/init-npm.ts
@@ -15,7 +15,14 @@ export function siblingDep(name: string): string {
 }
 
 export const deps = ['electron-squirrel-startup'];
-export const devDeps = [siblingDep('cli'), siblingDep('maker-squirrel'), siblingDep('maker-zip'), siblingDep('maker-deb'), siblingDep('maker-rpm')];
+export const devDeps = [
+  siblingDep('cli'),
+  siblingDep('maker-squirrel'),
+  siblingDep('maker-zip'),
+  siblingDep('maker-deb'),
+  siblingDep('maker-rpm'),
+  siblingDep('plugin-auto-unpack-natives'),
+];
 export const exactDevDeps = ['electron'];
 
 export const initNPM = async <T>(dir: string, task: ForgeListrTask<T>): Promise<void> => {

--- a/packages/template/base/tmpl/forge.config.js
+++ b/packages/template/base/tmpl/forge.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  packagerConfig: {},
+  packagerConfig: {
+    asar: true,
+  },
   rebuildConfig: {},
   makers: [
     {
@@ -17,6 +19,11 @@ module.exports = {
     {
       name: '@electron-forge/maker-rpm',
       config: {},
+    },
+  ],
+  plugins: [
+    {
+      name: '@electron-forge/plugin-auto-unpack-natives',
     },
   ],
 };

--- a/packages/template/webpack-typescript/tmpl/forge.config.ts
+++ b/packages/template/webpack-typescript/tmpl/forge.config.ts
@@ -3,16 +3,20 @@ import { MakerSquirrel } from '@electron-forge/maker-squirrel';
 import { MakerZIP } from '@electron-forge/maker-zip';
 import { MakerDeb } from '@electron-forge/maker-deb';
 import { MakerRpm } from '@electron-forge/maker-rpm';
+import { AutoUnpackNativesPlugin } from '@electron-forge/plugin-auto-unpack-natives';
 import { WebpackPlugin } from '@electron-forge/plugin-webpack';
 
 import { mainConfig } from './webpack.main.config';
 import { rendererConfig } from './webpack.renderer.config';
 
 const config: ForgeConfig = {
-  packagerConfig: {},
+  packagerConfig: {
+    asar: true,
+  },
   rebuildConfig: {},
   makers: [new MakerSquirrel({}), new MakerZIP({}, ['darwin']), new MakerRpm({}), new MakerDeb({})],
   plugins: [
+    new AutoUnpackNativesPlugin({}),
     new WebpackPlugin({
       mainConfig,
       renderer: {

--- a/packages/template/webpack-typescript/tmpl/package.json
+++ b/packages/template/webpack-typescript/tmpl/package.json
@@ -1,6 +1,5 @@
 {
   "devDependencies": {
-    "@electron-forge/plugin-auto-unpack-natives": "ELECTRON_FORGE/VERSION",
     "@electron-forge/plugin-webpack": "ELECTRON_FORGE/VERSION",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",

--- a/packages/template/webpack-typescript/tmpl/package.json
+++ b/packages/template/webpack-typescript/tmpl/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "@electron-forge/plugin-auto-unpack-natives": "ELECTRON_FORGE/VERSION",
     "@electron-forge/plugin-webpack": "ELECTRON_FORGE/VERSION",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",

--- a/packages/template/webpack/tmpl/forge.config.js
+++ b/packages/template/webpack/tmpl/forge.config.js
@@ -1,5 +1,7 @@
 module.exports = {
-  packagerConfig: {},
+  packagerConfig: {
+    asar: true,
+  },
   rebuildConfig: {},
   makers: [
     {
@@ -20,6 +22,9 @@ module.exports = {
     },
   ],
   plugins: [
+    {
+      name: '@electron-forge/plugin-auto-unpack-natives',
+    },
     {
       name: '@electron-forge/plugin-webpack',
       config: {


### PR DESCRIPTION
Enables `asar` by default with the AutoUnpackNativesPlugin in all of our templates.

cc @malept @MarshallOfSound 