### PR TITLE
chore(maker-rpm): map arm64 -> aarch64

### DIFF
--- a/packages/maker/rpm/src/MakerRpm.ts
+++ b/packages/maker/rpm/src/MakerRpm.ts
@@ -5,12 +5,18 @@ import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
 
 import { MakerRpmConfig } from './Config';
 
+function renameRpm(dest: string, _src: string): string {
+  return path.join(dest, '<%= name %>-<%= version %>-<%= revision %>.<%= arch === "aarch64" ? "arm64" : arch %>.rpm');
+}
+
 export function rpmArch(nodeArch: ForgeArch): string {
   switch (nodeArch) {
     case 'ia32':
       return 'i386';
     case 'x64':
       return 'x86_64';
+    case 'arm64':
+      return 'aarch64';
     case 'armv7l':
       return 'armv7hl';
     case 'arm':
@@ -43,7 +49,7 @@ export default class MakerRpm extends MakerBase<MakerRpmConfig> {
       arch: rpmArch(targetArch),
       src: dir,
       dest: outDir,
-      rename: undefined,
+      rename: renameRpm,
     });
     return packagePaths;
   }

--- a/packages/maker/rpm/test/MakerRpm_spec.ts
+++ b/packages/maker/rpm/test/MakerRpm_spec.ts
@@ -56,11 +56,11 @@ describe('MakerRpm', () => {
       packageJSON,
     });
     const opts = eirStub.firstCall.args[0];
+    delete opts.rename;
     expect(opts).to.deep.equal({
       arch: rpmArch(process.arch as ForgeArch),
       src: dir,
       dest: path.join(makeDir, 'rpm', process.arch),
-      rename: undefined,
     });
   });
 
@@ -81,6 +81,7 @@ describe('MakerRpm', () => {
       packageJSON,
     });
     const opts = eirStub.firstCall.args[0];
+    delete opts.rename;
     expect(opts).to.deep.equal({
       arch: rpmArch(process.arch as ForgeArch),
       options: {
@@ -88,7 +89,6 @@ describe('MakerRpm', () => {
       },
       src: dir,
       dest: path.join(makeDir, 'rpm', process.arch),
-      rename: undefined,
     });
   });
 
@@ -99,6 +99,10 @@ describe('MakerRpm', () => {
 
     it('should convert x64 to x86_64', () => {
       expect(rpmArch('x64')).to.equal('x86_64');
+    });
+
+    it('should convert arm64 to aarch64', () => {
+      expect(rpmArch('arm64')).to.equal('aarch64');
     });
 
     it('should convert arm to armv6hl', () => {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

The canonical name used by the `rpm` package is aarch64. The current behavior of leaving the name arm64 unmapped can lead to subtle behavior differences, since during the RPM building process, the platform name is used for matching against macros under `/usr/lib/rpm/platform/<platform>/macros`, and the platform name there is `aarch64-linux`. Mapping to aarch64 also ensures that the behavior of `--arch=arm64` is the same as running on a Linux Arm64 machine, where `uname` will be returning aarch64, not arm64.

Note that this does change the extension of the final RPM to `*.aarch64.rpm` instead of `*.arm64.rpm`.