### PR TITLE
fix: point preloads to native_modules

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -184,6 +184,7 @@ export default class WebpackConfigGenerator {
           __dirname: false,
           __filename: false,
         },
+        plugins: [new AssetRelocatorPatch(this.isProd, !!this.pluginConfig.renderer.nodeIntegration)],
       },
       rendererConfig || {},
       { target: 'electron-preload' }

--- a/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
+++ b/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
@@ -152,7 +152,7 @@ describe('AssetRelocatorPatch', () => {
       await expectOutputFileToHaveTheCorrectNativeModulePath({
         outDir: path.join(rendererOut, 'main_window'),
         jsPath: path.join(rendererOut, 'main_window/preload.js'),
-        nativeModulesString: '__webpack_require__.ab = __dirname + "/native_modules/"',
+        nativeModulesString: `__webpack_require__.ab = ${JSON.stringify(path.join(rendererOut, 'main_window'))} + "/native_modules/"`,
         nativePathString: `require(__webpack_require__.ab + \\"${nativePathSuffix}\\")`,
       });
     });
@@ -205,7 +205,7 @@ describe('AssetRelocatorPatch', () => {
       await expectOutputFileToHaveTheCorrectNativeModulePath({
         outDir: path.join(rendererOut, 'main_window'),
         jsPath: path.join(rendererOut, 'main_window/preload.js'),
-        nativeModulesString: '.ab=__dirname+"/native_modules/"',
+        nativeModulesString: '.ab=require("path").resolve(require("path").dirname(__filename),"..")+"/native_modules/"',
         nativePathString: `.ab+"${nativePathSuffix}"`,
       });
     });

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -332,7 +332,7 @@ describe('WebpackConfigGenerator', () => {
         path: path.join(mockProjectDir, '.webpack', 'renderer', 'main'),
         filename: 'preload.js',
       });
-      expect(hasAssetRelocatorPatchPlugin(webpackConfig.plugins)).to.equal(false);
+      expect(hasAssetRelocatorPatchPlugin(webpackConfig.plugins)).to.equal(true);
     });
 
     it('generates a production config', async () => {
@@ -358,7 +358,7 @@ describe('WebpackConfigGenerator', () => {
         path: path.join(mockProjectDir, '.webpack', 'renderer', 'main'),
         filename: 'preload.js',
       });
-      expect(hasAssetRelocatorPatchPlugin(webpackConfig.plugins)).to.equal(false);
+      expect(hasAssetRelocatorPatchPlugin(webpackConfig.plugins)).to.equal(true);
     });
     it('prevents the preload target from being overridden', async () => {
       const config = {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

- When using the webpack+typescript template if you `import` any packages that require `native_modules` the `webpack-asset-relocator` will inject `__dirname` into the output files in both development and production 
- Example of package use in preload that causes this issue in the webpack+typescript template; `import { auto } from "darkreader";`
- The browser console then reports `__dirname is undefined` and preload doesn't run
- Some users have removed `webpack-asset-relocator` from their webpack configuration to get around this, but without `native_modules` the `BrowserView` becomes sluggish
- This PR applies the patch used for the renderer config to the preloads
- The tests are updated and pass locally, but I am not sure if this is the effect maintainers want to happen, especially considering there are explicit tests to ensure this *isn't* applied