### PR TITLE
fix(publisher-s3): Make S3 upload fail non-silently

### DIFF
--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -57,6 +57,7 @@ export default class PublisherS3 extends PublisherBase<PublisherS3Config> {
         d('uploading:', artifact.path);
         const uploader = new Upload({
           client: s3Client,
+          leavePartsOnError: true,
           params: {
             Body: fs.createReadStream(artifact.path),
             Bucket: this.config.bucket,


### PR DESCRIPTION


<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Fixes electron/forge#3166

Simply put, the default behaviour of `@aws-sdk/lib-storage` is to fail silently if part of a file fails to upload to S3, but it includes this option, which makes it actually raise an error. There's a separate PR upstream (https://github.com/aws/aws-sdk-js-v3/pull/4414) to make that behaviour the default.

See also: https://github.com/aws/aws-sdk-js-v3/issues/2311
