### PR TITLE
docs: fix InternalOptions links in API docs

### DIFF
--- a/packages/maker/deb/README.md
+++ b/packages/maker/deb/README.md
@@ -2,7 +2,7 @@
 
 `@electron-forge/maker-deb` builds .deb packages, which are the standard package format for Debian-based Linux distributions such as Ubuntu. You can only build the deb target on Linux or macOS machines with the fakeroot and dpkg packages installed.
 
-Configuration options are documented in [`MakerDebConfigOptions`](https://js.electronforge.io/interfaces/_electron_forge_maker_deb._internal_.MakerDebConfigOptions.html).
+Configuration options are documented in [`MakerDebConfigOptions`](https://js.electronforge.io/interfaces/_electron_forge_maker_deb.InternalOptions.MakerDebConfigOptions.html).
 
 ```
 {

--- a/packages/maker/flatpak/README.md
+++ b/packages/maker/flatpak/README.md
@@ -4,7 +4,7 @@
 
 You can only build the Flatpak target if you have `flatpak`, `flatpak-builder`, and `eu-strip` _\(usually part of the `elfutils` package\)_ installed on your system.
 
-Configuration options are documented in [`MakerFlatpakOptionsConfig`](https://js.electronforge.io/interfaces/_electron_forge_maker_flatpak._internal_.MakerFlatpakOptionsConfig.html).
+Configuration options are documented in [`MakerFlatpakOptionsConfig`](https://js.electronforge.io/interfaces/_electron_forge_maker_flatpak.InternalOptions.MakerFlatpakOptionsConfig.html).
 
 ```javascript
 {

--- a/packages/maker/rpm/README.md
+++ b/packages/maker/rpm/README.md
@@ -4,7 +4,7 @@
 
 You can only build the RPM target on Linux machines with the `rpm` or `rpm-build` packages installed.
 
-Configuration options are documented in [`MakerRpmConfigOptions`](https://js.electronforge.io/interfaces/_electron_forge_maker_rpm._internal_.MakerRpmConfigOptions.html).
+Configuration options are documented in [`MakerRpmConfigOptions`](https://js.electronforge.io/interfaces/_electron_forge_maker_rpm.InternalOptions.MakerRpmConfigOptions.html).
 
 ```javascript
 {

--- a/packages/maker/squirrel/README.md
+++ b/packages/maker/squirrel/README.md
@@ -6,7 +6,7 @@ Pre-requisites:
 * Windows machine
 * MacOS /Linux machine with `mono` and `wine` installed.
 
-Configuration options are documented in [`MakerSquirrelConfigOptions`](https://js.electronforge.io/interfaces/_electron_forge_maker_squirrel._internal_.Options.html).
+Configuration options are documented in [`MakerSquirrelConfigOptions`](https://js.electronforge.io/interfaces/_electron_forge_maker_squirrel.InternalOptions.Options.html).
 
 ```javascript
 {


### PR DESCRIPTION
5104cc0 changed the URLs to internal modules, which broke some links in our generated API docs.