### PR TITLE
chore: gitignore `lerna-debug.log`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist
 docs
 doc
 node_modules
+lerna-debug.log
 yarn-error.log
 packages/**/.npmignore
 packages/**/tsconfig.json


### PR DESCRIPTION
This artifact is created when `yarn lerna:publish` fails.