### PR TITLE
docs: maker-squirrel does not support macOS

### DIFF
--- a/packages/maker/squirrel/README.md
+++ b/packages/maker/squirrel/README.md
@@ -5,7 +5,7 @@
 Pre-requisites:
 
 * Windows machine
-* MacOS /Linux machine with `mono` and `wine` installed.
+* Linux machine with `mono` and `wine` installed.
 
 Configuration options are documented in [`MakerSquirrelConfigOptions`](https://js.electronforge.io/interfaces/_electron_forge_maker_squirrel.InternalOptions.Options.html).
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Doesn't work on macOS so let's not lead folks astray.