### PR TITLE
ci: disable node_modules cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,8 @@ commands:
             yarn build
   run-fast-tests:
     steps:
-      - node/install-packages
+      - node/install-packages:
+          with-cache: false
       - attach_workspace:
           at: .
       - run:
@@ -34,7 +35,8 @@ commands:
 
   run-slow-tests:
     steps:
-      - node/install-packages
+      - node/install-packages:
+          with-cache: false
       - attach_workspace:
           at: .
       - run:


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

I don't think the cache step is doing anything, unfortunately.
