### PR TITLE
build: use lerna run build instead of lerna exec

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -3,14 +3,11 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": ["coverage:base", "test", "test:base", "test:fast", "test:slow"]
+        "cacheableOperations": ["build", "build:fast", "build:full", "test", "test:base", "test:fast"]
       }
     }
   },
   "targetDefaults": {
-    "coverage:base": {
-      "dependsOn": ["^coverage:base"]
-    },
     "test": {
       "dependsOn": ["^test"]
     },
@@ -20,8 +17,17 @@
     "test:fast": {
       "dependsOn": ["^test:fast"]
     },
-    "test:slow": {
-      "dependsOn": ["^test:slow"]
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "build:fast": {
+      "dependsOn": ["^build:fast"],
+      "outputs": ["{projectRoot}/dist"]
+    },
+    "build:full": {
+      "dependsOn": ["^build:full"],
+      "outputs": ["{projectRoot}/dist"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   },
   "scripts": {
     "clean": "rimraf dist && lerna exec -- rimraf dist tsconfig.tsbuildinfo",
-    "build": "lerna exec -- tsc --emitDeclarationOnly && yarn build:fast",
-    "build:fast": "lerna exec -- swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
-    "build:full": "lerna exec -- tsc -b",
+    "build": "lerna run build",
+    "build:fast": "lerna run build:fast",
+    "build:full": "lerna run build:full",
     "postbuild": "ts-node tools/test-dist",
     "docs": "yarn build:full && yarn docs:generate",
     "docs:generate": "yarn docs:plugin && node --max-old-space-size=8192 -r ts-node/register ./tools/gen-docs.ts",

--- a/packages/api/cli/package.json
+++ b/packages/api/cli/package.json
@@ -42,5 +42,10 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -8,6 +8,9 @@
   "author": "Samuel Attard",
   "license": "MIT",
   "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b",
     "coverage:base": "nyc yarn test:base",
     "test": "yarn test:base test/**/*_spec.ts test/**/*_spec_slow.ts",
     "test:base": "cross-env TS_NODE_FILES=1 mocha --config ../../../.mocharc.js",

--- a/packages/external/create-electron-app/package.json
+++ b/packages/external/create-electron-app/package.json
@@ -11,5 +11,10 @@
   },
   "bin": {
     "create-electron-app": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/maker/appx/package.json
+++ b/packages/maker/appx/package.json
@@ -26,5 +26,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/maker/base/package.json
+++ b/packages/maker/base/package.json
@@ -22,5 +22,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/maker/deb/package.json
+++ b/packages/maker/deb/package.json
@@ -26,5 +26,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/maker/dmg/package.json
+++ b/packages/maker/dmg/package.json
@@ -8,6 +8,9 @@
   "main": "dist/MakerDMG.js",
   "typings": "dist/MakerDMG.d.ts",
   "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b",
     "test": "yarn test:base test/**/*_spec.ts",
     "test:base": "cross-env TS_NODE_FILES=1 mocha --config ../../../.mocharc.js"
   },

--- a/packages/maker/flatpak/package.json
+++ b/packages/maker/flatpak/package.json
@@ -8,6 +8,9 @@
   "main": "dist/MakerFlatpak.js",
   "typings": "dist/MakerFlatpak.d.ts",
   "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b",
     "test": "yarn test:base test/**/*_spec.ts",
     "test:base": "cross-env TS_NODE_FILES=1 mocha --config ../../../.mocharc.js"
   },

--- a/packages/maker/pkg/package.json
+++ b/packages/maker/pkg/package.json
@@ -23,5 +23,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/maker/rpm/package.json
+++ b/packages/maker/rpm/package.json
@@ -8,6 +8,9 @@
   "main": "dist/MakerRpm.js",
   "typings": "dist/MakerRpm.d.ts",
   "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b",
     "test": "yarn test:base test/**/*_spec.ts",
     "test:base": "cross-env TS_NODE_FILES=1 mocha --config ../../../.mocharc.js"
   },

--- a/packages/maker/snap/package.json
+++ b/packages/maker/snap/package.json
@@ -7,6 +7,9 @@
   "main": "dist/MakerSnap.js",
   "typings": "dist/MakerSnap.d.ts",
   "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b",
     "test": "yarn test:base test/**/*_spec.ts",
     "test:base": "cross-env TS_NODE_FILES=1 mocha --config ../../../.mocharc.js"
   },

--- a/packages/maker/squirrel/package.json
+++ b/packages/maker/squirrel/package.json
@@ -24,5 +24,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/maker/wix/package.json
+++ b/packages/maker/wix/package.json
@@ -24,5 +24,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/maker/zip/package.json
+++ b/packages/maker/zip/package.json
@@ -22,5 +22,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/plugin/auto-unpack-natives/package.json
+++ b/packages/plugin/auto-unpack-natives/package.json
@@ -16,5 +16,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/plugin/base/package.json
+++ b/packages/plugin/base/package.json
@@ -19,5 +19,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/plugin/compile/package.json
+++ b/packages/plugin/compile/package.json
@@ -21,5 +21,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/plugin/electronegativity/package.json
+++ b/packages/plugin/electronegativity/package.json
@@ -21,5 +21,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/plugin/local-electron/package.json
+++ b/packages/plugin/local-electron/package.json
@@ -21,5 +21,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/plugin/webpack/package.json
+++ b/packages/plugin/webpack/package.json
@@ -8,6 +8,9 @@
   "main": "dist/WebpackPlugin.js",
   "typings": "dist/WebpackPlugin.d.ts",
   "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b",
     "test": "xvfb-maybe mocha --config ../../../.mocharc.js test/**/*_spec.ts"
   },
   "devDependencies": {

--- a/packages/publisher/base/package.json
+++ b/packages/publisher/base/package.json
@@ -8,6 +8,9 @@
   "main": "dist/Publisher.js",
   "typings": "dist/Publisher.d.ts",
   "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b",
     "test": "yarn test:base test/**/*_spec.ts",
     "test:base": "cross-env TS_NODE_FILES=1 mocha --config ../../../.mocharc.js"
   },

--- a/packages/publisher/bitbucket/package.json
+++ b/packages/publisher/bitbucket/package.json
@@ -22,5 +22,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/publisher/electron-release-server/package.json
+++ b/packages/publisher/electron-release-server/package.json
@@ -27,5 +27,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/publisher/github/package.json
+++ b/packages/publisher/github/package.json
@@ -8,6 +8,9 @@
   "main": "dist/PublisherGithub.js",
   "typings": "dist/PublisherGithub.d.ts",
   "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b",
     "test": "yarn test:base test/**/*_spec.ts",
     "test:base": "cross-env TS_NODE_FILES=1 mocha --config ../../../.mocharc.js"
   },

--- a/packages/publisher/nucleus/package.json
+++ b/packages/publisher/nucleus/package.json
@@ -23,5 +23,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/publisher/s3/package.json
+++ b/packages/publisher/s3/package.json
@@ -25,5 +25,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/publisher/snapcraft/package.json
+++ b/packages/publisher/snapcraft/package.json
@@ -23,5 +23,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/template/base/package.json
+++ b/packages/template/base/package.json
@@ -8,6 +8,9 @@
   "main": "dist/BaseTemplate.js",
   "typings": "dist/BaseTemplate.d.ts",
   "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b",
     "test": "mocha --config ../../../.mocharc.js test/**/*_spec.ts"
   },
   "engines": {

--- a/packages/template/webpack-typescript/package.json
+++ b/packages/template/webpack-typescript/package.json
@@ -8,6 +8,9 @@
   "main": "dist/WebpackTypeScriptTemplate.js",
   "typings": "dist/WebpackTypeScriptTemplate.d.ts",
   "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b",
     "test": "mocha --config ../../../.mocharc.js test/**/*_spec_slow.ts"
   },
   "engines": {

--- a/packages/template/webpack/package.json
+++ b/packages/template/webpack/package.json
@@ -8,6 +8,9 @@
   "main": "dist/WebpackTemplate.js",
   "typings": "dist/WebpackTemplate.d.ts",
   "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b",
     "test": "mocha --config ../../../.mocharc.js test/**/*_spec.ts"
   },
   "engines": {

--- a/packages/utils/core-utils/package.json
+++ b/packages/utils/core-utils/package.json
@@ -24,5 +24,10 @@
   },
   "devDependencies": {
     "chai": "^4.3.3"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/utils/test-utils/package.json
+++ b/packages/utils/test-utils/package.json
@@ -17,5 +17,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/utils/types/package.json
+++ b/packages/utils/types/package.json
@@ -17,5 +17,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }

--- a/packages/utils/web-multi-logger/package.json
+++ b/packages/utils/web-multi-logger/package.json
@@ -19,5 +19,10 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "scripts": {
+    "build": "tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "tsc -b"
   }
 }


### PR DESCRIPTION
Using `run build` rather than `exec` allows us to leverage `nx` build caching
