### PR TITLE
fix(plugin-fuses): `resetAdHocDarwinSignature` rules on Mac

### DIFF
--- a/packages/plugin/fuses/README.md
+++ b/packages/plugin/fuses/README.md
@@ -5,7 +5,7 @@ This plugin allows flipping [Electron Fuses](https://github.com/electron/fuses) 
 
 ## Usage
 
-Install `@electron-forge/plugin-fuses` and `@electron/fuses` as dev dependencies and add this plugin to the `plugins` array in your Forge configuration::
+Install `@electron-forge/plugin-fuses` and `@electron/fuses` as dev dependencies and add this plugin to the `plugins` array in your Forge configuration:
 ```shell
 # Yarn
 yarn add --dev @electron-forge/plugin-fuses @electron/fuses

--- a/packages/plugin/fuses/src/FusesPlugin.ts
+++ b/packages/plugin/fuses/src/FusesPlugin.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import { namedHookWithTaskFn, PluginBase } from '@electron-forge/plugin-base';
-import { ForgeMultiHookMap } from '@electron-forge/shared-types';
+import { ForgeMultiHookMap, ForgePlatform } from '@electron-forge/shared-types';
 import { flipFuses, FuseConfig } from '@electron/fuses';
 
 import { getElectronExecutablePath } from './util/getElectronExecutablePath';
@@ -22,9 +22,11 @@ export default class FusesPlugin extends PluginBase<FuseConfig> {
       packageAfterCopy: namedHookWithTaskFn<'packageAfterCopy'>(async (listrTask, resolvedForgeConfig, resourcesPath, electronVersion, platform, arch) => {
         const { fusesConfig } = this;
 
+        const applePlatforms: ForgePlatform[] = ['darwin', 'mas'];
+
         if (Object.keys(fusesConfig).length) {
           const pathToElectronExecutable = getElectronExecutablePath({
-            appName: ['darwin', 'mas'].includes(platform) ? 'Electron' : 'electron',
+            appName: applePlatforms.includes(platform) ? 'Electron' : 'electron',
             basePath: path.resolve(resourcesPath, '../..'),
             platform,
           });
@@ -33,7 +35,7 @@ export default class FusesPlugin extends PluginBase<FuseConfig> {
           const hasOSXSignConfig = (typeof osxSignConfig === 'object' && Boolean(Object.keys(osxSignConfig).length)) || Boolean(osxSignConfig);
 
           await flipFuses(pathToElectronExecutable, {
-            resetAdHocDarwinSignature: !hasOSXSignConfig && platform === 'darwin' && arch === 'arm64',
+            resetAdHocDarwinSignature: !hasOSXSignConfig && applePlatforms.includes(platform) && arch === 'arm64',
             ...this.fusesConfig,
           });
         }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Fixing a couple of whoopsies from #3132:
- `resetAdHocDarwinSignature` logic for `platform=mas`
- a _very_ minor typo in the README that is not worth a separate PR IMO.