### PR TITLE
build: improve lerna publish process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,11 +110,7 @@ Here are some things to keep in mind as you file pull requests to fix bugs, add 
 - Make sure the tests pass with `lerna run test`
 - Run `git clean -fdx` - this will ensure unneeded build files (and potentially sensitive files) are not included in the npm package.
 - Ensure that you are logged into npm via command line (`npm login`)
-- `lerna publish --force-publish`
-  - **running this command without the `--force-publish` flag will only publish packages that have changes since
-    last release**.
-  - for beta releases, select `custom prerelease` when prompted, and enter `y` to increment the beta version.
-  - version numbers should be an un-prefixed [semantic version](https://semver.org/) number (e.g. `6.0.0-beta.67)
+- Run `yarn send`, which will run the `lerna publish` command with a necessary set of flags.
   - The script will then ask you for your `npm` OTP password.
   - The script will commit the changes automatically. Run `git log` to confirm that the changes have been
     committed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ Here are some things to keep in mind as you file pull requests to fix bugs, add 
 - Make sure the tests pass with `lerna run test`
 - Run `git clean -fdx` - this will ensure unneeded build files (and potentially sensitive files) are not included in the npm package.
 - Ensure that you are logged into npm via command line (`npm login`)
-- Run `yarn send`, which will run the `lerna publish` command with a necessary set of flags.
+- Run `yarn lerna:publish`, which will run the `lerna publish` command with a necessary set of flags.
   - The script will then ask you for your `npm` OTP password.
   - The script will commit the changes automatically. Run `git log` to confirm that the changes have been
     committed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "electron-forge",
-  "//": "See lerna.json for version number",
   "version": "0.0.0-development",
   "private": true,
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,17 @@
 {
   "name": "electron-forge",
-  "version": "6.0.3",
+  "//": "See lerna.json for version number",
+  "version": "0.0.0-development",
   "private": true,
   "license": "MIT",
   "engines": {
     "node": ">= 14.17.5"
   },
   "scripts": {
-    "clean": "rimraf dist && lerna exec --no-private -- rimraf dist tsconfig.tsbuildinfo",
-    "build": "lerna exec --no-private -- tsc --emitDeclarationOnly && yarn build:fast",
-    "build:fast": "lerna exec --no-private -- swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
-    "build:full": "lerna exec --no-private -- tsc -b",
+    "clean": "rimraf dist && lerna exec -- rimraf dist tsconfig.tsbuildinfo",
+    "build": "lerna exec -- tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "lerna exec -- swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "lerna exec -- tsc -b",
     "postbuild": "ts-node tools/test-dist",
     "docs": "yarn build:full && yarn docs:generate",
     "docs:generate": "yarn docs:plugin && node --max-old-space-size=8192 -r ts-node/register ./tools/gen-docs.ts",
@@ -18,7 +19,7 @@
     "docs:deploy:build": "yarn docs",
     "lint": "prettier --check . && eslint .",
     "lint:fix": "prettier --write .",
-    "link:prepare": "lerna exec --no-private -- node ../../../tools/silent.js yarn link --link-folder ../../../.links --silent --no-bin-links",
+    "link:prepare": "lerna exec -- node ../../../tools/silent.js yarn link --link-folder ../../../.links --silent --no-bin-links",
     "test": "xvfb-maybe cross-env LINK_FORGE_DEPENDENCIES_ON_INIT=1 TS_NODE_PROJECT='./tsconfig.test.json' TS_NODE_FILES=1 mocha './tools/test-globber.ts'",
     "test:fast": "xvfb-maybe cross-env LINK_FORGE_DEPENDENCIES_ON_INIT=1 TS_NODE_PROJECT='./tsconfig.test.json' TEST_FAST_ONLY=1 TS_NODE_FILES=1 mocha './tools/test-globber.ts'",
     "postinstall": "rimraf node_modules/.bin/*.ps1 && ts-node ./tools/gen-tsconfigs.ts && ts-node ./tools/gen-ts-glue.ts",
@@ -168,7 +169,6 @@
   },
   "workspaces": {
     "packages": [
-      ".",
       "packages/api/*",
       "packages/external/*",
       "packages/plugin/*",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "electron-forge",
-  "version": "6.0.1",
+  "version": "6.0.3",
   "private": true,
   "license": "MIT",
   "engines": {
     "node": ">= 14.17.5"
   },
   "scripts": {
-    "clean": "rimraf dist && lerna exec -- rimraf dist tsconfig.tsbuildinfo",
-    "build": "lerna exec -- tsc --emitDeclarationOnly && yarn build:fast",
-    "build:fast": "lerna exec -- swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
-    "build:full": "lerna exec -- tsc -b",
+    "clean": "rimraf dist && lerna exec --no-private -- rimraf dist tsconfig.tsbuildinfo",
+    "build": "lerna exec --no-private -- tsc --emitDeclarationOnly && yarn build:fast",
+    "build:fast": "lerna exec --no-private -- swc src --out-dir dist --quiet --extensions \".ts\" --config-file ../../../.swcrc",
+    "build:full": "lerna exec --no-private -- tsc -b",
     "postbuild": "ts-node tools/test-dist",
     "docs": "yarn build:full && yarn docs:generate",
     "docs:generate": "yarn docs:plugin && node --max-old-space-size=8192 -r ts-node/register ./tools/gen-docs.ts",
@@ -18,12 +18,13 @@
     "docs:deploy:build": "yarn docs",
     "lint": "prettier --check . && eslint .",
     "lint:fix": "prettier --write .",
-    "link:prepare": "lerna exec -- node ../../../tools/silent.js yarn link --link-folder ../../../.links --silent --no-bin-links",
+    "link:prepare": "lerna exec --no-private -- node ../../../tools/silent.js yarn link --link-folder ../../../.links --silent --no-bin-links",
     "test": "xvfb-maybe cross-env LINK_FORGE_DEPENDENCIES_ON_INIT=1 TS_NODE_PROJECT='./tsconfig.test.json' TS_NODE_FILES=1 mocha './tools/test-globber.ts'",
     "test:fast": "xvfb-maybe cross-env LINK_FORGE_DEPENDENCIES_ON_INIT=1 TS_NODE_PROJECT='./tsconfig.test.json' TEST_FAST_ONLY=1 TS_NODE_FILES=1 mocha './tools/test-globber.ts'",
     "postinstall": "rimraf node_modules/.bin/*.ps1 && ts-node ./tools/gen-tsconfigs.ts && ts-node ./tools/gen-ts-glue.ts",
     "prepare": "husky install",
-    "preversion": "yarn build"
+    "preversion": "yarn build",
+    "send": "lerna publish --force-publish --conventional-commits --no-changelog"
   },
   "dependencies": {
     "@aws-sdk/abort-controller": "^3.29.0",
@@ -167,6 +168,7 @@
   },
   "workspaces": {
     "packages": [
+      ".",
       "packages/api/*",
       "packages/external/*",
       "packages/plugin/*",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "docs:generate": "yarn docs:plugin && node --max-old-space-size=8192 -r ts-node/register ./tools/gen-docs.ts",
     "docs:plugin": "cd ./tools/doc-plugin && yarn build",
     "docs:deploy:build": "yarn docs",
+    "lerna:publish": "lerna publish --force-publish --conventional-commits --no-changelog",
     "lint": "prettier --check . && eslint .",
     "lint:fix": "prettier --write .",
     "link:prepare": "lerna exec -- node ../../../tools/silent.js yarn link --link-folder ../../../.links --silent --no-bin-links",
@@ -24,8 +25,7 @@
     "test:fast": "xvfb-maybe cross-env LINK_FORGE_DEPENDENCIES_ON_INIT=1 TS_NODE_PROJECT='./tsconfig.test.json' TEST_FAST_ONLY=1 TS_NODE_FILES=1 mocha './tools/test-globber.ts'",
     "postinstall": "rimraf node_modules/.bin/*.ps1 && ts-node ./tools/gen-tsconfigs.ts && ts-node ./tools/gen-ts-glue.ts",
     "prepare": "husky install",
-    "preversion": "yarn build",
-    "send": "lerna publish --force-publish --conventional-commits --no-changelog"
+    "preversion": "yarn build"
   },
   "dependencies": {
     "@aws-sdk/abort-controller": "^3.29.0",


### PR DESCRIPTION
## Motivation

We don't leverage our conventional commit usage to help automate versioning.

## Changes

Wraps the `lerna publish` command into a new `lerna:publish` npm script with additional configuration to address the two issues above.

* `--conventional-commits`: Auto-selects the package number for us.
* `--no-changelog`: Seems like the changelog generated is per package, which we don't want. Let's keep doing this step manually.

 Having this in a command within the repo helps in two ways:
1. Less human error possible by forgetting a flag by accident.
2. Lerna version matches our devDependencies rather than being a globally installed NPM package.

I also changed the root `package.json` version number to `0.0.0-development` since Lerna doesn't update the root package.json number by default and our version number was stale. There's a workaround that involves adding the root folder as a package itself, but then you have to run each `lerna` command with `--no-private` which is annoying and not worth it IMO.

## Testing

I tested this manually by running `lerna version --no-push --no-git-tag-version --force-publish --conventional-commits --no-changelog`, which is as close to a dry run as possible since Lerna does not yet support dry runs.


