### PR TITLE
fix: use correct platform paths for artifacts in dryRunResume

### DIFF
--- a/packages/api/core/src/api/publish.ts
+++ b/packages/api/core/src/api/publish.ts
@@ -218,8 +218,10 @@ const publish = async ({
 
                     for (const makeResult of restoredMakeResults) {
                       for (const makePath of makeResult.artifacts) {
-                        if (!(await fs.pathExists(makePath))) {
-                          throw new Error(`Attempted to resume a dry run but an artifact (${makePath}) could not be found`);
+                        // standardize the path to artifacts across platforms
+                        const normalizedPath = makePath.split(/\/|\\/).join(path.sep);
+                        if (!(await fs.pathExists(normalizedPath))) {
+                          throw new Error(`Attempted to resume a dry run but an artifact (${normalizedPath}) could not be found`);
                         }
                       }
                     }


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

Fixes a path issue within publisher -> dryRunResume. If a dry run occurred on one platform (e.g. Windows), the path slashes will retain their original formatting, even if the resume action is called on a platform with different path syntax (e.g. Linux).

This PR normalizes the path formats to fix whatever format is needed for dryRunResume.
