### PR TITLE
fix(plugin-local-electron): Make the plugin compatible on Windows, and can live with other plugins

### DIFF
--- a/packages/api/core/src/util/electron-executable.ts
+++ b/packages/api/core/src/util/electron-executable.ts
@@ -28,6 +28,12 @@ export function pluginCompileExists(packageJSON: PackageJSON): boolean {
 }
 
 export default async function locateElectronExecutable(dir: string, packageJSON: PackageJSON): Promise<string> {
+  const overrideDist = process.env.ELECTRON_OVERRIDE_DIST_PATH;
+  if (overrideDist) {
+    console.info('Using electron dist from ELECTRON_OVERRIDE_DIST_PATH: ' + overrideDist);
+    return overrideDist;
+  }
+
   let electronModulePath: string | undefined = await getElectronModulePath(dir, packageJSON);
   if (electronModulePath?.endsWith('electron-prebuilt-compile') && !pluginCompileExists(packageJSON)) {
     console.warn(

--- a/packages/plugin/local-electron/src/LocalElectronPlugin.ts
+++ b/packages/plugin/local-electron/src/LocalElectronPlugin.ts
@@ -11,12 +11,14 @@ export default class LocalElectronPlugin extends PluginBase<LocalElectronPluginC
     super(c);
 
     this.getHooks = this.getHooks.bind(this);
+  }
 
+  init = (): void => {
     if (this.enabled) {
       this.checkPlatform(process.platform);
       process.env.ELECTRON_OVERRIDE_DIST_PATH = this.config.electronPath;
     }
-  }
+  };
 
   get enabled(): boolean {
     if (typeof this.config.enabled === 'undefined') {

--- a/packages/plugin/local-electron/src/LocalElectronPlugin.ts
+++ b/packages/plugin/local-electron/src/LocalElectronPlugin.ts
@@ -11,7 +11,11 @@ export default class LocalElectronPlugin extends PluginBase<LocalElectronPluginC
     super(c);
 
     this.getHooks = this.getHooks.bind(this);
-    this.startLogic = this.startLogic.bind(this);
+
+    if (this.enabled) {
+      this.checkPlatform(process.platform);
+      process.env.ELECTRON_OVERRIDE_DIST_PATH = this.config.electronPath;
+    }
   }
 
   get enabled(): boolean {
@@ -19,14 +23,6 @@ export default class LocalElectronPlugin extends PluginBase<LocalElectronPluginC
       return true;
     }
     return this.config.enabled;
-  }
-
-  async startLogic(): Promise<false> {
-    if (this.enabled) {
-      this.checkPlatform(process.platform);
-      process.env.ELECTRON_OVERRIDE_DIST_PATH = this.config.electronPath;
-    }
-    return false;
   }
 
   getHooks(): ForgeHookMap {

--- a/packages/plugin/local-electron/test/LocalElectronPlugin_spec.ts
+++ b/packages/plugin/local-electron/test/LocalElectronPlugin_spec.ts
@@ -20,30 +20,22 @@ describe('LocalElectronPlugin', () => {
     it('should set ELECTRON_OVERRIDE_DIST_PATH when enabled', async () => {
       expect(process.env.ELECTRON_OVERRIDE_DIST_PATH).to.equal(undefined);
       const p = new LocalElectronPlugin({ electronPath: 'test/foo' });
-      await p.startLogic();
+      p.init();
       expect(process.env.ELECTRON_OVERRIDE_DIST_PATH).to.equal('test/foo');
     });
 
     it('should not set ELECTRON_OVERRIDE_DIST_PATH when disabled', async () => {
       expect(process.env.ELECTRON_OVERRIDE_DIST_PATH).to.equal(undefined);
       const p = new LocalElectronPlugin({ enabled: false, electronPath: 'test/foo' });
-      await p.startLogic();
+      p.init();
       expect(process.env.ELECTRON_OVERRIDE_DIST_PATH).to.equal(undefined);
     });
 
     it("should throw an error if platforms don't match", async () => {
       const p = new LocalElectronPlugin({ electronPath: 'test/bar', electronPlatform: 'wut' });
-      await expect(p.startLogic()).to.eventually.be.rejectedWith(
+      await expect(p.init()).to.eventually.be.rejectedWith(
         `Can not use local Electron version, required platform "${process.platform}" but local platform is "wut"`
       );
-    });
-
-    it('should always return false', async () => {
-      let p = new LocalElectronPlugin({ electronPath: 'test/bar' });
-      expect(await p.startLogic()).to.equal(false);
-
-      p = new LocalElectronPlugin({ enabled: false, electronPath: 'test/bar' });
-      expect(await p.startLogic()).to.equal(false);
     });
   });
 
@@ -53,7 +45,7 @@ describe('LocalElectronPlugin', () => {
     beforeEach(() => {
       p = new LocalElectronPlugin({ electronPath: 'test/foo' });
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      p.init('', {} as any);
+      p.init();
     });
 
     describe('with afterExtract hook', () => {

--- a/packages/plugin/local-electron/test/LocalElectronPlugin_spec.ts
+++ b/packages/plugin/local-electron/test/LocalElectronPlugin_spec.ts
@@ -46,6 +46,10 @@ describe('LocalElectronPlugin', () => {
       p.init();
     });
 
+    after(() => {
+      delete process.env.ELECTRON_OVERRIDE_DIST_PATH;
+    });
+
     describe('with afterExtract hook', () => {
       let tmpDir: string;
 

--- a/packages/plugin/local-electron/test/LocalElectronPlugin_spec.ts
+++ b/packages/plugin/local-electron/test/LocalElectronPlugin_spec.ts
@@ -33,9 +33,7 @@ describe('LocalElectronPlugin', () => {
 
     it("should throw an error if platforms don't match", async () => {
       const p = new LocalElectronPlugin({ electronPath: 'test/bar', electronPlatform: 'wut' });
-      await expect(p.init()).to.eventually.be.rejectedWith(
-        `Can not use local Electron version, required platform "${process.platform}" but local platform is "wut"`
-      );
+      expect(p.init).to.throw(`Can not use local Electron version, required platform "${process.platform}" but local platform is "wut"`);
     });
   });
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

The `plugin-local-electron` currently cannot work with `plugin-vite` (or any other plugin) because it claims `startLogic`, which is unnecessary because it just merely set the `ELECTRON_OVERRIDE_DIST_PATH` env var. 

This PR:
1. Moved this logic to `init` function instead of `startLogic`
2. Changed function `locateElectronExecutable` to detect this `ELECTRON_OVERRIDE_DIST_PATH` env var to make the project directly starts the binary in the wanted path. (Because on Windows this env variable makes no effect and still launch the binary under `node_modules`...)
