### PR TITLE
refactor: improve typing of package.json usages

### DIFF
--- a/packages/api/cli/src/electron-forge.ts
+++ b/packages/api/cli/src/electron-forge.ts
@@ -1,16 +1,19 @@
 #!/usr/bin/env node
 // This file requires a shebang above. If it is missing, this is an error.
 
+import path from 'path';
+
+import { ElectronForgePackageJSON } from '@electron-forge/shared-types';
 import chalk from 'chalk';
 import program from 'commander';
+import fs from 'fs-extra';
 import { Listr } from 'listr2';
 
 import './util/terminate';
 
 import { checkSystem } from './util/check-system';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const metadata = require('../package.json');
+const metadata: ElectronForgePackageJSON = fs.readJsonSync(path.join(__dirname, '../package.json'));
 
 const originalSC = program.executeSubCommand.bind(program);
 program.executeSubCommand = (argv: string[], args: string[], unknown: string[]) => {

--- a/packages/api/cli/src/util/check-system.ts
+++ b/packages/api/cli/src/util/check-system.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 
 import { utils as forgeUtils } from '@electron-forge/core';
-import { ForgeListrTask } from '@electron-forge/shared-types';
+import { ElectronForgePackageJSON, ForgeListrTask } from '@electron-forge/shared-types';
 import debug from 'debug';
 import fs from 'fs-extra';
 import semver from 'semver';
@@ -17,11 +17,12 @@ async function getGitVersion(): Promise<string | null> {
 }
 
 async function checkNodeVersion() {
-  const { engines } = await fs.readJson(path.resolve(__dirname, '..', '..', 'package.json'));
-  const versionSatisfied = semver.satisfies(process.versions.node, engines.node);
+  const packageJSON: ElectronForgePackageJSON = await fs.readJson(path.resolve(__dirname, '..', '..', 'package.json'));
+
+  const versionSatisfied = semver.satisfies(process.versions.node, packageJSON.engines.node);
 
   if (!versionSatisfied) {
-    throw new Error(`You are running Node.js version ${process.versions.node}, but Electron Forge requires Node.js ${engines.node}.`);
+    throw new Error(`You are running Node.js version ${process.versions.node}, but Electron Forge requires Node.js ${packageJSON.engines.node}.`);
   }
 
   return process.versions.node;

--- a/packages/api/core/src/api/init-scripts/init-npm.ts
+++ b/packages/api/core/src/api/init-scripts/init-npm.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { safeYarnOrNpm, yarnOrNpmSpawn } from '@electron-forge/core-utils';
-import { ForgeListrTask } from '@electron-forge/shared-types';
+import { ForgeListrTask, PackageJSON } from '@electron-forge/shared-types';
 import debug from 'debug';
 import fs from 'fs-extra';
 
@@ -9,7 +9,7 @@ import installDepList, { DepType, DepVersionRestriction } from '../../util/insta
 import { readRawPackageJson } from '../../util/read-package-json';
 
 const d = debug('electron-forge:init:npm');
-const corePackage = fs.readJsonSync(path.resolve(__dirname, '../../../package.json'));
+const corePackage: PackageJSON = fs.readJsonSync(path.resolve(__dirname, '../../../package.json'));
 
 export function siblingDep(name: string): string {
   return `@electron-forge/${name}@^${corePackage.version}`;
@@ -40,7 +40,7 @@ export const initNPM = async (dir: string, task: ForgeListrTask<any>): Promise<v
   if (process.env.LINK_FORGE_DEPENDENCIES_ON_INIT) {
     const packageJson = await readRawPackageJson(dir);
     const linkFolder = path.resolve(__dirname, '..', '..', '..', '..', '..', '..', '.links');
-    for (const packageName of Object.keys(packageJson.devDependencies)) {
+    for (const packageName of Object.keys(packageJson.devDependencies ?? {})) {
       if (packageName.startsWith('@electron-forge/')) {
         task.output = `${packageManager} link --link-folder ${linkFolder} ${packageName}`;
         await yarnOrNpmSpawn(['link', '--link-folder', linkFolder, packageName], {

--- a/packages/api/core/src/api/init.ts
+++ b/packages/api/core/src/api/init.ts
@@ -45,7 +45,7 @@ async function validateTemplate(template: string, templateModule: ForgeTemplate)
   }
 
   const forgeVersion = (await readRawPackageJson(path.join(__dirname, '..', '..'))).version;
-  if (!semver.satisfies(forgeVersion, templateModule.requiredForgeVersion)) {
+  if (!forgeVersion || !semver.satisfies(forgeVersion, templateModule.requiredForgeVersion)) {
     throw new Error(
       `Template (${template}) is not compatible with this version of Electron Forge (${forgeVersion}), it requires ${templateModule.requiredForgeVersion}`
     );

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import { promisify } from 'util';
 
 import { getElectronVersion, listrCompatibleRebuildHook } from '@electron-forge/core-utils';
-import { ForgeArch, ForgeListrTask, ForgeListrTaskDefinition, ForgePlatform, ResolvedForgeConfig } from '@electron-forge/shared-types';
+import { ForgeArch, ForgeListrTask, ForgeListrTaskDefinition, ForgePlatform, PackageJSON, ResolvedForgeConfig } from '@electron-forge/shared-types';
 import { getHostArch } from '@electron/get';
 import chalk from 'chalk';
 import debug from 'debug';
@@ -73,7 +73,7 @@ function sequentialFinalizePackageTargetsHooks(hooks: FinalizePackageTargetsHook
 type PackageContext = {
   dir: string;
   forgeConfig: ResolvedForgeConfig;
-  packageJSON: any;
+  packageJSON: PackageJSON;
   calculatedOutDir: string;
   packagerPromise: Promise<string[]>;
   targets: InternalTargetDefinition[];

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -1,7 +1,7 @@
 import { spawn, SpawnOptions } from 'child_process';
 
 import { getElectronVersion, listrCompatibleRebuildHook } from '@electron-forge/core-utils';
-import { ElectronProcess, ForgeArch, ForgeListrTask, ForgePlatform, ResolvedForgeConfig, StartOptions } from '@electron-forge/shared-types';
+import { ElectronProcess, ForgeArch, ForgeListrTask, ForgePlatform, PackageJSON, ResolvedForgeConfig, StartOptions } from '@electron-forge/shared-types';
 import chalk from 'chalk';
 import debug from 'debug';
 import { Listr } from 'listr2';
@@ -19,7 +19,7 @@ export { StartOptions };
 type StartContext = {
   dir: string;
   forgeConfig: ResolvedForgeConfig;
-  packageJSON: any;
+  packageJSON: PackageJSON;
   spawned: ElectronProcess;
 };
 

--- a/packages/api/core/src/util/electron-executable.ts
+++ b/packages/api/core/src/util/electron-executable.ts
@@ -1,11 +1,9 @@
 import path from 'path';
 
 import { getElectronModulePath } from '@electron-forge/core-utils';
+import { PackageJSON } from '@electron-forge/shared-types';
 import chalk from 'chalk';
 import logSymbols from 'log-symbols';
-
-type PackageJSON = Record<string, unknown>;
-type Dependencies = Record<string, string>;
 
 export function pluginCompileExists(packageJSON: PackageJSON): boolean {
   if (!packageJSON.devDependencies) {
@@ -15,11 +13,11 @@ export function pluginCompileExists(packageJSON: PackageJSON): boolean {
   const pluginCompileName = '@electron-forge/plugin-compile';
   const findPluginCompile = (packageName: string): boolean => packageName === pluginCompileName;
 
-  if (Object.keys(packageJSON.devDependencies as Dependencies).find(findPluginCompile)) {
+  if (Object.keys(packageJSON.devDependencies).find(findPluginCompile)) {
     return true;
   }
 
-  if (Object.keys((packageJSON.dependencies as Dependencies) || {}).find(findPluginCompile)) {
+  if (Object.keys(packageJSON.dependencies || {}).find(findPluginCompile)) {
     console.warn(logSymbols.warning, chalk.yellow(`${pluginCompileName} was detected in dependencies, it should be in devDependencies`));
     return true;
   }

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { ForgeConfig, ResolvedForgeConfig } from '@electron-forge/shared-types';
+import { ForgeAppPackageJSON, ForgeConfig, ResolvedForgeConfig } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
 import * as interpret from 'interpret';
 import { template } from 'lodash';
@@ -106,8 +106,8 @@ export function renderConfigTemplate(dir: string, templateObj: any, obj: any): v
 type MaybeESM<T> = T | { default: T };
 
 export default async (dir: string): Promise<ResolvedForgeConfig> => {
-  const packageJSON = await readRawPackageJson(dir);
-  let forgeConfig: ForgeConfig | string | null = packageJSON.config && packageJSON.config.forge ? packageJSON.config.forge : null;
+  const packageJSON = (await readRawPackageJson(dir)) as ForgeAppPackageJSON;
+  let forgeConfig: ForgeConfig | string | null = packageJSON.config?.forge ?? null;
 
   if (!forgeConfig || typeof forgeConfig === 'string') {
     for (const extension of ['.js', ...Object.keys(interpret.extensions)]) {

--- a/packages/api/core/src/util/read-package-json.ts
+++ b/packages/api/core/src/util/read-package-json.ts
@@ -1,13 +1,11 @@
 import path from 'path';
 
-import { ResolvedForgeConfig } from '@electron-forge/shared-types';
+import { ForgeAppPackageJSON, PackageJSON, ResolvedForgeConfig } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
 
 import { runMutatingHook } from './hook';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const readRawPackageJson = async (dir: string): Promise<any> => fs.readJson(path.resolve(dir, 'package.json'));
+export const readRawPackageJson = async (dir: string): Promise<PackageJSON> => fs.readJson(path.resolve(dir, 'package.json'));
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const readMutatedPackageJson = async (dir: string, forgeConfig: ResolvedForgeConfig): Promise<any> =>
-  runMutatingHook(forgeConfig, 'readPackageJson', await readRawPackageJson(dir));
+export const readMutatedPackageJson = async (dir: string, forgeConfig: ResolvedForgeConfig): Promise<ForgeAppPackageJSON> =>
+  runMutatingHook(forgeConfig, 'readPackageJson', await readRawPackageJson(dir)) as Promise<ForgeAppPackageJSON>;

--- a/packages/api/core/src/util/resolve-dir.ts
+++ b/packages/api/core/src/util/resolve-dir.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import { getElectronVersion } from '@electron-forge/core-utils';
+import { ForgeAppPackageJSON } from '@electron-forge/shared-types';
 import debug from 'debug';
 import fs from 'fs-extra';
 
@@ -22,7 +23,7 @@ export default async (dir: string): Promise<string | null> => {
     const testPath = path.resolve(mDir, 'package.json');
     d('searching for project in:', mDir);
     if (await fs.pathExists(testPath)) {
-      const packageJSON = await readRawPackageJson(mDir);
+      const packageJSON = (await readRawPackageJson(mDir)) as ForgeAppPackageJSON;
 
       // TODO: Move this check to inside the forge config resolver and use
       //       mutatedPackageJson reader
@@ -34,7 +35,7 @@ export default async (dir: string): Promise<string | null> => {
         }
       }
 
-      if (packageJSON.config && packageJSON.config.forge) {
+      if (packageJSON.config?.forge) {
         d('electron-forge compatible package.json found in', testPath);
         return mDir;
       }

--- a/packages/api/core/src/util/upgrade-forge-config.ts
+++ b/packages/api/core/src/util/upgrade-forge-config.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { ForgeConfig, ForgePlatform, IForgeResolvableMaker, IForgeResolvablePublisher } from '@electron-forge/shared-types';
+import { ForgeAppPackageJSON, ForgeConfig, ForgePlatform, IForgeResolvableMaker, IForgeResolvablePublisher } from '@electron-forge/shared-types';
 
 import { siblingDep } from '../api/init-scripts/init-npm';
 
@@ -32,13 +32,6 @@ type Forge5Config = {
 };
 
 type Forge5ConfigKey = keyof Forge5Config;
-
-type ForgePackageJSON = Record<string, unknown> & {
-  config: {
-    forge: ForgeConfig;
-  };
-  devDependencies: Record<string, string>;
-};
 
 function mapMakeTargets(forge5Config: Forge5Config): Map<string, ForgePlatform[]> {
   const makeTargets = new Map<string, ForgePlatform[]>();
@@ -160,15 +153,15 @@ export default function upgradeForgeConfig(forge5Config: Forge5Config): ForgeCon
   return forgeConfig;
 }
 
-export function updateUpgradedForgeDevDeps(packageJSON: ForgePackageJSON, devDeps: string[]): string[] {
-  const forgeConfig = packageJSON.config.forge;
+export function updateUpgradedForgeDevDeps(packageJSON: ForgeAppPackageJSON, devDeps: string[]): string[] {
+  const forgeConfig = packageJSON.config?.forge;
   devDeps = devDeps.filter((dep) => !dep.startsWith('@electron-forge/maker-'));
-  devDeps = devDeps.concat((forgeConfig.makers as IForgeResolvableMaker[]).map((maker: IForgeResolvableMaker) => siblingDep(path.basename(maker.name))));
+  devDeps = devDeps.concat((forgeConfig?.makers as IForgeResolvableMaker[]).map((maker: IForgeResolvableMaker) => siblingDep(path.basename(maker.name))));
   devDeps = devDeps.concat(
-    (forgeConfig.publishers as IForgeResolvablePublisher[]).map((publisher: IForgeResolvablePublisher) => siblingDep(path.basename(publisher.name)))
+    (forgeConfig?.publishers as IForgeResolvablePublisher[]).map((publisher: IForgeResolvablePublisher) => siblingDep(path.basename(publisher.name)))
   );
 
-  if (Object.keys(packageJSON.devDependencies).find((dep: string) => dep === 'electron-prebuilt-compile')) {
+  if (Object.keys(packageJSON.devDependencies ?? {}).find((dep: string) => dep === 'electron-prebuilt-compile')) {
     devDeps = devDeps.concat(siblingDep('plugin-compile'));
   }
 

--- a/packages/api/core/test/fast/electron-executable_spec.ts
+++ b/packages/api/core/test/fast/electron-executable_spec.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 
+import { PackageJSON } from '@electron-forge/shared-types';
 import chai, { expect } from 'chai';
 import { createSandbox } from 'sinon';
 import sinonChai from 'sinon-chai';
@@ -23,7 +24,9 @@ describe('locateElectronExecutable', () => {
 
   it('returns the correct path to electron', async () => {
     const appFixture = path.join(fixtureDir, 'electron_app');
-    const packageJSON = {
+    const packageJSON: PackageJSON = {
+      name: 'foo',
+      version: '0.0.0-development',
       devDependencies: { electron: '^100.0.0' },
     };
 
@@ -33,7 +36,9 @@ describe('locateElectronExecutable', () => {
 
   it('warns and returns a hardcoded path to electron if another electron module does not export a string', async () => {
     const appFixture = path.join(fixtureDir, 'bad-export');
-    const packageJSON = {
+    const packageJSON: PackageJSON = {
+      name: 'foo',
+      version: '0.0.0-development',
       devDependencies: {
         '@electron-forge/plugin-compile': '^6.0.0-beta.1',
         'electron-prebuilt-compile': '^1.4.0',
@@ -45,7 +50,9 @@ describe('locateElectronExecutable', () => {
   });
 
   it('warns if prebuilt-compile exists without the corresponding plugin', async () => {
-    const packageJSON = {
+    const packageJSON: PackageJSON = {
+      name: 'foo',
+      version: '0.0.0-development',
       devDependencies: { 'electron-prebuilt-compile': '1.0.0' },
     };
     const compileFixture = path.join(fixtureDir, 'prebuilt-compile');
@@ -55,7 +62,9 @@ describe('locateElectronExecutable', () => {
   });
 
   it('does not warn if prebuilt-compile exists with the corresponding plugin', async () => {
-    const packageJSON = {
+    const packageJSON: PackageJSON = {
+      name: 'foo',
+      version: '0.0.0-development',
       devDependencies: {
         '@electron-forge/plugin-compile': '^6.0.0-beta.1',
         'electron-prebuilt-compile': '1.0.0',
@@ -80,15 +89,26 @@ describe('pluginCompileExists', () => {
   });
 
   it('returns false if there is no devDependencies', () => {
-    expect(pluginCompileExists({})).to.equal(false);
+    const packageJSON: PackageJSON = {
+      name: 'foo',
+      version: '0.0.0-development',
+    };
+    expect(pluginCompileExists(packageJSON)).to.equal(false);
   });
 
   it('returns false if the plugin is not found in devDependencies', () => {
-    expect(pluginCompileExists({ devDependencies: {} })).to.equal(false);
+    const packageJSON: PackageJSON = {
+      name: 'foo',
+      version: '0.0.0-development',
+      devDependencies: {},
+    };
+    expect(pluginCompileExists(packageJSON)).to.equal(false);
   });
 
   it('returns true if the plugin is found in devDependencies', () => {
-    const packageJSON = {
+    const packageJSON: PackageJSON = {
+      name: 'foo',
+      version: '0.0.0-development',
       devDependencies: { '@electron-forge/plugin-compile': '^6.0.0-beta.1' },
     };
 
@@ -97,7 +117,9 @@ describe('pluginCompileExists', () => {
   });
 
   it('warns and returns true if the plugin is found in dependencies', () => {
-    const packageJSON = {
+    const packageJSON: PackageJSON = {
+      name: 'foo',
+      version: '0.0.0-development',
       dependencies: { '@electron-forge/plugin-compile': '^6.0.0-beta.1' },
       devDependencies: {},
     };

--- a/packages/api/core/test/fast/hook_spec.ts
+++ b/packages/api/core/test/fast/hook_spec.ts
@@ -1,4 +1,4 @@
-import { ForgeHookFn, ResolvedForgeConfig } from '@electron-forge/shared-types';
+import { ForgeHookFn, PackageJSON, ResolvedForgeConfig } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import { SinonStub, stub } from 'sinon';
 
@@ -31,10 +31,12 @@ describe('hooks', () => {
 
   describe('runMutatingHook', () => {
     it('should return the input when running non existent hooks', async () => {
-      const info = {
+      const packageJSON: PackageJSON = {
+        name: 'foo',
+        version: '0.0.0-development',
         foo: 'bar',
       };
-      expect(await runMutatingHook({ ...fakeConfig }, 'readPackageJson', info)).to.equal(info);
+      expect(await runMutatingHook({ ...fakeConfig }, 'readPackageJson', packageJSON)).to.equal(packageJSON);
     });
 
     it('should return the mutated input when returned from a hook', async () => {
@@ -45,10 +47,12 @@ describe('hooks', () => {
           mutated: 'foo',
         })
       );
-      const info = {
+      const packageJSON: PackageJSON = {
+        name: 'foo',
+        version: '0.0.0-development',
         foo: 'bar',
       };
-      const output = await runMutatingHook({ hooks: { readPackageJson: myStub }, ...fakeConfig }, 'readPackageJson', info);
+      const output = await runMutatingHook({ hooks: { readPackageJson: myStub }, ...fakeConfig }, 'readPackageJson', packageJSON);
       expect(output).to.deep.equal({
         mutated: 'foo',
       });

--- a/packages/api/core/test/fast/make_spec.ts
+++ b/packages/api/core/test/fast/make_spec.ts
@@ -1,7 +1,8 @@
 import * as path from 'path';
 
-import { ForgeMakeResult } from '@electron-forge/shared-types';
+import { ForgeMakeResult, PackageJSON } from '@electron-forge/shared-types';
 import { expect } from 'chai';
+import fs from 'fs-extra';
 import proxyquire from 'proxyquire';
 
 import { MakeOptions } from '../../src/api';
@@ -13,7 +14,7 @@ describe('make', () => {
   it('works with scoped package names', async () => {
     const stubbedMake: (opts: MakeOptions) => Promise<ForgeMakeResult[]> = proxyquire.noCallThru().load('../../src/api/make', {
       '../util/read-package-json': {
-        readMutatedPackageJson: () => Promise.resolve(require('../fixture/app-with-scoped-name/package.json')),
+        readMutatedPackageJson: () => Promise.resolve<PackageJSON>(fs.readJsonSync(path.join(__dirname, '../fixture/app-with-scoped-name/package.json'))),
       },
     }).default;
     await stubbedMake({
@@ -81,7 +82,7 @@ describe('make', () => {
   it('can skip makers via config', async () => {
     const stubbedMake = proxyquire.noCallThru().load('../../src/api/make', {
       '../util/read-package-json': {
-        readMutatedPackageJson: () => Promise.resolve(require('../fixture/app-with-maker-disable/package.json')),
+        readMutatedPackageJson: () => Promise.resolve<PackageJSON>(fs.readJsonSync(path.join(__dirname, '../fixture/app-with-maker-disable/package.json'))),
       },
     }).default;
     await expect(

--- a/packages/api/core/test/fast/read-package-json_spec.ts
+++ b/packages/api/core/test/fast/read-package-json_spec.ts
@@ -1,7 +1,8 @@
 import path from 'path';
 
-import { ResolvedForgeConfig } from '@electron-forge/shared-types';
+import { PackageJSON, ResolvedForgeConfig } from '@electron-forge/shared-types';
 import { expect } from 'chai';
+import fs from 'fs-extra';
 
 import { readMutatedPackageJson, readRawPackageJson } from '../../src/util/read-package-json';
 
@@ -16,7 +17,9 @@ const emptyForgeConfig: Partial<ResolvedForgeConfig> = {
 describe('read-package-json', () => {
   describe('readRawPackageJson', () => {
     it('should find a package.json file from the given directory', async () => {
-      expect(await readRawPackageJson(path.resolve(__dirname, '../..'))).to.deep.equal(require('../../package.json'));
+      expect(await readRawPackageJson(path.resolve(__dirname, '../..'))).to.deep.equal(
+        fs.readJsonSync(path.join(__dirname, '../../package.json')) as PackageJSON
+      );
     });
   });
 
@@ -33,7 +36,7 @@ describe('read-package-json', () => {
             getHookListrTasks: () => Promise.resolve([]),
           },
         } as ResolvedForgeConfig)
-      ).to.deep.equal(require('../../package.json'));
+      ).to.deep.equal(fs.readJsonSync(path.join(__dirname, '../../package.json')) as PackageJSON);
     });
 
     it('should allow mutations from hooks', async () => {

--- a/packages/api/core/test/fast/start_spec.ts
+++ b/packages/api/core/test/fast/start_spec.ts
@@ -1,5 +1,8 @@
-import { ElectronProcess } from '@electron-forge/shared-types';
+import path from 'path';
+
+import { ElectronProcess, PackageJSON } from '@electron-forge/shared-types';
 import { expect } from 'chai';
+import fs from 'fs-extra';
 import proxyquire from 'proxyquire';
 import { SinonStub, stub } from 'sinon';
 
@@ -7,7 +10,7 @@ import { StartOptions } from '../../src/api';
 
 describe('start', () => {
   let start: (opts: StartOptions) => Promise<ElectronProcess>;
-  let packageJSON: Record<string, string>;
+  let packageJSON: PackageJSON;
   let resolveStub: SinonStub;
   let spawnStub: SinonStub;
   let shouldOverride: false | { on: () => void };
@@ -17,7 +20,7 @@ describe('start', () => {
     resolveStub = stub();
     spawnStub = stub();
     shouldOverride = false;
-    packageJSON = require('../fixture/dummy_app/package.json');
+    packageJSON = fs.readJsonSync(path.join(__dirname, '../fixture/dummy_app/package.json'));
 
     start = proxyquire.noCallThru().load('../../src/api/start', {
       '../util/electron-executable': () => Promise.resolve('fake_electron_path'),

--- a/packages/api/core/test/fast/upgrade-forge-config_spec.ts
+++ b/packages/api/core/test/fast/upgrade-forge-config_spec.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import { ForgeConfig, IForgeResolvableMaker, IForgeResolvablePublisher } from '@electron-forge/shared-types';
+import { ForgeAppPackageJSON, ForgeConfig, IForgeResolvableMaker, IForgeResolvablePublisher } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import { merge } from 'lodash';
 
@@ -115,7 +115,9 @@ describe('upgradeForgeConfig', () => {
 });
 
 describe('updateUpgradedForgeDevDeps', () => {
-  const skeletonPackageJSON = {
+  const skeletonPackageJSON: ForgeAppPackageJSON = {
+    name: 'foo',
+    version: '0.0.0-development',
     config: {
       forge: {
         packagerConfig: {},
@@ -141,6 +143,7 @@ describe('updateUpgradedForgeDevDeps', () => {
 
   it('adds makers to devDependencies', () => {
     const packageJSON = merge({}, skeletonPackageJSON);
+    assert(packageJSON.config?.forge);
     packageJSON.config.forge.makers = [
       {
         name: '@electron-forge/maker-zip',
@@ -161,6 +164,7 @@ describe('updateUpgradedForgeDevDeps', () => {
 
   it('adds publishers to devDependencies', () => {
     const packageJSON = merge({}, skeletonPackageJSON);
+    assert(packageJSON.config?.forge);
     packageJSON.config.forge.publishers = [{ name: '@electron-forge/publisher-github' }, { name: '@electron-forge/publisher-snapcraft' }];
 
     const actual = updateUpgradedForgeDevDeps(packageJSON, []);

--- a/packages/api/core/test/slow/install-dependencies_spec_slow.ts
+++ b/packages/api/core/test/slow/install-dependencies_spec_slow.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 import path from 'path';
 
+import { PackageJSON } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import fs from 'fs-extra';
 
@@ -17,7 +18,7 @@ if (!(process.platform === 'linux' && process.env.CI)) {
     it('should install the latest minor version when the dependency has a caret', async () => {
       await installDeps(installDir, ['debug@^2.0.0']);
 
-      const packageJSON = require(path.resolve(installDir, 'node_modules', 'debug', 'package.json'));
+      const packageJSON: PackageJSON = fs.readJsonSync(path.resolve(installDir, 'node_modules', 'debug', 'package.json'));
       expect(packageJSON.version).to.not.equal('2.0.0');
     });
 

--- a/packages/maker/base/src/Maker.ts
+++ b/packages/maker/base/src/Maker.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { ForgeArch, ForgePlatform, IForgeMaker, ResolvedForgeConfig } from '@electron-forge/shared-types';
+import { ForgeAppPackageJSON, ForgeArch, ForgePlatform, IForgeMaker, ResolvedForgeConfig } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
 import which from 'which';
 
@@ -35,7 +35,7 @@ export interface MakerOptions {
   /**
    * The application's package.json file
    */
-  packageJSON: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  packageJSON: ForgeAppPackageJSON;
 }
 
 export default abstract class Maker<C> implements IForgeMaker {

--- a/packages/maker/deb/test/MakerDeb_spec.ts
+++ b/packages/maker/deb/test/MakerDeb_spec.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
-import { ForgeArch } from '@electron-forge/shared-types';
+import { ForgeAppPackageJSON, ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { SinonStub, stub } from 'sinon';
@@ -29,7 +29,7 @@ describe('MakerDeb', () => {
   const makeDir = path.resolve('/foo/bar/make');
   const appName = 'My Test App';
   const targetArch = process.arch;
-  const packageJSON = { version: '1.2.3' };
+  const packageJSON: ForgeAppPackageJSON = { name: 'foo', version: '1.2.3' };
 
   beforeEach(() => {
     ensureDirectoryStub = stub().returns(Promise.resolve());

--- a/packages/maker/dmg/test/MakerDMG_spec.ts
+++ b/packages/maker/dmg/test/MakerDMG_spec.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
-import { ForgeArch } from '@electron-forge/shared-types';
+import { ForgeAppPackageJSON, ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { SinonStub, stub } from 'sinon';
@@ -29,7 +29,7 @@ describe('MakerDMG', () => {
   const makeDir = '/my/test/dir/make';
   const appName = 'My Test App';
   const targetArch = process.arch;
-  const packageJSON = { version: '1.2.3' };
+  const packageJSON: ForgeAppPackageJSON = { name: 'foo', version: '1.2.3' };
 
   beforeEach(() => {
     ensureFileStub = stub().returns(Promise.resolve());

--- a/packages/maker/flatpak/test/MakerFlatpak_spec.ts
+++ b/packages/maker/flatpak/test/MakerFlatpak_spec.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
-import { ForgeArch } from '@electron-forge/shared-types';
+import { ForgeAppPackageJSON, ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import 'chai-as-promised';
 import proxyquire from 'proxyquire';
@@ -30,7 +30,7 @@ describe('MakerFlatpak', () => {
   const makeDir = path.resolve('/make/dir');
   const appName = 'My Test App';
   const targetArch = process.arch;
-  const packageJSON = { version: '1.2.3' };
+  const packageJSON: ForgeAppPackageJSON = { name: 'foo', version: '1.2.3' };
 
   beforeEach(() => {
     ensureDirectoryStub = stub().returns(Promise.resolve());

--- a/packages/maker/pkg/test/MakerPKG_spec.ts
+++ b/packages/maker/pkg/test/MakerPKG_spec.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
-import { ForgeArch } from '@electron-forge/shared-types';
+import { ForgeAppPackageJSON, ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { SinonStub, stub } from 'sinon';
@@ -29,7 +29,7 @@ describe('MakerPKG', () => {
   const makeDir = '/my/test/dir/make';
   const appName = 'My Test App';
   const targetArch = process.arch;
-  const packageJSON = { version: '1.2.3' };
+  const packageJSON: ForgeAppPackageJSON = { name: 'foo', version: '1.2.3' };
 
   beforeEach(() => {
     ensureFileStub = stub().returns(Promise.resolve());

--- a/packages/maker/rpm/test/MakerRpm_spec.ts
+++ b/packages/maker/rpm/test/MakerRpm_spec.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
-import { ForgeArch } from '@electron-forge/shared-types';
+import { ForgeAppPackageJSON, ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { SinonStub, stub } from 'sinon';
@@ -29,7 +29,7 @@ describe('MakerRpm', () => {
   const makeDir = path.resolve('/make/dir');
   const appName = 'My Test App';
   const targetArch = process.arch;
-  const packageJSON = { version: '1.2.3' };
+  const packageJSON: ForgeAppPackageJSON = { name: 'foo', version: '1.2.3' };
 
   beforeEach(() => {
     ensureDirectoryStub = stub().returns(Promise.resolve());

--- a/packages/maker/snap/test/MakerSnap_spec.ts
+++ b/packages/maker/snap/test/MakerSnap_spec.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
-import { ForgeArch } from '@electron-forge/shared-types';
+import { ForgeAppPackageJSON, ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { SinonStub, stub } from 'sinon';
@@ -28,7 +28,7 @@ describe('MakerSnap', () => {
   const makeDir = path.resolve('/make/dir');
   const appName = 'My Test App';
   const targetArch = process.arch;
-  const packageJSON = { version: '1.2.3' };
+  const packageJSON: ForgeAppPackageJSON = { name: 'foo', version: '1.2.3' };
 
   beforeEach(() => {
     ensureDirectoryStub = stub().returns(Promise.resolve());

--- a/packages/plugin/compile/src/lib/compile-hook.ts
+++ b/packages/plugin/compile/src/lib/compile-hook.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { ForgeHookFn } from '@electron-forge/shared-types';
+import { ForgeHookFn, PackageJSON } from '@electron-forge/shared-types';
 import fs from 'fs-extra';
 
 export const createCompileHook =
@@ -25,7 +25,7 @@ export const createCompileHook =
         }
       }
 
-      const packageJSON = await fs.readJson(path.resolve(appDir, 'package.json'));
+      const packageJSON: PackageJSON = await fs.readJson(path.resolve(appDir, 'package.json'));
 
       const index = packageJSON.main || 'index.js';
       packageJSON.originalMain = index;

--- a/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
+++ b/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
@@ -52,6 +52,7 @@ describe('PublisherERS', () => {
         {
           artifacts: ['/path/to/artifact'],
           packageJSON: {
+            name: 'foo',
             version,
           },
           platform: 'linux',
@@ -99,6 +100,7 @@ describe('PublisherERS', () => {
         {
           artifacts: ['/path/to/artifact'],
           packageJSON: {
+            name: 'foo',
             version,
           },
           platform: 'linux',
@@ -136,6 +138,7 @@ describe('PublisherERS', () => {
         {
           artifacts: ['/path/to/existing-artifact'],
           packageJSON: {
+            name: 'foo',
             version,
           },
           platform: 'linux',
@@ -175,6 +178,7 @@ describe('PublisherERS', () => {
         {
           artifacts: ['/path/to/artifact'],
           packageJSON: {
+            name: 'foo',
             version,
           },
           platform: 'linux',

--- a/packages/template/webpack-typescript/src/WebpackTypeScriptTemplate.ts
+++ b/packages/template/webpack-typescript/src/WebpackTypeScriptTemplate.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { ForgeListrTaskDefinition, InitTemplateOptions } from '@electron-forge/shared-types';
+import { ForgeListrTaskDefinition, InitTemplateOptions, PackageJSON } from '@electron-forge/shared-types';
 import { BaseTemplate } from '@electron-forge/template-base';
 import fs from 'fs-extra';
 
@@ -52,9 +52,10 @@ class WebpackTypeScriptTemplate extends BaseTemplate {
 
           // update package.json
           const packageJSONPath = path.resolve(directory, 'package.json');
-          const packageJSON = await fs.readJson(packageJSONPath);
+          const packageJSON: PackageJSON = await fs.readJson(packageJSONPath);
           packageJSON.main = '.webpack/main';
           // Configure scripts for TS template
+          packageJSON.scripts = packageJSON.scripts ?? {};
           packageJSON.scripts.lint = 'eslint --ext .ts,.tsx .';
           await fs.writeJson(packageJSONPath, packageJSON, {
             spaces: 2,

--- a/packages/template/webpack-typescript/test/WebpackTypeScript_spec_slow.ts
+++ b/packages/template/webpack-typescript/test/WebpackTypeScript_spec_slow.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import { yarnOrNpmSpawn } from '@electron-forge/core-utils';
+import { PackageJSON } from '@electron-forge/shared-types';
 import * as testUtils from '@electron-forge/test-utils';
 import { expect } from 'chai';
 import glob from 'fast-glob';
@@ -67,8 +68,7 @@ describe('WebpackTypeScriptTemplate', () => {
       // typescript type-resolution.  In prod no one has to worry about things like this
       const pj = await fs.readJson(path.resolve(dir, 'package.json'));
       pj.resolutions = {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        webpack: `${require('../../../../node_modules/webpack/package.json').version}`,
+        webpack: `${(fs.readJsonSync(path.join(__dirname, '../../../../node_modules/webpack/package.json')) as PackageJSON).version}`,
       };
       await fs.writeJson(path.resolve(dir, 'package.json'), pj);
       await yarnOrNpmSpawn(['install'], {

--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -33,8 +33,7 @@ export interface ForgeSimpleHookSignatures {
 export interface ForgeMutatingHookSignatures {
   postMake: [makeResults: ForgeMakeResult[]];
   resolveForgeConfig: [currentConfig: ResolvedForgeConfig];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  readPackageJson: [packageJson: Record<string, any>];
+  readPackageJson: [packageJson: PackageJSON];
 }
 
 export type ForgeHookName = keyof (ForgeSimpleHookSignatures & ForgeMutatingHookSignatures);
@@ -105,7 +104,7 @@ export interface ForgeMakeResult {
   /**
    * The state of the package.json file when the make happened
    */
-  packageJSON: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+  packageJSON: ForgeAppPackageJSON;
   /**
    * The platform this make run was for
    */
@@ -217,3 +216,30 @@ export type PackagePerson =
       email?: string;
       url?: string;
     };
+
+export type PackageJSON = Record<string, unknown> & {
+  author?: PackagePerson;
+  name: string;
+  description?: string;
+  version?: string;
+  main?: string;
+  engines?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  scripts?: Record<string, string>;
+  productName?: string;
+};
+
+export type ForgeAppPackageJSON = PackageJSON & {
+  version: string;
+  config?: {
+    forge?: ForgeConfig;
+  };
+};
+
+export type ElectronForgePackageJSON = PackageJSON & {
+  version: string;
+  engines: {
+    node: string;
+  };
+};


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Cleans up typings and removes about ten `eslint-disable` comments. It also cleans up usages of `require` for loading `package.json` in favor of using `fs.readJsonSync` from `fs-extra`.