### PR TITLE
ci: create a `test:slow` script to avoid re-running fast tests in the `slow-tests` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,6 @@ jobs:
       - name: Build
         run: yarn build
       - name: Test
-        run: yarn test
+        run: yarn test:slow
         env:
           DEBUG: electron-installer-snap:snapcraft

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "link:prepare": "lerna exec -- node ../../../tools/silent.js yarn link --link-folder ../../../.links --silent --no-bin-links",
     "test": "xvfb-maybe cross-env LINK_FORGE_DEPENDENCIES_ON_INIT=1 TS_NODE_PROJECT='./tsconfig.test.json' TS_NODE_FILES=1 mocha './tools/test-globber.ts'",
     "test:fast": "xvfb-maybe cross-env LINK_FORGE_DEPENDENCIES_ON_INIT=1 TS_NODE_PROJECT='./tsconfig.test.json' TEST_FAST_ONLY=1 TS_NODE_FILES=1 mocha './tools/test-globber.ts'",
+    "test:slow": "xvfb-maybe cross-env LINK_FORGE_DEPENDENCIES_ON_INIT=1 TS_NODE_PROJECT='./tsconfig.test.json' TEST_SLOW_ONLY=1 TS_NODE_FILES=1 mocha './tools/test-globber.ts'",
     "postinstall": "rimraf node_modules/.bin/*.ps1 && ts-node ./tools/gen-tsconfigs.ts && ts-node ./tools/gen-ts-glue.ts",
     "prepare": "husky install",
     "preversion": "yarn build"

--- a/tools/test-globber.ts
+++ b/tools/test-globber.ts
@@ -7,6 +7,7 @@ import { getPackageInfoSync } from './utils';
 
 const argv = minimist(process.argv.slice(process.argv.findIndex((arg) => arg === 'mocha.opts')));
 
+const isSlow = argv.slow || process.env.TEST_SLOW_ONLY;
 const isFast = argv.fast || process.env.TEST_FAST_ONLY;
 
 const packages = getPackageInfoSync();
@@ -22,7 +23,7 @@ for (const p of packages) {
   if (argv.glob) {
     specGlob.push(path.posix.join(packagePath, argv.glob));
   } else {
-    specGlob.push(path.posix.join(packagePath, 'test', '**', `*_spec${isFast ? '' : '*'}.ts`));
+    specGlob.push(path.posix.join(packagePath, 'test', '**', `*_spec${isFast ? '' : isSlow ? '_slow' : '*'}.ts`));
   }
   testFiles.push(...glob.sync(specGlob));
 }


### PR DESCRIPTION
… `slow-tests` job

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Basically the title. This PR slashes a minute or so (~10%-ish) from the time it takes to run the slow tests by not re-running the fast tests, which are already covered by a separate job.