### PR TITLE
build: drop unused .npmignore

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -61,10 +61,17 @@
       }
     },
     {
+      "files": ["ci/**/*.js"],
+      "rules": {
+        "node/no-unpublished-require": "off"
+      }
+    },
+    {
       "files": ["packages/*/*/test/**/*_spec*.ts", "packages/*/*/test/fixture/**/*.ts"],
       "rules": {
         "global-require": "off",
         "import/no-dynamic-require": "off",
+        "node/no-extraneous-import": "off",
         "node/no-unpublished-import": "off",
         "node/no-unpublished-require": "off"
       }

--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-*-error.log
-src
-doc
-README.md
-test
-ci
-docs
-/index.ts


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

After #3284 this file is no longer needed (wasn't being used before anyway). Requires a couple of ESLint config changes as previously there were errors being suppressed by the presence of `.npmignore`