### PR TITLE
ci: bump deprecated versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
       - image: cimg/base:stable
   macos:
     macos:
-      xcode: '14.0.0'
+      xcode: '14.3.0'
     resource_class: macos.x86.medium.gen2
   windows:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
     resource_class: macos.x86.medium.gen2
   windows:
     machine:
-      image: windows-server-2019-vs2019:stable
+      image: windows-server-2022-gui:stable
       resource_class: windows.medium
       shell: bash
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
       - image: cimg/base:stable
   macos:
     macos:
-      xcode: '13.4.0'
+      xcode: '14.0.0'
     resource_class: macos.x86.medium.gen2
   windows:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ commands:
     steps:
       - run: git config --global core.autocrlf input
       - node/install:
-          node-version: '16.20.1'
-      - run: nvm use 16.20.1
+          node-version: '18.15.0'
+      - run: nvm use 18.15.0
       - checkout
       - restore_cache:
           name: Restore Cached Dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,8 @@ commands:
     steps:
       - run: git config --global core.autocrlf input
       - node/install:
-          node-version: '14.18.0'
-      - run: nvm use 14.18.0
+          node-version: '16.20.1'
+      - run: nvm use 16.20.1
       - checkout
       - restore_cache:
           name: Restore Cached Dependencies


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Bumps the versions of several build environment dependencies to get them off deprecated versions:
* Xcode to 14.3.0
* Node to v18 (v16 EOL is Sep 2023)
* Windows Sever to 2022, to pick up a newer `nvm-windows` which fixes issues with newer Node versions