### PR TITLE
fix(core): properly log invalid plugin configs

### DIFF
--- a/packages/api/core/src/util/plugin-interface.ts
+++ b/packages/api/core/src/util/plugin-interface.ts
@@ -47,7 +47,7 @@ export default class PluginInterface implements IForgePluginInterface {
         return new Plugin(opts);
       }
 
-      throw new Error(`Expected plugin to either be a plugin instance or a { name, config } object but found ${plugin}`);
+      throw new Error(`Expected plugin to either be a plugin instance or a { name, config } object but found ${JSON.stringify(plugin)}`);
     });
     // TODO: fix hack
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This avoids a non-descript `[object Object]` error in our logging.