### PR TITLE
fix(publisher-ers): support arm64 osx platform

### DIFF
--- a/packages/publisher/electron-release-server/src/PublisherERS.ts
+++ b/packages/publisher/electron-release-server/src/PublisherERS.ts
@@ -38,7 +38,7 @@ const fetchAndCheckStatus = async (url: RequestInfo, init?: RequestInit): Promis
 export const ersPlatform = (platform: ForgePlatform, arch: ForgeArch): string => {
   switch (platform) {
     case 'darwin':
-      return 'osx_64';
+      return arch === 'arm64' ? 'osx_arm64' : 'osx_64';
     case 'linux':
       return arch === 'ia32' ? 'linux_32' : 'linux_64';
     case 'win32':


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [ x ] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [ x ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ x ] The changes are appropriately documented (if applicable).
- [ x ] The changes have sufficient test coverage (if applicable).
- [ x ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

At present, the platform field only supports `osx_64` under OSX, and the judgment branch of `osx_arm64` is missing.
