### PR TITLE
fix(plugin-webpack): preload race condition

### DIFF
--- a/packages/plugin/webpack/src/Config.ts
+++ b/packages/plugin/webpack/src/Config.ts
@@ -121,6 +121,10 @@ export interface WebpackPluginRendererConfig {
   entryPoints: WebpackPluginEntryPoint[];
 }
 
+export interface EntryPointPluginConfig {
+  name: string;
+}
+
 export interface WebpackPluginConfig {
   /**
    * The webpack config for your main process

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -7,6 +7,7 @@ import { merge as webpackMerge } from 'webpack-merge';
 
 import { WebpackPluginConfig, WebpackPluginEntryPoint, WebpackPluginEntryPointLocalWindow, WebpackPluginEntryPointPreloadOnly } from './Config';
 import AssetRelocatorPatch from './util/AssetRelocatorPatch';
+import EntryPointPreloadPlugin from './util/EntryPointPreloadPlugin';
 import processConfig from './util/processConfig';
 import { isLocalOrNoWindowEntries, isLocalWindow, isNoWindow, isPreloadOnly, isPreloadOnlyEntries } from './util/rendererTypeUtils';
 
@@ -304,7 +305,10 @@ export default class WebpackConfigGenerator {
         globalObject: 'self',
         ...(this.isProd ? {} : { publicPath: '/' }),
       },
-      plugins: target === RendererTarget.ElectronPreload ? [] : [new webpack.ExternalsPlugin('commonjs2', externals)],
+      plugins: [
+        new EntryPointPreloadPlugin({ name: `entry-point-preload-${target}` }),
+        ...(target !== RendererTarget.ElectronPreload ? [] : [new webpack.ExternalsPlugin('commonjs2', externals)]),
+      ],
     };
     return webpackMerge(baseConfig, rendererConfig || {}, config);
   }

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -7,7 +7,6 @@ import { merge as webpackMerge } from 'webpack-merge';
 
 import { WebpackPluginConfig, WebpackPluginEntryPoint, WebpackPluginEntryPointLocalWindow, WebpackPluginEntryPointPreloadOnly } from './Config';
 import AssetRelocatorPatch from './util/AssetRelocatorPatch';
-import EntryPointPreloadPlugin from './util/EntryPointPreloadPlugin';
 import processConfig from './util/processConfig';
 import { isLocalOrNoWindowEntries, isLocalWindow, isNoWindow, isPreloadOnly, isPreloadOnlyEntries } from './util/rendererTypeUtils';
 
@@ -305,10 +304,7 @@ export default class WebpackConfigGenerator {
         globalObject: 'self',
         ...(this.isProd ? {} : { publicPath: '/' }),
       },
-      plugins: [
-        new EntryPointPreloadPlugin({ name: `entry-point-preload-${target}` }),
-        ...(target !== RendererTarget.ElectronPreload ? [] : [new webpack.ExternalsPlugin('commonjs2', externals)]),
-      ],
+      plugins: target === RendererTarget.ElectronPreload ? [] : [new webpack.ExternalsPlugin('commonjs2', externals)],
     };
     return webpackMerge(baseConfig, rendererConfig || {}, config);
   }

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -290,7 +290,7 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}`);
     }
 
     const preloadPlugins: string[] = [];
-    let preloadEntriesWithConfig = 0;
+    let numPreloadEntriesWithConfig = 0;
     for (const entryConfig of configs) {
       if (!entryConfig.plugins) entryConfig.plugins = [];
       entryConfig.plugins.push(new ElectronForgeLoggingPlugin(logger.createTab(`Renderer Target Bundle (${entryConfig.target})`)));
@@ -299,7 +299,7 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}`);
       if (filename?.endsWith('preload.js')) {
         let name = `entry-point-preload-${entryConfig.target}`;
         if (preloadPlugins.includes(name)) {
-          name = `${name}-${++preloadEntriesWithConfig}`;
+          name = `${name}-${++numPreloadEntriesWithConfig}`;
         }
         entryConfig.plugins.push(new EntryPointPreloadPlugin({ name }));
         preloadPlugins.push(name);

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -326,7 +326,6 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}`);
 
     const webpackDevServer = new WebpackDevServer(this.devServerOptions(), compiler);
     await webpackDevServer.start();
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.servers.push(webpackDevServer.server!);
     await Promise.all(promises);
   };

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -290,13 +290,17 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}`);
     }
 
     const preloadPlugins: string[] = [];
+    let preloadEntriesWithConfig = 0;
     for (const entryConfig of configs) {
       if (!entryConfig.plugins) entryConfig.plugins = [];
       entryConfig.plugins.push(new ElectronForgeLoggingPlugin(logger.createTab(`Renderer Target Bundle (${entryConfig.target})`)));
 
       const filename = entryConfig.output?.filename as string;
       if (filename.endsWith('preload.js')) {
-        const name = `entry-point-preload-${entryConfig.target}`;
+        let name = `entry-point-preload-${entryConfig.target}`;
+        if (preloadPlugins.includes(name)) {
+          name = `${name}-${++preloadEntriesWithConfig}`;
+        }
         entryConfig.plugins.push(new EntryPointPreloadPlugin({ name }));
         preloadPlugins.push(name);
       }

--- a/packages/plugin/webpack/src/util/EntryPointPreloadPlugin.ts
+++ b/packages/plugin/webpack/src/util/EntryPointPreloadPlugin.ts
@@ -1,0 +1,10 @@
+import { PluginBase } from '@electron-forge/plugin-base';
+
+import { EntryPointPluginConfig } from '../Config';
+
+export default class EntryPointPreloadPlugin extends PluginBase<EntryPointPluginConfig> {
+  name = this.config.name;
+  apply() {
+    // noop
+  }
+}


### PR DESCRIPTION
fixes: https://github.com/electron/forge/issues/3343

Due to webpack preload [refactoring](https://github.com/electron/forge/pull/3101), a bug mainly affecting windows resulted in users temporarily seeing an error as the window attempted to display preload contents before webpack was done compiling the preload. This PR introduces logic to wait for preload compilation to finish first.