### PR TITLE
fix: normalize artifact paths in makeResult dryRunResume

### DIFF
--- a/packages/api/core/src/api/publish.ts
+++ b/packages/api/core/src/api/publish.ts
@@ -217,13 +217,16 @@ const publish = async ({
                     d('restoring publish settings from dry run');
 
                     for (const makeResult of restoredMakeResults) {
-                      for (const makePath of makeResult.artifacts) {
-                        // standardize the path to artifacts across platforms
-                        const normalizedPath = makePath.split(/\/|\\/).join(path.sep);
-                        if (!(await fs.pathExists(normalizedPath))) {
-                          throw new Error(`Attempted to resume a dry run but an artifact (${normalizedPath}) could not be found`);
-                        }
-                      }
+                      makeResult.artifacts = await Promise.all(
+                        makeResult.artifacts.map(async (makePath: string) => {
+                          // standardize the path to artifacts across platforms
+                          const normalizedPath = makePath.split(/\/|\\/).join(path.sep);
+                          if (!(await fs.pathExists(normalizedPath))) {
+                            throw new Error(`Attempted to resume a dry run, but an artifact (${normalizedPath}) could not be found`);
+                          }
+                          return normalizedPath;
+                        })
+                      );
                     }
 
                     d('publishing for given state set');


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

Follow up to #3184- this PR re-assigns any incorrect paths back to the makeResults, so that publishers will later handle them correctly.
