### PR TITLE
fix(publisher-ers): Update ERS API usage for v2.x

### DIFF
--- a/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
+++ b/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
@@ -35,7 +35,7 @@ describe('PublisherERS', () => {
       // mock login
       fetch.postOnce('path:/api/auth/login', { body: { token }, status: 200 });
       // mock fetch all existing versions
-      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [], flavor: 'default' }], status: 200 });
+      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [], flavor: { name: 'default' } }], status: 200 });
       // mock creating a new version
       fetch.postOnce('path:/api/version', { status: 200 });
       // mock asset upload
@@ -65,7 +65,7 @@ describe('PublisherERS', () => {
 
       // creates a new version with the correct flavor, name, and channel
       expect(calls[2][0]).to.equal(`${baseUrl}/api/version`);
-      expect(calls[2][1]?.body).to.equal(`{"channel":{"name":"stable"},"flavor":"${flavor}","name":"${version}","notes":""}`);
+      expect(calls[2][1]?.body).to.equal(`{"channel":"stable","flavor":"${flavor}","name":"${version}","notes":"","id":"${version}_stable"}`);
 
       // uploads asset successfully
       expect(calls[3][0]).to.equal(`${baseUrl}/api/asset`);
@@ -83,7 +83,7 @@ describe('PublisherERS', () => {
       // mock login
       fetch.postOnce('path:/api/auth/login', { body: { token }, status: 200 });
       // mock fetch all existing versions
-      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [], flavor: 'lite' }], status: 200 });
+      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [], flavor: { name: 'lite' } }], status: 200 });
       // mock asset upload
       fetch.post('path:/api/asset', { status: 200 });
 
@@ -123,7 +123,10 @@ describe('PublisherERS', () => {
       // mock login
       fetch.postOnce('path:/api/auth/login', { body: { token }, status: 200 });
       // mock fetch all existing versions
-      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [{ name: 'existing-artifact' }], flavor: 'default' }], status: 200 });
+      fetch.getOnce('path:/api/version', {
+        body: [{ name: '2.0.0', assets: [{ name: 'existing-artifact', platform: 'linux_64' }], flavor: { name: 'default' } }],
+        status: 200,
+      });
 
       const publisher = new PublisherERS({
         baseUrl,
@@ -158,7 +161,7 @@ describe('PublisherERS', () => {
       // mock login
       fetch.postOnce('path:/api/auth/login', { body: { token }, status: 200 });
       // mock fetch all existing versions
-      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [{ name: 'existing-artifact' }], flavor: 'default' }], status: 200 });
+      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [{ name: 'existing-artifact' }], flavor: { name: 'default' } }], status: 200 });
       // mock creating a new version
       fetch.postOnce('path:/api/version', { status: 200 });
       // mock asset upload
@@ -188,7 +191,7 @@ describe('PublisherERS', () => {
 
       // creates a new version with the correct flavor, name, and channel
       expect(calls[2][0]).to.equal(`${baseUrl}/api/version`);
-      expect(calls[2][1]?.body).to.equal(`{"channel":{"name":"stable"},"flavor":"${flavor}","name":"${version}","notes":""}`);
+      expect(calls[2][1]?.body).to.equal(`{"channel":"stable","flavor":"${flavor}","name":"${version}","notes":"","id":"${version}_stable"}`);
 
       // uploads asset successfully
       expect(calls[3][0]).to.equal(`${baseUrl}/api/asset`);


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

Recently, v2.0 of electron-release-server was released. This version updated many of the underlying packages and should be adopted by all users of the server. In the process, the API changed due to a change with SailsJS. This corrects the API usage within the ERS publisher plugin to allow users to continue using it.
Note that this issue was reported here: https://github.com/ArekSredzki/electron-release-server/issues/314
