### PR TITLE
fix(publisher-s3): ensure published files do not overwrite multiple arches

### DIFF
--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -21,6 +21,10 @@ type S3Artifact = {
 export default class PublisherS3 extends PublisherBase<PublisherS3Config> {
   name = 's3';
 
+  private s3KeySafe = (key: string) => {
+    return key.replace(/@/g, '_').replace(/\//g, '_');
+  };
+
   async publish({ makeResults, setStatusLine }: PublisherOptions): Promise<void> {
     const artifacts: S3Artifact[] = [];
 
@@ -32,7 +36,7 @@ export default class PublisherS3 extends PublisherBase<PublisherS3Config> {
       artifacts.push(
         ...makeResult.artifacts.map((artifact) => ({
           path: artifact,
-          keyPrefix: this.config.folder || makeResult.packageJSON.version,
+          keyPrefix: this.config.folder || this.s3KeySafe(makeResult.packageJSON.name),
           platform: makeResult.platform,
           arch: makeResult.arch,
         }))
@@ -84,7 +88,7 @@ export default class PublisherS3 extends PublisherBase<PublisherS3Config> {
       return this.config.keyResolver(path.basename(artifact.path), artifact.platform, artifact.arch);
     }
 
-    return `${artifact.keyPrefix}/${path.basename(artifact.path)}`;
+    return `${artifact.keyPrefix}/${artifact.platform}/${artifact.arch}/${path.basename(artifact.path)}`;
   }
 
   generateCredentials(): Credentials | undefined {


### PR DESCRIPTION
I don't think anyone can viably be using this publisher for multiple arches at the moment without using the `keyResolver` which this change doesn't impact.  There's a world where this breaks someone, but I don't think we make any documented guarantees around _where_ the file gets uploaded too exactly in the bucket (maybe we should document that once this lands?)