### PR TITLE
fix(plugin-vite): correctly close vite dev-server

### DIFF
--- a/packages/plugin/vite/src/VitePlugin.ts
+++ b/packages/plugin/vite/src/VitePlugin.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs/promises';
-import http from 'node:http';
 import path from 'node:path';
 
 import { namedHookWithTaskFn, PluginBase } from '@electron-forge/plugin-base';
@@ -31,7 +30,7 @@ export default class VitePlugin extends PluginBase<VitePluginConfig> {
 
   private watchers: RollupWatcher[] = [];
 
-  private servers: http.Server[] = [];
+  private servers: vite.ViteDevServer[] = [];
 
   init = (dir: string): void => {
     this.setDirectories(dir);
@@ -131,7 +130,7 @@ export default class VitePlugin extends PluginBase<VitePluginConfig> {
       viteDevServer.printUrls();
 
       if (viteDevServer.httpServer) {
-        this.servers.push(viteDevServer.httpServer);
+        this.servers.push(viteDevServer);
       }
     }
   };


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Use the Vite dev-server close as it also close fs-watcher, hrm-ws, pre-bundle etc.

https://github.com/vitejs/vite/blob/v4.2.0/packages/vite/src/node/server/index.ts#L455-L462

<img width="447" alt="image" src="https://user-images.githubusercontent.com/26263658/229258344-e9bd2671-1f7f-4f02-939b-a1fba630c23d.png">

