### PR TITLE
test(plugin-fuses): clear test TODOs

### DIFF
--- a/packages/plugin/fuses/test/FusesPlugin_spec_slow.ts
+++ b/packages/plugin/fuses/test/FusesPlugin_spec_slow.ts
@@ -23,10 +23,7 @@ describe('FusesPlugin', () => {
 
   const { name: appName } = packageJSON;
 
-  // @TODO get rid of this once https://github.com/electron/forge/pull/3123 lands
-  const platformArchSuffix = `${process.platform}-x64`;
-
-  const outDir = path.join(appPath, 'out', `${appName}-${platformArchSuffix}`);
+  const outDir = path.join(appPath, 'out', 'fuses-test-app');
 
   before(async () => {
     delete process.env.TS_NODE_PROJECT;
@@ -36,9 +33,6 @@ describe('FusesPlugin', () => {
 
   after(async () => {
     await fsExtra.remove(path.resolve(outDir, '../'));
-
-    // @TODO this can be removed once the mock app installs a published version of @electron-forge/plugin-fuses instead of a local package
-    await fsExtra.remove(path.join(__dirname, './fixture/app/node_modules'));
   });
 
   it('should flip Fuses', async () => {
@@ -51,6 +45,7 @@ describe('FusesPlugin', () => {
     });
 
     const args: string[] = process.platform === 'linux' ? ['-v', '--no-sandbox'] : ['-v'];
+
     /**
      * If the `RunAsNode` fuse had not been flipped,
      * this would return the Node.js version (e.g. `v14.16.0`)

--- a/packages/plugin/fuses/test/fixture/app/package.json.tmpl
+++ b/packages/plugin/fuses/test/fixture/app/package.json.tmpl
@@ -10,9 +10,9 @@
     "fs-extra": "^10.0.0"
   },
   "devDependencies": {
-    "@electron-forge/cli": "6.0.5",
-    "@electron-forge/plugin-fuses": "file:./../../../../fuses",
-    "@electron-forge/shared-types": "6.0.5",
+    "@electron-forge/cli": "6.4.0",
+    "@electron-forge/plugin-fuses": "6.4.0",
+    "@electron-forge/shared-types": "6.4.0",
     "electron": "12.0.0"
   }
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Now that the Fuses plugin is published to npm, the test app doesn't need to install it from the filesystem anymore. I've also updated the output directory path to make it consistent across all platforms/architectures (this was already implemented [here](https://github.com/electron/forge/blob/3d2e8d40c77f4c456b04b610204e669ec0132434/packages/plugin/fuses/test/fixture/app/forge.config.ts#L14-L16), but it wasn't working because of a bug with the `afterComplete` hook that's been fixed since v6.2.1).

This will hopefully solve that nasty error we've been getting when running this test locally 🤞🏼