### PR TITLE
chore: remove Volta config

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,9 +173,6 @@
   "prettier": {
     "singleQuote": true
   },
-  "volta": {
-    "node": "14.17.5"
-  },
   "workspaces": {
     "packages": [
       "packages/api/*",


### PR DESCRIPTION
I don't think anyone on the Forge dev
team uses Volta anymore.