### PR TITLE
fix(cli): use fallback renderer for any DEBUG vars

### DIFF
--- a/packages/api/core/src/api/import.ts
+++ b/packages/api/core/src/api/import.ts
@@ -66,7 +66,7 @@ export default async ({
       collapseErrors: false,
     },
     rendererSilent: !interactive,
-    rendererFallback: Boolean(process.env.DEBUG && process.env.DEBUG.includes('electron-forge')),
+    rendererFallback: Boolean(process.env.DEBUG),
   };
 
   const runner = new Listr(

--- a/packages/api/core/src/api/init.ts
+++ b/packages/api/core/src/api/init.ts
@@ -137,7 +137,7 @@ export default async ({ dir = process.cwd(), interactive = false, copyCIFiles = 
     {
       concurrent: false,
       rendererSilent: !interactive,
-      rendererFallback: Boolean(process.env.DEBUG && process.env.DEBUG.includes('electron-forge')),
+      rendererFallback: Boolean(process.env.DEBUG),
     }
   );
 

--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -106,7 +106,7 @@ export const listrMake = (
       collapseErrors: false,
     },
     rendererSilent: !interactive,
-    rendererFallback: Boolean(process.env.DEBUG && process.env.DEBUG.includes('electron-forge')),
+    rendererFallback: Boolean(process.env.DEBUG),
   };
 
   const runner = new Listr<MakeContext>(

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -430,7 +430,7 @@ export const listrPackage = ({
     {
       concurrent: false,
       rendererSilent: !interactive,
-      rendererFallback: Boolean(process.env.DEBUG && process.env.DEBUG.includes('electron-forge')),
+      rendererFallback: Boolean(process.env.DEBUG),
       rendererOptions: {
         collapse: false,
         collapseErrors: false,

--- a/packages/api/core/src/api/publish.ts
+++ b/packages/api/core/src/api/publish.ts
@@ -85,7 +85,7 @@ const publish = async ({
       collapseErrors: false,
     },
     rendererSilent: !interactive,
-    rendererFallback: Boolean(process.env.DEBUG && process.env.DEBUG.includes('electron-forge')),
+    rendererFallback: Boolean(process.env.DEBUG),
   };
 
   const publishDistributablesTasks = [

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -41,7 +41,7 @@ export default async ({
       collapseErrors: false,
     },
     rendererSilent: !interactive,
-    rendererFallback: Boolean(process.env.DEBUG && process.env.DEBUG.includes('electron-forge')),
+    rendererFallback: Boolean(process.env.DEBUG),
   };
 
   const runner = new Listr<StartContext>(


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [ ] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Uses the non-TTY renderer anytime the `DEBUG` environment variable has a value rather than only when it contains `electron-forge`. This is useful when debugging transient dependencies such as `electron-packager` or `electron-osx-sign`.
