### PR TITLE
ci: junit reporter adjustments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,13 @@ jobs:
                     libgtk-3-0 \
                     libgbm1
       - run-slow-tests
+      - run:
+          when: always # the report is generated on pass or fail
+          name: Make test report paths relative
+          command: |
+            if [ -e ./reports/out/test_output.xml ]; then
+              sed -i.bak "s|`pwd`/||g" ./reports/out/test_output.xml
+            fi
       - store_test_results:
           path: ./reports/
 

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -31,7 +31,7 @@ if (args.length === 0) {
 const reporterConfig = process.env.CI
   ? {
       reporter: 'mocha-junit-reporter',
-      'reporter-option': ['mochaFile=./reports/test_output.xml'],
+      'reporter-option': ['mochaFile=./reports/out/test_output.xml'],
     }
   : {};
 


### PR DESCRIPTION
Follow-up to #3316

Test timings are still busted, so I followed CircleCI's troubleshooting docs here: https://support.circleci.com/hc/en-us/articles/360021624194-Test-Summary-Troubleshooting

Two things that we weren't respecting:
* XML reports need to go inside a subfolder of the main test summary folder.
* Paths need to match the output of the test glob from the `circleci` CLI. This means that we need to convert the output strings from `mocha-junit-reporter` from absolute paths to relative paths.