### PR TITLE
chore: add needed Vite infra details

### DIFF
--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -48,6 +48,7 @@
     "@electron-forge/template-base": "6.1.0",
     "@electron-forge/template-webpack": "6.1.0",
     "@electron-forge/template-webpack-typescript": "6.1.0",
+    "@electron-forge/template-vite": "6.1.0",
     "@electron/get": "^2.0.0",
     "@electron/rebuild": "^3.2.10",
     "@malept/cross-spawn-promise": "^2.0.0",

--- a/packages/plugin/vite/package.json
+++ b/packages/plugin/vite/package.json
@@ -34,5 +34,8 @@
     "chalk": "^4.0.0",
     "debug": "^4.3.1",
     "vite": "^4.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/template/vite/package.json
+++ b/packages/template/vite/package.json
@@ -26,5 +26,8 @@
     "@electron-forge/test-utils": "6.1.0",
     "chai": "^4.3.3",
     "listr2": "^5.0.3"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

In 6.1.0, you cannot create a new Vite template with create-electron-app, because we did not include the needed packages in dependencies. This PR adds the needed dependency to @electron-forge/core.
