### PR TITLE
fix(publisher-ers): properly publish non-default flavours

### DIFF
--- a/packages/publisher/electron-release-server/src/PublisherERS.ts
+++ b/packages/publisher/electron-release-server/src/PublisherERS.ts
@@ -85,6 +85,8 @@ export default class PublisherERS extends PublisherBase<PublisherERSConfig> {
       let channel = 'stable';
       if (config.channel) {
         channel = config.channel;
+      } else if (packageJSON.version.includes('rc')) {
+        channel = 'rc';
       } else if (packageJSON.version.includes('beta')) {
         channel = 'beta';
       } else if (packageJSON.version.includes('alpha')) {
@@ -127,7 +129,7 @@ export default class PublisherERS extends PublisherBase<PublisherERSConfig> {
           d('attempting to upload asset:', artifactPath);
           const artifactForm = new FormData();
           artifactForm.append('token', token);
-          artifactForm.append('version', packageJSON.version);
+          artifactForm.append('version', `${packageJSON.version}_${flavor}`);
           artifactForm.append('platform', ersPlatform(makeResult.platform, makeResult.arch));
 
           // see https://github.com/form-data/form-data/issues/426


### PR DESCRIPTION

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

- post request form data for version now uses flavor value
- also including auto channel selection for 'rc' versions
