### PR TITLE
fix(cli): add `template-vite-typescript` to Forge's core dependencies

### DIFF
--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -47,6 +47,7 @@
     "@electron-forge/shared-types": "6.4.0",
     "@electron-forge/template-base": "6.4.0",
     "@electron-forge/template-vite": "6.4.0",
+    "@electron-forge/template-vite-typescript": "6.4.0",
     "@electron-forge/template-webpack": "6.4.0",
     "@electron-forge/template-webpack-typescript": "6.4.0",
     "@electron/get": "^2.0.0",


### PR DESCRIPTION
**Summarize your changes:**

In order to install a template from the `electron-forge init` command, the template needs to be a dependency of the `@electron-forge/core` package.

Closes https://github.com/electron/forge/issues/3304

See:

```
success Installed "create-electron-app@6.4.0" with binaries:
      - create-electron-app
  electron-forge:init Initializing in: /Users/erick.zhao/640-test-app +0ms
[STARTED] Locating custom template: "vite-typescript"
  electron-forge:init:find-template Trying global template: electron-forge-template-vite-typescript +0ms
  electron-forge:init:find-template Error: get-installed-path: module not found "electron-forge-template-vite-typescript" in path /Users/erick.zhao/.nvm/versions/node/v16.20.1/lib/node_modules/electron-forge-template-vite-typescript +1ms
  electron-forge:init:find-template Trying global template: @electron-forge/template-vite-typescript +0ms
  electron-forge:init:find-template Error: get-installed-path: module not found "@electron-forge/template-vite-typescript" in path /Users/erick.zhao/.nvm/versions/node/v16.20.1/lib/node_modules/@electron-forge/template-vite-typescript +0ms
  electron-forge:init:find-template Trying local template: electron-forge-template-vite-typescript +0ms
  electron-forge:init:find-template Error: Cannot find module 'electron-forge-template-vite-typescript'
  electron-forge:init:find-template Require stack:
  electron-forge:init:find-template - /Users/erick.zhao/.config/yarn/global/node_modules/@electron-forge/core/dist/api/init-scripts/find-template.js
  electron-forge:init:find-template - /Users/erick.zhao/.config/yarn/global/node_modules/@electron-forge/core/dist/api/init.js
  electron-forge:init:find-template - /Users/erick.zhao/.config/yarn/global/node_modules/@electron-forge/core/dist/api/index.js
  electron-forge:init:find-template - /Users/erick.zhao/.config/yarn/global/node_modules/@electron-forge/cli/dist/electron-forge-init.js
  electron-forge:init:find-template - /Users/erick.zhao/.config/yarn/global/node_modules/create-electron-app/dist/index.js +0ms
  electron-forge:init:find-template Trying local template: @electron-forge/template-vite-typescript +0ms
  electron-forge:init:find-template Error: Cannot find module '@electron-forge/template-vite-typescript'
  electron-forge:init:find-template Require stack:
  electron-forge:init:find-template - /Users/erick.zhao/.config/yarn/global/node_modules/@electron-forge/core/dist/api/init-scripts/find-template.js
  electron-forge:init:find-template - /Users/erick.zhao/.config/yarn/global/node_modules/@electron-forge/core/dist/api/init.js
  electron-forge:init:find-template - /Users/erick.zhao/.config/yarn/global/node_modules/@electron-forge/core/dist/api/index.js
  electron-forge:init:find-template - /Users/erick.zhao/.config/yarn/global/node_modules/@electron-forge/cli/dist/electron-forge-init.js
  electron-forge:init:find-template - /Users/erick.zhao/.config/yarn/global/node_modules/create-electron-app/dist/index.js +1ms
  electron-forge:init:find-template Trying local template: vite-typescript +0ms
  electron-forge:init:find-template Error: Cannot find module 'vite-typescript'
  electron-forge:init:find-template Require stack:
  electron-forge:init:find-template - /Users/erick.zhao/.config/yarn/global/node_modules/@electron-forge/core/dist/api/init-scripts/find-template.js
  electron-forge:init:find-template - /Users/erick.zhao/.config/yarn/global/node_modules/@electron-forge/core/dist/api/init.js
  electron-forge:init:find-template - /Users/erick.zhao/.config/yarn/global/node_modules/@electron-forge/core/dist/api/index.js
  electron-forge:init:find-template - /Users/erick.zhao/.config/yarn/global/node_modules/@electron-forge/cli/dist/electron-forge-init.js
  electron-forge:init:find-template - /Users/erick.zhao/.config/yarn/global/node_modules/create-electron-app/dist/index.js +0ms
[FAILED] Failed to locate custom template: "vite-typescript"
[FAILED]
[FAILED] Try `npm install -g @electron-forge/template-vite-typescript`
```

On a side note, asking users to install the template globally as a workaround could work, but seems like a very bad code smell.