### PR TITLE
feat(package): add support for async Forge configs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,13 @@ for versions 6.0.1 and up.
 LINK_FORGE_DEPENDENCIES_ON_INIT=1 node path/to/forge/packages/api/cli/dist/electron-forge-init.js my-app
 ```
 
+To link an existing project to your local Forge packages, use the `yarn link:prepare` command as listed
+above, and then run the following command in your project:
+
+```sh
+yarn link @electron-forge/core --link-folder=path/to/forge/.links
+```
+
 Forge commands executed in your `my-app` sample project should reflect any changes in your local
 Forge build. (Make sure to run `yarn build:fast` or `yarn build` between code changes.)
 

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -104,7 +104,7 @@ export function renderConfigTemplate(dir: string, templateObj: any, obj: any): v
 }
 
 type MaybeESM<T> = T | { default: T };
-type AsyncFn = () => Promise<ForgeConfig>;
+type AsyncForgeConfigGenerator = () => Promise<ForgeConfig>;
 
 export default async (dir: string): Promise<ResolvedForgeConfig> => {
   const packageJSON = await readRawPackageJson(dir);
@@ -126,7 +126,7 @@ export default async (dir: string): Promise<ResolvedForgeConfig> => {
     try {
       // The loaded "config" could potentially be a static forge config, ESM module or async function
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const loaded = require(path.resolve(dir, forgeConfig as string)) as MaybeESM<ForgeConfig> | AsyncFn;
+      const loaded = require(path.resolve(dir, forgeConfig as string)) as MaybeESM<ForgeConfig | AsyncForgeConfigGenerator>;
       const maybeForgeConfig = 'default' in loaded ? loaded.default : loaded;
       forgeConfig = typeof maybeForgeConfig === 'function' ? await maybeForgeConfig() : maybeForgeConfig;
     } catch (err) {

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -126,11 +126,9 @@ export default async (dir: string): Promise<ResolvedForgeConfig> => {
     try {
       // The loaded "config" could potentially be a static forge config, ESM module or async function
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      let loaded = require(path.resolve(dir, forgeConfig as string)) as MaybeESM<ForgeConfig> | AsyncFn;
-      if (typeof loaded === 'function') {
-        loaded = await loaded();
-      }
-      forgeConfig = 'default' in loaded ? loaded.default : loaded;
+      const loaded = require(path.resolve(dir, forgeConfig as string)) as MaybeESM<ForgeConfig> | AsyncFn;
+      const maybeForgeConfig = 'default' in loaded ? loaded.default : loaded;
+      forgeConfig = typeof maybeForgeConfig === 'function' ? await maybeForgeConfig() : maybeForgeConfig;
     } catch (err) {
       console.error(`Failed to load: ${path.resolve(dir, forgeConfig as string)}`);
       throw err;

--- a/packages/api/core/test/fast/forge-config_spec.ts
+++ b/packages/api/core/test/fast/forge-config_spec.ts
@@ -24,6 +24,22 @@ describe('forge-config', () => {
     await expect(findConfig(path.resolve(__dirname, '../fixture/bad_external_forge_config'))).to.eventually.be.rejectedWith(/Unexpected token/);
   });
 
+  it('should support async configs exported in forge.config.js', async () => {
+    const config = await findConfig(path.resolve(__dirname, '../fixture/async_forge_config'));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (config as any).pluginInterface;
+    expect(config).to.be.deep.equal({
+      ...defaults,
+      makers: [
+        {
+          name: '@electron-forge/maker-zip',
+          platforms: ['darwin'],
+        },
+      ],
+      packagerConfig: { foo: {} },
+    });
+  });
+
   it('should be set to the defaults if no Forge config is specified in package.json', async () => {
     const config = await findConfig(path.resolve(__dirname, '../fixture/no_forge_config'));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/api/core/test/fixture/async_forge_config/forge.config.js
+++ b/packages/api/core/test/fixture/async_forge_config/forge.config.js
@@ -1,0 +1,12 @@
+module.exports = async function () {
+  return {
+    packagerConfig: { foo: {} },
+    rebuildConfig: {},
+    makers: [
+      {
+        name: '@electron-forge/maker-zip',
+        platforms: ['darwin'],
+      },
+    ],
+  };
+};

--- a/packages/api/core/test/fixture/async_forge_config/package.json
+++ b/packages/api/core/test/fixture/async_forge_config/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "async-test",
+  "devDependencies": {
+    "electron": "^1000.0.0",
+    "@electron-forge/cli": "6.0.0",
+    "@electron-forge/core": "6.0.0"
+  }
+}


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The test suite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This PR modifies the `getForgeConfig()` method to accept asynchronous configs.
