### PR TITLE
fix(core): pass `this.config` when calling internal hooks

### DIFF
--- a/packages/api/core/src/util/plugin-interface.ts
+++ b/packages/api/core/src/util/plugin-interface.ts
@@ -98,7 +98,7 @@ export default class PluginInterface implements IForgePluginInterface {
               task: async (_, task) => {
                 if ((hook as any).__hookName) {
                   // Also give it the task
-                  await (hook as any).call(task, ...(hookArgs as any[]));
+                  await (hook as any).call(task, this.config, ...(hookArgs as any[]));
                 } else {
                   await hook(this.config, ...hookArgs);
                 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Some internal hooks are decorated with the `__hookName` field to indicate that the first parameter should be the task. However, when invoking these callbacks the config param was left out. This resulted in a signature mismatch, which caused issues like #3114 where the arch param was not being passed along correctly to rebuild.