### PR TITLE
feat: esm forge.config.js support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ packages/*/*/doc
 packages/*/*/index.ts
 packages/**/bad.js
 tmpl
+packages/api/core/helper/dynamic-import.js

--- a/packages/api/core/helper/dynamic-import.d.ts
+++ b/packages/api/core/helper/dynamic-import.d.ts
@@ -1,0 +1,1 @@
+export declare function dynamicImport(path: string): Promise<any>;

--- a/packages/api/core/helper/dynamic-import.js
+++ b/packages/api/core/helper/dynamic-import.js
@@ -1,3 +1,5 @@
+const url = require('url');
+
 exports.dynamicImport = function dynamicImport(path) {
-  return import(path);
+  return import(url.pathToFileURL(path));
 };

--- a/packages/api/core/helper/dynamic-import.js
+++ b/packages/api/core/helper/dynamic-import.js
@@ -1,0 +1,3 @@
+exports.dynamicImport = function dynamicImport(path) {
+  return import(path);
+};

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -93,6 +93,7 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "helper"
   ]
 }

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -125,8 +125,13 @@ export default async (dir: string): Promise<ResolvedForgeConfig> => {
   if (await forgeConfigIsValidFilePath(dir, forgeConfig)) {
     try {
       // The loaded "config" could potentially be a static forge config, ESM module or async function
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const loaded = require(path.resolve(dir, forgeConfig as string)) as MaybeESM<ForgeConfig | AsyncForgeConfigGenerator>;
+      let loaded;
+      try {
+        loaded = (await eval(`import('${path.resolve(dir, forgeConfig as string)}')`)) as MaybeESM<ForgeConfig | AsyncForgeConfigGenerator>;
+      } catch (err) {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        loaded = require(path.resolve(dir, forgeConfig as string)) as MaybeESM<ForgeConfig | AsyncForgeConfigGenerator>;
+      }
       const maybeForgeConfig = 'default' in loaded ? loaded.default : loaded;
       forgeConfig = typeof maybeForgeConfig === 'function' ? await maybeForgeConfig() : maybeForgeConfig;
     } catch (err) {

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -6,6 +6,8 @@ import * as interpret from 'interpret';
 import { template } from 'lodash';
 import * as rechoir from 'rechoir';
 
+import { dynamicImport } from '../../helper/dynamic-import.js';
+
 import { runMutatingHook } from './hook';
 import PluginInterface from './plugin-interface';
 import { readRawPackageJson } from './read-package-json';
@@ -127,7 +129,7 @@ export default async (dir: string): Promise<ResolvedForgeConfig> => {
       // The loaded "config" could potentially be a static forge config, ESM module or async function
       let loaded;
       try {
-        loaded = (await eval(`import('${path.resolve(dir, forgeConfig as string)}')`)) as MaybeESM<ForgeConfig | AsyncForgeConfigGenerator>;
+        loaded = (await dynamicImport(path.resolve(dir, forgeConfig as string))) as MaybeESM<ForgeConfig | AsyncForgeConfigGenerator>;
       } catch (err) {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         loaded = require(path.resolve(dir, forgeConfig as string)) as MaybeESM<ForgeConfig | AsyncForgeConfigGenerator>;

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -125,19 +125,20 @@ export default async (dir: string): Promise<ResolvedForgeConfig> => {
   forgeConfig = forgeConfig || ({} as ForgeConfig);
 
   if (await forgeConfigIsValidFilePath(dir, forgeConfig)) {
+    const forgeConfigPath = path.resolve(dir, forgeConfig as string);
     try {
       // The loaded "config" could potentially be a static forge config, ESM module or async function
       let loaded;
       try {
-        loaded = (await dynamicImport(path.resolve(dir, forgeConfig as string))) as MaybeESM<ForgeConfig | AsyncForgeConfigGenerator>;
+        loaded = (await dynamicImport(forgeConfigPath)) as MaybeESM<ForgeConfig | AsyncForgeConfigGenerator>;
       } catch (err) {
         // eslint-disable-next-line @typescript-eslint/no-var-requires
-        loaded = require(path.resolve(dir, forgeConfig as string)) as MaybeESM<ForgeConfig | AsyncForgeConfigGenerator>;
+        loaded = require(forgeConfigPath) as MaybeESM<ForgeConfig | AsyncForgeConfigGenerator>;
       }
       const maybeForgeConfig = 'default' in loaded ? loaded.default : loaded;
       forgeConfig = typeof maybeForgeConfig === 'function' ? await maybeForgeConfig() : maybeForgeConfig;
     } catch (err) {
-      console.error(`Failed to load: ${path.resolve(dir, forgeConfig as string)}`);
+      console.error(`Failed to load: ${forgeConfigPath}`);
       throw err;
     }
   } else if (typeof forgeConfig !== 'object') {

--- a/packages/api/core/test/fast/forge-config_spec.ts
+++ b/packages/api/core/test/fast/forge-config_spec.ts
@@ -130,6 +130,13 @@ describe('forge-config', () => {
     expect(conf.defaultResolved).to.equal(true);
   });
 
+  it('should resolve the ESM JS file exports of forge.config.js if config.forge does not exist ', async () => {
+    type DefaultResolvedConfig = ResolvedForgeConfig & { defaultResolved: boolean };
+    const conf = (await findConfig(path.resolve(__dirname, '../fixture/dummy_default_esm_conf'))) as DefaultResolvedConfig;
+    expect(conf.buildIdentifier).to.equal('esm');
+    expect(conf.defaultResolved).to.equal(true);
+  });
+
   it(`should resolve the yml config from forge.config.yml if it's specified in config.forge`, async () => {
     type DefaultResolvedConfig = ResolvedForgeConfig;
     const conf = (await findConfig(path.resolve(__dirname, '../fixture/dummy_ts_conf'))) as DefaultResolvedConfig;

--- a/packages/api/core/test/fixture/dummy_default_esm_conf/forge.config.js
+++ b/packages/api/core/test/fixture/dummy_default_esm_conf/forge.config.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line node/no-unsupported-features/es-syntax
+export default {
+  buildIdentifier: 'esm',
+  defaultResolved: true,
+};

--- a/packages/api/core/test/fixture/dummy_default_esm_conf/package.json
+++ b/packages/api/core/test/fixture/dummy_default_esm_conf/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "",
+  "productName": "",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "start": "electron-forge start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "electron-prebuilt": "9.9.9"
+  }
+}


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This tiny PR adds ESM config support. Test added. Closes https://github.com/electron/forge/issues/3350

It is not a breaking change. Be ready for Electron 28 with ESM support! 💯 