### PR TITLE
fix(package): bump `@electron/osx-sign` to latest

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,9 +1201,9 @@
     fs-extra "^9.0.1"
 
 "@electron/osx-sign@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@electron/osx-sign/-/osx-sign-1.0.1.tgz#ab4fceded7fed9f2f18c25650f46c1e3a6f17054"
-  integrity sha512-WkUcva+qkt809bI6uxxEG/uOWfl8HAw0m8aPijpKmGMIpZ1CWWB808YG6aY3wckUO86xZdmiOsUJTM4keLhY8A==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@electron/osx-sign/-/osx-sign-1.0.5.tgz#0af7149f2fce44d1a8215660fd25a9fb610454d8"
+  integrity sha512-k9ZzUQtamSoweGQDV2jILiRIHUu7lYlJ3c6IEmjv1hC17rclE+eb9U+f6UFlOOETo0JzY1HNlXy4YOlCvl+Lww==
   dependencies:
     compare-version "^0.1.2"
     debug "^4.3.4"


### PR DESCRIPTION
**Summarize your changes:**

ref https://github.com/electron/osx-sign/pull/292

Fixes the `preAutoEntitlements` option to only run on the root `.app` bundle rather than on all child files. Fixes MAS uploading for Electron Forge.




