### PR TITLE
chore: specify `packageManager` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
   "prettier": {
     "singleQuote": true
   },
+  "packageManager": "yarn@1.22.18+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447",
   "workspaces": {
     "packages": [
       "packages/api/*",


### PR DESCRIPTION
For folks using the Corepack feature in Node.js, `packageManager` specifies which package manager version to use. Not sure if we want to land this right away since the feature isn't marked as stable in Node.js yet, but people using Corepack with the `--activate` (global fallback version) flag might be installing the wrong version of Yarn.

ref https://github.com/electron/forge/pull/3357#issuecomment-1725870363

Note: this feature is still marked as experimental. See https://github.com/nodejs/corepack/issues/104 for discussion of stability.