### PR TITLE
fix(template): add missing config in plugin

### DIFF
--- a/packages/plugin/auto-unpack-natives/README.md
+++ b/packages/plugin/auto-unpack-natives/README.md
@@ -8,7 +8,8 @@ This plugin will automatically add all native Node modules in your node_modules 
 module.exports = {
   plugins: [
     {
-      name: '@electron-forge/plugin-auto-unpack-natives'
+      name: '@electron-forge/plugin-auto-unpack-natives',
+      config: {}
     }
   ]
 };

--- a/packages/template/base/tmpl/forge.config.js
+++ b/packages/template/base/tmpl/forge.config.js
@@ -24,6 +24,7 @@ module.exports = {
   plugins: [
     {
       name: '@electron-forge/plugin-auto-unpack-natives',
+      config: {},
     },
   ],
 };

--- a/packages/template/webpack/tmpl/forge.config.js
+++ b/packages/template/webpack/tmpl/forge.config.js
@@ -24,6 +24,7 @@ module.exports = {
   plugins: [
     {
       name: '@electron-forge/plugin-auto-unpack-natives',
+      config: {},
     },
     {
       name: '@electron-forge/plugin-webpack',


### PR DESCRIPTION
Fixes an issue with the v6.2.0 release where templates were broken.