### PR TITLE
feat(make): allow async maker configs

### DIFF
--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -264,7 +264,7 @@ export const listrMake = (
                      *   * Change the entire API of maker from a single constructor to
                      *     providing a MakerFactory
                      */
-                    await maker.prepareConfig(targetArch);
+                    await Promise.resolve(maker.prepareConfig(targetArch));
                     const artifacts = await maker.make({
                       appName,
                       forgeConfig,

--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -264,7 +264,7 @@ export const listrMake = (
                      *   * Change the entire API of maker from a single constructor to
                      *     providing a MakerFactory
                      */
-                    maker.prepareConfig(targetArch);
+                    await maker.prepareConfig(targetArch);
                     const artifacts = await maker.make({
                       appName,
                       forgeConfig,

--- a/packages/maker/base/src/Maker.ts
+++ b/packages/maker/base/src/Maker.ts
@@ -69,9 +69,9 @@ export default abstract class Maker<C> implements IForgeMaker {
 
   // TODO: Remove this, it is an eye-sore and is a nasty hack to provide forge
   //       v5 style functionality in the new API
-  prepareConfig(targetArch: ForgeArch): void {
+  async prepareConfig(targetArch: ForgeArch): Promise<void> {
     if (typeof this.configOrConfigFetcher === 'function') {
-      this.config = (this.configOrConfigFetcher as unknown as (arch: ForgeArch) => C)(targetArch);
+      this.config = await Promise.resolve((this.configOrConfigFetcher as (arch: ForgeArch) => C)(targetArch));
     } else {
       this.config = this.configOrConfigFetcher as C;
     }

--- a/packages/maker/base/test/config-fetcher_spec.ts
+++ b/packages/maker/base/test/config-fetcher_spec.ts
@@ -10,7 +10,7 @@ class MakerImpl extends MakerBase<{ a: number }> {
 }
 
 describe('prepareConfig', () => {
-  it('should call the provided configure function', () => {
+  it('should accept sync configure functions', async () => {
     const fetcher = stub();
     fetcher.returns({
       a: 123,
@@ -18,7 +18,7 @@ describe('prepareConfig', () => {
     const maker = new MakerImpl(fetcher, []);
     expect(maker.config).to.be.undefined;
     expect(fetcher.callCount).to.equal(0);
-    maker.prepareConfig('x64');
+    await maker.prepareConfig('x64');
     expect(maker.config).to.deep.equal({
       a: 123,
     });
@@ -26,7 +26,23 @@ describe('prepareConfig', () => {
     expect(fetcher.firstCall.args).to.deep.equal(['x64']);
   });
 
-  it('should hand through the provided object', () => {
+  it('should accept async configure functions', async () => {
+    const fetcher = stub();
+    fetcher.resolves({
+      a: 123,
+    });
+    const maker = new MakerImpl(fetcher, []);
+    expect(maker.config).to.be.undefined;
+    expect(fetcher.callCount).to.equal(0);
+    await maker.prepareConfig('x64');
+    expect(maker.config).to.deep.equal({
+      a: 123,
+    });
+    expect(fetcher.callCount).to.equal(1);
+    expect(fetcher.firstCall.args).to.deep.equal(['x64']);
+  });
+
+  it('should hand through the provided object', async () => {
     const maker = new MakerImpl(
       {
         a: 234,
@@ -34,7 +50,7 @@ describe('prepareConfig', () => {
       []
     );
     expect(maker.config).to.be.undefined;
-    maker.prepareConfig('x64');
+    await maker.prepareConfig('x64');
     expect(maker.config).to.deep.equal({
       a: 234,
     });

--- a/packages/maker/deb/test/MakerDeb_spec.ts
+++ b/packages/maker/deb/test/MakerDeb_spec.ts
@@ -23,7 +23,7 @@ describe('MakerDeb', () => {
   let ensureDirectoryStub: SinonStub;
   let config: MakerDebConfig;
   let maker: MakerImpl;
-  let createMaker: () => void;
+  let createMaker: () => Promise<void>;
 
   const dir = '/my/test/dir/out';
   const makeDir = path.resolve('/foo/bar/make');
@@ -31,7 +31,7 @@ describe('MakerDeb', () => {
   const targetArch = process.arch;
   const packageJSON = { version: '1.2.3' };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     ensureDirectoryStub = stub().returns(Promise.resolve());
     eidStub = stub().returns({ packagePaths: ['/foo/bar.deb'] });
     config = {};
@@ -39,12 +39,12 @@ describe('MakerDeb', () => {
     MakerDeb = proxyquire.noPreserveCache().noCallThru().load('../src/MakerDeb', {
       'electron-installer-debian': eidStub,
     }).default;
-    createMaker = () => {
+    createMaker = async () => {
       maker = new MakerDeb(config, []);
       maker.ensureDirectory = ensureDirectoryStub;
-      maker.prepareConfig(targetArch as ForgeArch);
+      await maker.prepareConfig(targetArch);
     };
-    createMaker();
+    await createMaker();
   });
 
   it('should pass through correct defaults', async () => {
@@ -74,7 +74,7 @@ describe('MakerDeb', () => {
       },
     } as Record<string, unknown>;
 
-    createMaker();
+    await createMaker();
 
     await (maker.make as MakeFunction)({
       dir,

--- a/packages/maker/dmg/test/MakerDMG_spec.ts
+++ b/packages/maker/dmg/test/MakerDMG_spec.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
-import { ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { SinonStub, stub } from 'sinon';
@@ -23,7 +22,7 @@ describe('MakerDMG', () => {
   let renameStub: SinonStub;
   let config: MakerDMGConfig;
   let maker: MakerImpl;
-  let createMaker: () => void;
+  let createMaker: () => Promise<void>;
 
   const dir = '/my/test/dir/out';
   const makeDir = '/my/test/dir/make';
@@ -31,7 +30,7 @@ describe('MakerDMG', () => {
   const targetArch = process.arch;
   const packageJSON = { version: '1.2.3' };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     ensureFileStub = stub().returns(Promise.resolve());
     eidStub = stub().returns(Promise.resolve({ dmgPath: '/path/to/dmg' }));
     renameStub = stub().returns(Promise.resolve());
@@ -47,12 +46,12 @@ describe('MakerDMG', () => {
           rename: renameStub,
         },
       }).default;
-    createMaker = () => {
+    createMaker = async () => {
       maker = new MakerDMG(config);
       maker.ensureFile = ensureFileStub;
-      maker.prepareConfig(targetArch as ForgeArch);
+      await maker.prepareConfig(targetArch);
     };
-    createMaker();
+    await createMaker();
   });
 
   it('should pass through correct defaults', async () => {
@@ -97,7 +96,7 @@ describe('MakerDMG', () => {
 
   it('should not attempt to rename the DMG file if a custom name is set', async () => {
     config.name = 'foobar';
-    createMaker();
+    await createMaker();
     await (maker.make as MakeFunction)({
       dir,
       makeDir,

--- a/packages/maker/flatpak/test/MakerFlatpak_spec.ts
+++ b/packages/maker/flatpak/test/MakerFlatpak_spec.ts
@@ -24,7 +24,7 @@ describe('MakerFlatpak', () => {
   let eifStub: SinonStub;
   let ensureDirectoryStub: SinonStub;
   let config: MakerFlatpakConfig;
-  let createMaker: () => void;
+  let createMaker: () => Promise<void>;
 
   const dir = '/my/test/dir/out';
   const makeDir = path.resolve('/make/dir');
@@ -32,7 +32,7 @@ describe('MakerFlatpak', () => {
   const targetArch = process.arch;
   const packageJSON = { version: '1.2.3' };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     ensureDirectoryStub = stub().returns(Promise.resolve());
     eifStub = stub().resolves();
     config = {};
@@ -44,12 +44,12 @@ describe('MakerFlatpak', () => {
         'fs-extra': { readdir: stub().returns(Promise.resolve([])) },
         '@malept/electron-installer-flatpak': eifStub,
       }).default;
-    createMaker = () => {
+    createMaker = async () => {
       maker = new MakerFlatpak(config);
       maker.ensureDirectory = ensureDirectoryStub;
-      maker.prepareConfig(targetArch as ForgeArch);
+      await maker.prepareConfig(targetArch);
     };
-    createMaker();
+    await createMaker();
   });
 
   it('should pass through correct defaults', async () => {
@@ -76,7 +76,7 @@ describe('MakerFlatpak', () => {
         productName: 'Flatpak',
       },
     } as Record<string, unknown>;
-    createMaker();
+    await createMaker();
 
     await (maker.make as MakeFunction)({
       dir,

--- a/packages/maker/pkg/test/MakerPKG_spec.ts
+++ b/packages/maker/pkg/test/MakerPKG_spec.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
-import { ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { SinonStub, stub } from 'sinon';
@@ -23,7 +22,7 @@ describe('MakerPKG', () => {
   let renameStub: SinonStub;
   let config: MakerPKGConfig;
   let maker: MakerImpl;
-  let createMaker: () => void;
+  let createMaker: () => Promise<void>;
 
   const dir = '/my/test/dir/out';
   const makeDir = '/my/test/dir/make';
@@ -31,7 +30,7 @@ describe('MakerPKG', () => {
   const targetArch = process.arch;
   const packageJSON = { version: '1.2.3' };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     ensureFileStub = stub().returns(Promise.resolve());
     osxSignStub = stub();
     renameStub = stub().returns(Promise.resolve());
@@ -49,12 +48,12 @@ describe('MakerPKG', () => {
           rename: renameStub,
         },
       }).default;
-    createMaker = () => {
+    createMaker = async () => {
       maker = new MakerDMG(config);
       maker.ensureFile = ensureFileStub;
-      maker.prepareConfig(targetArch as ForgeArch);
+      await maker.prepareConfig(targetArch);
     };
-    createMaker();
+    await createMaker();
   });
 
   it('should pass through correct defaults', async () => {

--- a/packages/maker/rpm/test/MakerRpm_spec.ts
+++ b/packages/maker/rpm/test/MakerRpm_spec.ts
@@ -23,7 +23,7 @@ describe('MakerRpm', () => {
   let ensureDirectoryStub: SinonStub;
   let config: MakerRpmConfig;
   let maker: MakerImpl;
-  let createMaker: () => void;
+  let createMaker: () => Promise<void>;
 
   const dir = '/my/test/dir/out';
   const makeDir = path.resolve('/make/dir');
@@ -31,7 +31,7 @@ describe('MakerRpm', () => {
   const targetArch = process.arch;
   const packageJSON = { version: '1.2.3' };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     ensureDirectoryStub = stub().returns(Promise.resolve());
     eirStub = stub().returns(Promise.resolve({ packagePaths: ['/foo/bar.rpm'] }));
     config = {};
@@ -39,12 +39,12 @@ describe('MakerRpm', () => {
     MakerRpm = proxyquire.noPreserveCache().noCallThru().load('../src/MakerRpm', {
       'electron-installer-redhat': eirStub,
     }).default;
-    createMaker = () => {
+    createMaker = async () => {
       maker = new MakerRpm(config);
       maker.ensureDirectory = ensureDirectoryStub;
-      maker.prepareConfig(targetArch as ForgeArch);
+      await maker.prepareConfig(targetArch);
     };
-    createMaker();
+    await createMaker();
   });
 
   it('should pass through correct defaults', async () => {
@@ -71,7 +71,7 @@ describe('MakerRpm', () => {
         productName: 'Redhat',
       },
     } as MakerRpmConfig;
-    createMaker();
+    await createMaker();
 
     await (maker.make as MakeFunction)({
       dir,

--- a/packages/maker/snap/test/MakerSnap_spec.ts
+++ b/packages/maker/snap/test/MakerSnap_spec.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
-import { ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import proxyquire from 'proxyquire';
 import { SinonStub, stub } from 'sinon';
@@ -22,7 +21,7 @@ describe('MakerSnap', () => {
   let eisStub: SinonStub;
   let ensureDirectoryStub: SinonStub;
   let config: MakerSnapConfig;
-  let createMaker: () => void;
+  let createMaker: () => Promise<void>;
 
   const dir = '/my/test/dir/out/foo-linux-x64';
   const makeDir = path.resolve('/make/dir');
@@ -30,7 +29,7 @@ describe('MakerSnap', () => {
   const targetArch = process.arch;
   const packageJSON = { version: '1.2.3' };
 
-  beforeEach(() => {
+  beforeEach(async () => {
     ensureDirectoryStub = stub().returns(Promise.resolve());
     eisStub = stub().resolves('/my/test/dir/out/make/foo_0.0.1_amd64.snap');
     config = {};
@@ -38,12 +37,12 @@ describe('MakerSnap', () => {
     MakerSnapModule = proxyquire.noPreserveCache().noCallThru().load('../src/MakerSnap', {
       'electron-installer-snap': eisStub,
     }).default;
-    createMaker = () => {
+    createMaker = async () => {
       maker = new MakerSnapModule(config);
       maker.ensureDirectory = ensureDirectoryStub;
-      maker.prepareConfig(targetArch as ForgeArch);
+      await maker.prepareConfig(targetArch);
     };
-    createMaker();
+    await createMaker();
   });
 
   it('should pass through correct defaults', async () => {

--- a/packages/maker/zip/test/MakerZip_spec.ts
+++ b/packages/maker/zip/test/MakerZip_spec.ts
@@ -1,7 +1,6 @@
 import os from 'os';
 import path from 'path';
 
-import { ForgeArch } from '@electron-forge/shared-types';
 import { expect } from 'chai';
 import fs from 'fs-extra';
 import got from 'got';
@@ -14,7 +13,7 @@ describe('MakerZip', () => {
   let ensureDirectoryStub: SinonStub;
   let config: MakerZIPConfig;
   let maker: MakerZIP;
-  let createMaker: () => void;
+  let createMaker: () => Promise<void>;
 
   const dir = path.resolve(__dirname, 'fixture', 'fake-app');
   const darwinDir = path.resolve(__dirname, 'fixture', 'fake-darwin-app');
@@ -25,16 +24,16 @@ describe('MakerZip', () => {
   let getStub: SinonStub;
   let isoString: SinonStub;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     ensureDirectoryStub = stub().returns(Promise.resolve());
     config = {};
 
-    createMaker = () => {
+    createMaker = async () => {
       maker = new MakerZIP(config);
       maker.ensureDirectory = ensureDirectoryStub;
-      maker.prepareConfig(targetArch as ForgeArch);
+      await maker.prepareConfig(targetArch);
     };
-    createMaker();
+    await createMaker();
     getStub = stub(got, 'get');
     isoString = stub(Date.prototype, 'toISOString');
   });


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This PR changes the MakerBase `prepareConfig()` function to accept asynchronous callbacks.