### PR TITLE
build(deps-dev): upgrade html-webpack-plugin to 5.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "form-data": "^4.0.0",
     "fs-extra": "^10.0.0",
     "got": "^11.8.5",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.5.3",
     "interpret": "^3.1.1",
     "lodash": "^4.17.20",
     "log-symbols": "^4.0.0",

--- a/packages/plugin/webpack/package.json
+++ b/packages/plugin/webpack/package.json
@@ -31,7 +31,7 @@
     "chalk": "^4.0.0",
     "debug": "^4.3.1",
     "fs-extra": "^10.0.0",
-    "html-webpack-plugin": "^5.3.1",
+    "html-webpack-plugin": "^5.5.3",
     "webpack": "^5.69.1",
     "webpack-dev-server": "^4.0.0",
     "webpack-merge": "^5.7.3"

--- a/packages/plugin/webpack/src/util/AssetRelocatorPatch.ts
+++ b/packages/plugin/webpack/src/util/AssetRelocatorPatch.ts
@@ -14,10 +14,7 @@ export default class AssetRelocatorPatch {
     if (this.nodeIntegration) {
       // In production the assets are found one directory up from
       // __dirname
-      //
-      // __dirname cannot be used directly until this PR lands
-      // https://github.com/jantimon/html-webpack-plugin/pull/1650
-      return 'require("path").resolve(require("path").dirname(__filename), "..")';
+      return 'require("path").resolve(__dirname, "..")';
     }
 
     // If nodeIntegration is disabled, we replace __dirname

--- a/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
+++ b/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
@@ -219,7 +219,7 @@ describe('AssetRelocatorPatch', () => {
       await expectOutputFileToHaveTheCorrectNativeModulePath({
         outDir: rendererOut,
         jsPath: path.join(rendererOut, 'main_window/index.js'),
-        nativeModulesString: '.ab=require("path").resolve(require("path").dirname(__filename),"..")+"/native_modules/"',
+        nativeModulesString: '.ab=require("path").resolve(__dirname,"..")+"/native_modules/"',
         nativePathString: `.ab+"${nativePathSuffix}"`,
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7273,10 +7273,10 @@ html-minifier-terser@^6.0.2:
     relateurl "^0.2.7"
     terser "^5.10.0"
 
-html-webpack-plugin@^5.3.1:
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz#c3911936f57681c1f9f4d8b68c158cd9dfe52f50"
-  integrity sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==
+html-webpack-plugin@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.5.3.tgz#72270f4a78e222b5825b296e5e3e1328ad525a3e"
+  integrity sha512-6YrDKTuqaP/TquFH7h4srYWsZx+x6k6+FbsTm0ziCwGHDP78Unr1r9F/H4+sGmMbX08GQcJ+K64x55b+7VM/jg==
   dependencies:
     "@types/html-minifier-terser" "^6.0.0"
     html-minifier-terser "^6.0.2"


### PR DESCRIPTION
upgrade the dependency- upstream has merged their version of https://github.com/jantimon/html-webpack-plugin/pull/1650/files and https://github.com/jantimon/html-webpack-plugin/pull/1763


This allows us to stop using a small hack where we call dirname(__filename) instead of __dirname