### PR TITLE
feat(publisher-ers): support ERS v2.x

### DIFF
--- a/packages/publisher/electron-release-server/src/PublisherERS.ts
+++ b/packages/publisher/electron-release-server/src/PublisherERS.ts
@@ -97,12 +97,11 @@ export default class PublisherERS extends PublisherBase<PublisherERSConfig> {
         await authFetch('api/version', {
           method: 'POST',
           body: JSON.stringify({
-            channel: {
-              name: channel,
-            },
+            channel: channel,
             flavor: config.flavor,
             name: packageJSON.version,
             notes: '',
+            id: packageJSON.version + '_' + channel,
           }),
           headers: {
             'Content-Type': 'application/json',

--- a/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
+++ b/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
@@ -35,7 +35,7 @@ describe('PublisherERS', () => {
       // mock login
       fetch.postOnce('path:/api/auth/login', { body: { token }, status: 200 });
       // mock fetch all existing versions
-      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [], flavor: 'default' }], status: 200 });
+      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [], flavor: { name: 'default' } }], status: 200 });
       // mock creating a new version
       fetch.postOnce('path:/api/version', { status: 200 });
       // mock asset upload
@@ -83,7 +83,7 @@ describe('PublisherERS', () => {
       // mock login
       fetch.postOnce('path:/api/auth/login', { body: { token }, status: 200 });
       // mock fetch all existing versions
-      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [], flavor: 'lite' }], status: 200 });
+      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [], flavor: { name: 'lite' } }], status: 200 });
       // mock asset upload
       fetch.post('path:/api/asset', { status: 200 });
 
@@ -123,7 +123,10 @@ describe('PublisherERS', () => {
       // mock login
       fetch.postOnce('path:/api/auth/login', { body: { token }, status: 200 });
       // mock fetch all existing versions
-      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [{ name: 'existing-artifact' }], flavor: 'default' }], status: 200 });
+      fetch.getOnce('path:/api/version', {
+        body: [{ name: '2.0.0', assets: [{ name: 'existing-artifact', platform: 'linux_64' }], flavor: { name: 'default' } }],
+        status: 200,
+      });
 
       const publisher = new PublisherERS({
         baseUrl,
@@ -158,7 +161,7 @@ describe('PublisherERS', () => {
       // mock login
       fetch.postOnce('path:/api/auth/login', { body: { token }, status: 200 });
       // mock fetch all existing versions
-      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [{ name: 'existing-artifact' }], flavor: 'default' }], status: 200 });
+      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [{ name: 'existing-artifact' }], flavor: { name: 'default' } }], status: 200 });
       // mock creating a new version
       fetch.postOnce('path:/api/version', { status: 200 });
       // mock asset upload

--- a/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
+++ b/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
@@ -65,7 +65,7 @@ describe('PublisherERS', () => {
 
       // creates a new version with the correct flavor, name, and channel
       expect(calls[2][0]).to.equal(`${baseUrl}/api/version`);
-      expect(calls[2][1]?.body).to.equal(`{"channel":{"name":"stable"},"flavor":"${flavor}","name":"${version}","notes":""}`);
+      expect(calls[2][1]?.body).to.equal(`{"channel":"stable","flavor":"${flavor}","name":"${version}","notes":"","id":"${version}_stable"}`);
 
       // uploads asset successfully
       expect(calls[3][0]).to.equal(`${baseUrl}/api/asset`);
@@ -188,7 +188,7 @@ describe('PublisherERS', () => {
 
       // creates a new version with the correct flavor, name, and channel
       expect(calls[2][0]).to.equal(`${baseUrl}/api/version`);
-      expect(calls[2][1]?.body).to.equal(`{"channel":{"name":"stable"},"flavor":"${flavor}","name":"${version}","notes":""}`);
+      expect(calls[2][1]?.body).to.equal(`{"channel":"stable","flavor":"${flavor}","name":"${version}","notes":"","id":"${version}_stable"}`);
 
       // uploads asset successfully
       expect(calls[3][0]).to.equal(`${baseUrl}/api/asset`);


### PR DESCRIPTION


<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [?] The changes are appropriately documented (if applicable). **_Need help here_**
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

With the latest version of the ERS the call to the version api need to have a different structure.

BREAKING CHANGE: Not compatible with ERS 1.x
