### PR TITLE
fix(template-vite): ignore `browser` field for isomorphic packages

### DIFF
--- a/packages/template/vite/tmpl/vite.main.config.mjs
+++ b/packages/template/vite/tmpl/vite.main.config.mjs
@@ -1,4 +1,10 @@
 import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config
-export default defineConfig({});
+export default defineConfig({
+  resolve: {
+    // Some libs that can run in both Web and Node.js, such as `axios`, we need to tell Vite to build them in Node.js.
+    browserField: false,
+    mainFields: ['module', 'jsnext:main', 'jsnext'],
+  },
+});


### PR DESCRIPTION
Packages like axios have a browser field in package.json. The main process needs to resolve the node module, not the browser module.

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [X] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Packages like axios have a browser field in package.json.
The main process needs to resolve the node module,
not the browser module.
