### PR TITLE
fix(package): ensure `electron-packager` throws if fails

### DIFF
--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -165,11 +165,6 @@ export const listrPackage = ({
 
           task.output = 'Determining targets...';
 
-          let provideTargets: (targets: TargetDefinition[]) => void;
-          const targetsPromise = new Promise<InternalTargetDefinition[]>((resolve) => {
-            provideTargets = resolve;
-          });
-
           type StepDoneSignalMap = Map<string, (() => void)[]>;
           const signalCopyDone: StepDoneSignalMap = new Map();
           const signalRebuildDone: StepDoneSignalMap = new Map();
@@ -185,6 +180,12 @@ export const listrPackage = ({
               map.set(targetKey, (map.get(targetKey) || []).concat([resolve]));
             });
           };
+
+          let provideTargets: (targets: TargetDefinition[]) => void;
+          const targetsPromise = new Promise<InternalTargetDefinition[]>((resolve, reject) => {
+            provideTargets = resolve;
+            rejects.push(reject);
+          });
 
           const rebuildTasks = new Map<string, Promise<ForgeListrTask<never>>[]>();
           const signalRebuildStart = new Map<string, ((task: ForgeListrTask<never>) => void)[]>();
@@ -309,7 +310,9 @@ export const listrPackage = ({
           // rejects is populated by the reject handlers for every
           // signal based promise in every subtask
           ctx.packagerPromise.catch((err) => {
-            for (const reject of rejects) reject(err);
+            for (const reject of rejects) {
+              reject(err);
+            }
           });
 
           const targets = await targetsPromise;


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixes #3128

For context, we use some pretty ugly hacks for Electron Packager to work with Listr2 (without being written with Listr2 itself).

To make this work, there's a single `packagerPromise` resolving from the `electron-packager` call:

https://github.com/electron/forge/blob/6a118c6c9cbf9b74341f1ff1ce5a311017fdad33/packages/api/core/src/api/package.ts#L307-L313

If this Promise rejects, then we catch it and reject it with an array of reject handlers from all subtasks declared above:

https://github.com/electron/forge/blob/6a118c6c9cbf9b74341f1ff1ce5a311017fdad33/packages/api/core/src/api/package.ts#L177

The problem here is that the `rejects` array is empty in the first `.catch()`, so the error is caught but never propagated. Therefore, the CLI ends up stalling indefinitely.

To solve this problem, we add the Promise reject handler from `targetsPromise` to the `rejects` array so the `packagerPromise` catch clause has a valid `rejects` target.

```js
const targetsPromise = new Promise<InternalTargetDefinition[]>((resolve, reject) => {
  provideTargets = resolve;
  rejects.push(reject);
});
```