### PR TITLE
build: npm@9 removed the bin command

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-"$(npm bin)"/lint-staged
+yarn lint-staged


### PR DESCRIPTION
Fix our husky usage with `npm@9`