### PR TITLE
fix: Type 'StartContext' is not comparable to type 'never'

### DIFF
--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -4,7 +4,14 @@ import { RebuildOptions } from '@electron/rebuild';
 import { ArchOption, Options as ElectronPackagerOptions, TargetPlatform } from 'electron-packager';
 import { ListrDefaultRenderer, ListrTask, ListrTaskWrapper } from 'listr2';
 
-export type ForgeListrTask<T> = ListrTaskWrapper<T, ListrDefaultRenderer>;
+export type StartContext = {
+  dir: string;
+  forgeConfig: ResolvedForgeConfig;
+  packageJSON: any;
+  spawned: ElectronProcess;
+};
+
+export type ForgeListrTask<T = StartContext> = ListrTaskWrapper<T, ListrDefaultRenderer>;
 export type ElectronProcess = ChildProcess & { restarted: boolean };
 
 export type ForgePlatform = TargetPlatform;


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Fix the Type 'StartContext' is not comparable to type 'never' in packages/utils/types/src/index.ts
#3345 