### PR TITLE
fix(template-vite): incorrectly bundling browser entrypoints

### DIFF
--- a/packages/template/vite/tmpl/vite.main.config.mjs
+++ b/packages/template/vite/tmpl/vite.main.config.mjs
@@ -5,7 +5,7 @@ export default defineConfig({
   resolve: {
     // Some libs that can run in both Web and Node.js, such as `axios`, we need to tell Vite to build them in Node.js.
     browserField: false,
-    conditions: ["node"],
+    conditions: ['node'],
     mainFields: ['module', 'jsnext:main', 'jsnext'],
   },
 });

--- a/packages/template/vite/tmpl/vite.main.config.mjs
+++ b/packages/template/vite/tmpl/vite.main.config.mjs
@@ -5,6 +5,7 @@ export default defineConfig({
   resolve: {
     // Some libs that can run in both Web and Node.js, such as `axios`, we need to tell Vite to build them in Node.js.
     browserField: false,
+    conditions: ["node"],
     mainFields: ['module', 'jsnext:main', 'jsnext'],
   },
 });


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [n/a] The changes are appropriately documented (if applicable).
- [n/a] The changes have sufficient test coverage (if applicable).
- [n/a] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

In some cases `browserField: false` in the `vite.main.config.js` is not sufficient to ensure that the Node version of a package is bundled (or rather, the browser version is not bundled) - in particular where the package uses [conditional exports](https://nodejs.org/api/packages.html#packages_conditional_exports), because Vite's resolver [favours conditions over the browser field](https://vitejs.dev/config/shared-options.html#resolve-mainfields):

> Note this takes lower precedence than conditional exports resolved from the exports field: if an entry point is successfully resolved from exports, the main field will be ignored.

This PR ensures that we set the `node` condition, which also makes Vite not load the browser version in certain cases.

I've tested this locally using the `ws` package: before this change it would throw an error when used from the main process (because it has a browser entrypoint that throws), while it doesn't with this change applied to my config.