### PR TITLE
chore(cli): limit yarn@^1.0.0

### DIFF
--- a/packages/api/cli/src/util/check-system.ts
+++ b/packages/api/cli/src/util/check-system.ts
@@ -33,9 +33,7 @@ const NPM_ALLOWLISTED_VERSIONS = {
   linux: '>= 5.4.0',
 };
 const YARN_ALLOWLISTED_VERSIONS = {
-  all: '0.23.3 || 0.24.6 || >= 1.0.0',
-  darwin: '0.27.5',
-  linux: '0.27.5',
+  all: '^1.0.0',
 };
 
 export function checkValidPackageManagerVersion(packageManager: string, version: string, allowlistedVersions: string) {


### PR DESCRIPTION
Explicitly disallows Yarn 2 and drops support for Yarn 0.x.

This is technically a breaking change, but according to npm's download stats, Yarn 0.x only has 2000 installs (~0.08%) of `yarn` (<=1.x) installs in the last week.