### PR TITLE
fix(package): pass user-defined `afterComplete` hooks to packager

### DIFF
--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -199,6 +199,8 @@ export const listrPackage = ({
 
           const pruneEnabled = !('prune' in forgeConfig.packagerConfig) || forgeConfig.packagerConfig.prune;
 
+          const beforeCopyHooks = resolveHooks(forgeConfig.packagerConfig.beforeCopy, ctx.dir);
+
           const afterCopyHooks: HookFunction[] = [
             async (buildPath, electronVersion, platform, arch, done) => {
               signalDone(signalCopyDone, { platform, arch });
@@ -245,6 +247,7 @@ export const listrPackage = ({
               signalPackageDone.get(getTargetKey({ platform: pPlatform, arch: pArch }))?.pop()?.();
               done();
             },
+            ...resolveHooks(forgeConfig.packagerConfig.afterComplete, ctx.dir),
           ];
 
           const afterPruneHooks = [];
@@ -268,6 +271,12 @@ export const listrPackage = ({
 
           type PackagerArch = Exclude<ForgeArch, 'arm'>;
 
+          const beforeAsarHooks = resolveHooks(forgeConfig.packagerConfig.beforeAsar, ctx.dir);
+          const afterAsarHooks = resolveHooks(forgeConfig.packagerConfig.afterAsar, ctx.dir);
+
+          const beforeCopyExtraResources = resolveHooks(forgeConfig.packagerConfig.beforeCopyExtraResources, ctx.dir);
+          const afterCopyExtraResources = resolveHooks(forgeConfig.packagerConfig.afterCopyExtraResources, ctx.dir);
+
           const packageOpts: packager.Options = {
             asar: false,
             overwrite: true,
@@ -279,7 +288,12 @@ export const listrPackage = ({
             platform,
             afterFinalizePackageTargets: sequentialFinalizePackageTargetsHooks(afterFinalizePackageTargetsHooks),
             afterComplete: sequentialHooks(afterCompleteHooks),
+            beforeCopy: sequentialHooks(beforeCopyHooks),
             afterCopy: sequentialHooks(afterCopyHooks),
+            beforeAsar: sequentialHooks(beforeAsarHooks),
+            afterAsar: sequentialHooks(afterAsarHooks),
+            beforeCopyExtraResources: sequentialHooks(beforeCopyExtraResources),
+            afterCopyExtraResources: sequentialHooks(afterCopyExtraResources),
             afterExtract: sequentialHooks(afterExtractHooks),
             afterPrune: sequentialHooks(afterPruneHooks),
             out: calculatedOutDir,


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Currently, `afterComplete` hooks defined in the Forge configuration are not being passed to electron-packager, so the following code has no effect:

```ts
const forgeConfig = {
  packagerConfig: {
    afterComplete: [
      async (buildPath, electronVersion, packagedPlatform, packagedArch, done) => {
        // some code...

        done();
      },
    ],
  },
};
```

The existing tests for hooks cover only Forge-specific hooks, not hooks from electron-packager, so I didn't add any tests.