### PR TITLE
feat: add tracing support for forge API

### DIFF
--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -50,6 +50,7 @@
     "@electron-forge/template-vite-typescript": "6.4.2",
     "@electron-forge/template-webpack": "6.4.2",
     "@electron-forge/template-webpack-typescript": "6.4.2",
+    "@electron-forge/tracer": "6.4.2",
     "@electron/get": "^2.0.0",
     "@electron/rebuild": "^3.2.10",
     "@malept/cross-spawn-promise": "^2.0.0",

--- a/packages/api/core/src/api/import.ts
+++ b/packages/api/core/src/api/import.ts
@@ -1,7 +1,9 @@
 import path from 'path';
 
 import { safeYarnOrNpm, updateElectronDependency } from '@electron-forge/core-utils';
+import { ForgeListrTaskFn } from '@electron-forge/shared-types';
 import baseTemplate from '@electron-forge/template-base';
+import { autoTrace } from '@electron-forge/tracer';
 import chalk from 'chalk';
 import debug from 'debug';
 import fs from 'fs-extra';
@@ -50,221 +52,219 @@ export interface ImportOptions {
   outDir?: string;
 }
 
-export default async ({
-  dir = process.cwd(),
-  interactive = false,
-  confirmImport,
-  shouldContinueOnExisting,
-  shouldRemoveDependency,
-  shouldUpdateScript,
-  outDir,
-}: ImportOptions): Promise<void> => {
-  const listrOptions = {
-    concurrent: false,
-    rendererOptions: {
-      collapse: false,
-      collapseErrors: false,
-    },
-    rendererSilent: !interactive,
-    rendererFallback: Boolean(process.env.DEBUG),
-  };
-
-  const runner = new Listr(
-    [
-      {
-        title: 'Locating importable project',
-        task: async () => {
-          d(`Attempting to import project in: ${dir}`);
-          if (!(await fs.pathExists(dir)) || !(await fs.pathExists(path.resolve(dir, 'package.json')))) {
-            throw new Error(`We couldn't find a project with a package.json file in: ${dir}`);
-          }
-
-          if (typeof confirmImport === 'function') {
-            if (!(await confirmImport())) {
-              // TODO: figure out if we can just return early here
-              // eslint-disable-next-line no-process-exit
-              process.exit(0);
-            }
-          }
-
-          await initGit(dir);
-        },
+export default autoTrace(
+  { name: 'import()', category: '@electron-forge/core' },
+  async (
+    childTrace,
+    { dir = process.cwd(), interactive = false, confirmImport, shouldContinueOnExisting, shouldRemoveDependency, shouldUpdateScript, outDir }: ImportOptions
+  ): Promise<void> => {
+    const listrOptions = {
+      concurrent: false,
+      rendererOptions: {
+        collapse: false,
+        collapseErrors: false,
       },
-      {
-        title: 'Processing configuration and dependencies',
-        options: {
-          persistentOutput: true,
-          bottomBar: Infinity,
+      rendererSilent: !interactive,
+      rendererFallback: Boolean(process.env.DEBUG),
+    };
+
+    const runner = new Listr(
+      [
+        {
+          title: 'Locating importable project',
+          task: childTrace({ name: 'locate-project', category: '@electron-forge/core' }, async () => {
+            d(`Attempting to import project in: ${dir}`);
+            if (!(await fs.pathExists(dir)) || !(await fs.pathExists(path.resolve(dir, 'package.json')))) {
+              throw new Error(`We couldn't find a project with a package.json file in: ${dir}`);
+            }
+
+            if (typeof confirmImport === 'function') {
+              if (!(await confirmImport())) {
+                // TODO: figure out if we can just return early here
+                // eslint-disable-next-line no-process-exit
+                process.exit(0);
+              }
+            }
+
+            await initGit(dir);
+          }),
         },
-        task: async (ctx, task) => {
-          const calculatedOutDir = outDir || 'out';
+        {
+          title: 'Processing configuration and dependencies',
+          options: {
+            persistentOutput: true,
+            bottomBar: Infinity,
+          },
+          task: childTrace<Parameters<ForgeListrTaskFn>>({ name: 'string', category: 'foo' }, async (_, ctx, task) => {
+            const calculatedOutDir = outDir || 'out';
 
-          const importDeps = ([] as string[]).concat(deps);
-          let importDevDeps = ([] as string[]).concat(devDeps);
-          let importExactDevDeps = ([] as string[]).concat(exactDevDeps);
+            const importDeps = ([] as string[]).concat(deps);
+            let importDevDeps = ([] as string[]).concat(devDeps);
+            let importExactDevDeps = ([] as string[]).concat(exactDevDeps);
 
-          let packageJSON = await readRawPackageJson(dir);
-          if (!packageJSON.version) {
-            task.output = chalk.yellow(`Please set the ${chalk.green('"version"')} in your application's package.json`);
-          }
-          if (packageJSON.config && packageJSON.config.forge) {
-            if (packageJSON.config.forge.makers) {
-              task.output = chalk.green('Existing Electron Forge configuration detected');
-              if (typeof shouldContinueOnExisting === 'function') {
-                if (!(await shouldContinueOnExisting())) {
-                  // TODO: figure out if we can just return early here
-                  // eslint-disable-next-line no-process-exit
-                  process.exit(0);
+            let packageJSON = await readRawPackageJson(dir);
+            if (!packageJSON.version) {
+              task.output = chalk.yellow(`Please set the ${chalk.green('"version"')} in your application's package.json`);
+            }
+            if (packageJSON.config && packageJSON.config.forge) {
+              if (packageJSON.config.forge.makers) {
+                task.output = chalk.green('Existing Electron Forge configuration detected');
+                if (typeof shouldContinueOnExisting === 'function') {
+                  if (!(await shouldContinueOnExisting())) {
+                    // TODO: figure out if we can just return early here
+                    // eslint-disable-next-line no-process-exit
+                    process.exit(0);
+                  }
+                }
+              } else if (!(typeof packageJSON.config.forge === 'object')) {
+                task.output = chalk.yellow(
+                  "We can't tell if the Electron Forge config is compatible because it's in an external JavaScript file, not trying to convert it and continuing anyway"
+                );
+              } else {
+                d('Upgrading an Electron Forge < 6 project');
+                packageJSON.config.forge = upgradeForgeConfig(packageJSON.config.forge);
+                importDevDeps = updateUpgradedForgeDevDeps(packageJSON, importDevDeps);
+              }
+            }
+
+            packageJSON.dependencies = packageJSON.dependencies || {};
+            packageJSON.devDependencies = packageJSON.devDependencies || {};
+
+            [importDevDeps, importExactDevDeps] = updateElectronDependency(packageJSON, importDevDeps, importExactDevDeps);
+
+            const keys = Object.keys(packageJSON.dependencies).concat(Object.keys(packageJSON.devDependencies));
+            const buildToolPackages: Record<string, string | undefined> = {
+              '@electron/get': 'already uses this module as a transitive dependency',
+              '@electron/osx-sign': 'already uses this module as a transitive dependency',
+              'electron-builder': 'provides mostly equivalent functionality',
+              'electron-download': 'already uses this module as a transitive dependency',
+              'electron-forge': 'replaced with @electron-forge/cli',
+              'electron-installer-debian': 'already uses this module as a transitive dependency',
+              'electron-installer-dmg': 'already uses this module as a transitive dependency',
+              'electron-installer-flatpak': 'already uses this module as a transitive dependency',
+              'electron-installer-redhat': 'already uses this module as a transitive dependency',
+              'electron-packager': 'already uses this module as a transitive dependency',
+              'electron-winstaller': 'already uses this module as a transitive dependency',
+            };
+
+            for (const key of keys) {
+              if (buildToolPackages[key]) {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                const explanation = buildToolPackages[key]!;
+                let remove = true;
+                if (typeof shouldRemoveDependency === 'function') {
+                  remove = await shouldRemoveDependency(key, explanation);
+                }
+
+                if (remove) {
+                  delete packageJSON.dependencies[key];
+                  delete packageJSON.devDependencies[key];
                 }
               }
-            } else if (!(typeof packageJSON.config.forge === 'object')) {
-              task.output = chalk.yellow(
-                "We can't tell if the Electron Forge config is compatible because it's in an external JavaScript file, not trying to convert it and continuing anyway"
-              );
-            } else {
-              d('Upgrading an Electron Forge < 6 project');
-              packageJSON.config.forge = upgradeForgeConfig(packageJSON.config.forge);
-              importDevDeps = updateUpgradedForgeDevDeps(packageJSON, importDevDeps);
             }
-          }
 
-          packageJSON.dependencies = packageJSON.dependencies || {};
-          packageJSON.devDependencies = packageJSON.devDependencies || {};
+            packageJSON.scripts = packageJSON.scripts || {};
+            d('reading current scripts object:', packageJSON.scripts);
 
-          [importDevDeps, importExactDevDeps] = updateElectronDependency(packageJSON, importDevDeps, importExactDevDeps);
-
-          const keys = Object.keys(packageJSON.dependencies).concat(Object.keys(packageJSON.devDependencies));
-          const buildToolPackages: Record<string, string | undefined> = {
-            '@electron/get': 'already uses this module as a transitive dependency',
-            '@electron/osx-sign': 'already uses this module as a transitive dependency',
-            'electron-builder': 'provides mostly equivalent functionality',
-            'electron-download': 'already uses this module as a transitive dependency',
-            'electron-forge': 'replaced with @electron-forge/cli',
-            'electron-installer-debian': 'already uses this module as a transitive dependency',
-            'electron-installer-dmg': 'already uses this module as a transitive dependency',
-            'electron-installer-flatpak': 'already uses this module as a transitive dependency',
-            'electron-installer-redhat': 'already uses this module as a transitive dependency',
-            'electron-packager': 'already uses this module as a transitive dependency',
-            'electron-winstaller': 'already uses this module as a transitive dependency',
-          };
-
-          for (const key of keys) {
-            if (buildToolPackages[key]) {
-              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              const explanation = buildToolPackages[key]!;
-              let remove = true;
-              if (typeof shouldRemoveDependency === 'function') {
-                remove = await shouldRemoveDependency(key, explanation);
+            const updatePackageScript = async (scriptName: string, newValue: string) => {
+              if (packageJSON.scripts[scriptName] !== newValue) {
+                let update = true;
+                if (typeof shouldUpdateScript === 'function') {
+                  update = await shouldUpdateScript(scriptName, newValue);
+                }
+                if (update) {
+                  packageJSON.scripts[scriptName] = newValue;
+                }
               }
+            };
 
-              if (remove) {
-                delete packageJSON.dependencies[key];
-                delete packageJSON.devDependencies[key];
-              }
-            }
-          }
+            await updatePackageScript('start', 'electron-forge start');
+            await updatePackageScript('package', 'electron-forge package');
+            await updatePackageScript('make', 'electron-forge make');
 
-          packageJSON.scripts = packageJSON.scripts || {};
-          d('reading current scripts object:', packageJSON.scripts);
+            d('forgified scripts object:', packageJSON.scripts);
 
-          const updatePackageScript = async (scriptName: string, newValue: string) => {
-            if (packageJSON.scripts[scriptName] !== newValue) {
-              let update = true;
-              if (typeof shouldUpdateScript === 'function') {
-                update = await shouldUpdateScript(scriptName, newValue);
-              }
-              if (update) {
-                packageJSON.scripts[scriptName] = newValue;
-              }
-            }
-          };
+            const writeChanges = async () => {
+              await fs.writeJson(path.resolve(dir, 'package.json'), packageJSON, { spaces: 2 });
+            };
 
-          await updatePackageScript('start', 'electron-forge start');
-          await updatePackageScript('package', 'electron-forge package');
-          await updatePackageScript('make', 'electron-forge make');
-
-          d('forgified scripts object:', packageJSON.scripts);
-
-          const writeChanges = async () => {
-            await fs.writeJson(path.resolve(dir, 'package.json'), packageJSON, { spaces: 2 });
-          };
-
-          return task.newListr(
-            [
-              {
-                title: 'Installing dependencies',
-                task: async (_, task) => {
-                  const packageManager = safeYarnOrNpm();
-                  await writeChanges();
-
-                  d('deleting old dependencies forcefully');
-                  await fs.remove(path.resolve(dir, 'node_modules/.bin/electron'));
-                  await fs.remove(path.resolve(dir, 'node_modules/.bin/electron.cmd'));
-
-                  d('installing dependencies');
-                  task.output = `${packageManager} install ${importDeps.join(' ')}`;
-                  await installDepList(dir, importDeps);
-
-                  d('installing devDependencies');
-                  task.output = `${packageManager} install --dev ${importDevDeps.join(' ')}`;
-                  await installDepList(dir, importDevDeps, DepType.DEV);
-
-                  d('installing exactDevDependencies');
-                  task.output = `${packageManager} install --dev --exact ${importExactDevDeps.join(' ')}`;
-                  await installDepList(dir, importExactDevDeps, DepType.DEV, DepVersionRestriction.EXACT);
-                },
-              },
-              {
-                title: 'Copying base template Forge configuration',
-                task: async () => {
-                  const pathToTemplateConfig = path.resolve(baseTemplate.templateDir, 'forge.config.js');
-
-                  // if there's an existing config.forge object in package.json
-                  if (packageJSON?.config?.forge && typeof packageJSON.config.forge === 'object') {
-                    d('detected existing Forge config in package.json, merging with base template Forge config');
-                    // eslint-disable-next-line @typescript-eslint/no-var-requires
-                    const templateConfig = require(path.resolve(baseTemplate.templateDir, 'forge.config.js'));
-                    packageJSON = await readRawPackageJson(dir);
-                    merge(templateConfig, packageJSON.config.forge); // mutates the templateConfig object
+            return task.newListr(
+              [
+                {
+                  title: 'Installing dependencies',
+                  task: async (_, task) => {
+                    const packageManager = safeYarnOrNpm();
                     await writeChanges();
-                    // otherwise, write to forge.config.js
-                  } else {
-                    d('writing new forge.config.js');
-                    await fs.copyFile(pathToTemplateConfig, path.resolve(dir, 'forge.config.js'));
-                  }
+
+                    d('deleting old dependencies forcefully');
+                    await fs.remove(path.resolve(dir, 'node_modules/.bin/electron'));
+                    await fs.remove(path.resolve(dir, 'node_modules/.bin/electron.cmd'));
+
+                    d('installing dependencies');
+                    task.output = `${packageManager} install ${importDeps.join(' ')}`;
+                    await installDepList(dir, importDeps);
+
+                    d('installing devDependencies');
+                    task.output = `${packageManager} install --dev ${importDevDeps.join(' ')}`;
+                    await installDepList(dir, importDevDeps, DepType.DEV);
+
+                    d('installing exactDevDependencies');
+                    task.output = `${packageManager} install --dev --exact ${importExactDevDeps.join(' ')}`;
+                    await installDepList(dir, importExactDevDeps, DepType.DEV, DepVersionRestriction.EXACT);
+                  },
                 },
-              },
-              {
-                title: 'Fixing .gitignore',
-                task: async () => {
-                  if (await fs.pathExists(path.resolve(dir, '.gitignore'))) {
-                    const gitignore = await fs.readFile(path.resolve(dir, '.gitignore'));
-                    if (!gitignore.includes(calculatedOutDir)) {
-                      await fs.writeFile(path.resolve(dir, '.gitignore'), `${gitignore}\n${calculatedOutDir}/`);
+                {
+                  title: 'Copying base template Forge configuration',
+                  task: async () => {
+                    const pathToTemplateConfig = path.resolve(baseTemplate.templateDir, 'forge.config.js');
+
+                    // if there's an existing config.forge object in package.json
+                    if (packageJSON?.config?.forge && typeof packageJSON.config.forge === 'object') {
+                      d('detected existing Forge config in package.json, merging with base template Forge config');
+                      // eslint-disable-next-line @typescript-eslint/no-var-requires
+                      const templateConfig = require(path.resolve(baseTemplate.templateDir, 'forge.config.js'));
+                      packageJSON = await readRawPackageJson(dir);
+                      merge(templateConfig, packageJSON.config.forge); // mutates the templateConfig object
+                      await writeChanges();
+                      // otherwise, write to forge.config.js
+                    } else {
+                      d('writing new forge.config.js');
+                      await fs.copyFile(pathToTemplateConfig, path.resolve(dir, 'forge.config.js'));
                     }
-                  }
+                  },
                 },
-              },
-            ],
-            listrOptions
-          );
+                {
+                  title: 'Fixing .gitignore',
+                  task: async () => {
+                    if (await fs.pathExists(path.resolve(dir, '.gitignore'))) {
+                      const gitignore = await fs.readFile(path.resolve(dir, '.gitignore'));
+                      if (!gitignore.includes(calculatedOutDir)) {
+                        await fs.writeFile(path.resolve(dir, '.gitignore'), `${gitignore}\n${calculatedOutDir}/`);
+                      }
+                    }
+                  },
+                },
+              ],
+              listrOptions
+            );
+          }),
         },
-      },
-      {
-        title: 'Finalizing import',
-        options: {
-          persistentOutput: true,
-          bottomBar: Infinity,
-        },
-        task: (_, task) => {
-          task.output = `We have attempted to convert your app to be in a format that Electron Forge understands.
+        {
+          title: 'Finalizing import',
+          options: {
+            persistentOutput: true,
+            bottomBar: Infinity,
+          },
+          task: childTrace<Parameters<ForgeListrTaskFn>>({ name: 'finalize-import', category: '@electron-forge/core' }, (_, __, task) => {
+            task.output = `We have attempted to convert your app to be in a format that Electron Forge understands.
           
           Thanks for using ${chalk.green('Electron Forge')}!`;
+          }),
         },
-      },
-    ],
-    listrOptions
-  );
+      ],
+      listrOptions
+    );
 
-  await runner.run();
-};
+    await runner.run();
+  }
+);

--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -2,7 +2,16 @@ import path from 'path';
 
 import { getElectronVersion } from '@electron-forge/core-utils';
 import { MakerBase } from '@electron-forge/maker-base';
-import { ForgeArch, ForgeConfigMaker, ForgeMakeResult, ForgePlatform, IForgeResolvableMaker, ResolvedForgeConfig } from '@electron-forge/shared-types';
+import {
+  ForgeArch,
+  ForgeConfigMaker,
+  ForgeListrTaskFn,
+  ForgeMakeResult,
+  ForgePlatform,
+  IForgeResolvableMaker,
+  ResolvedForgeConfig,
+} from '@electron-forge/shared-types';
+import { autoTrace, delayTraceTillSignal } from '@electron-forge/tracer';
 import { getHostArch } from '@electron/get';
 import chalk from 'chalk';
 import filenamify from 'filenamify';
@@ -88,6 +97,7 @@ export interface MakeOptions {
 }
 
 export const listrMake = (
+  childTrace: typeof autoTrace,
   {
     dir: providedDir = process.cwd(),
     interactive = false,
@@ -113,7 +123,7 @@ export const listrMake = (
     [
       {
         title: 'Loading configuration',
-        task: async (ctx) => {
+        task: childTrace<Parameters<ForgeListrTaskFn<MakeContext>>>({ name: 'load-forge-config', category: '@electron-forge/core' }, async (_, ctx) => {
           const resolvedDir = await resolveDir(providedDir);
           if (!resolvedDir) {
             throw new Error('Failed to locate startable Electron application');
@@ -121,183 +131,196 @@ export const listrMake = (
 
           ctx.dir = resolvedDir;
           ctx.forgeConfig = await getForgeConfig(resolvedDir);
-        },
+        }),
       },
       {
         title: 'Resolving make targets',
-        task: async (ctx, task) => {
-          const { dir, forgeConfig } = ctx;
-          ctx.actualOutDir = outDir || getCurrentOutDir(dir, forgeConfig);
+        task: childTrace<Parameters<ForgeListrTaskFn<MakeContext>>>(
+          { name: 'resolve-make-targets', category: '@electron-forge/core' },
+          async (_, ctx, task) => {
+            const { dir, forgeConfig } = ctx;
+            ctx.actualOutDir = outDir || getCurrentOutDir(dir, forgeConfig);
 
-          if (!['darwin', 'win32', 'linux', 'mas'].includes(platform)) {
-            throw new Error(`'${platform}' is an invalid platform. Choices are 'darwin', 'mas', 'win32' or 'linux'.`);
-          }
+            if (!['darwin', 'win32', 'linux', 'mas'].includes(platform)) {
+              throw new Error(`'${platform}' is an invalid platform. Choices are 'darwin', 'mas', 'win32' or 'linux'.`);
+            }
 
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const makers: Array<() => MakerBase<any>> = [];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const makers: Array<() => MakerBase<any>> = [];
 
-          const possibleMakers = generateTargets(forgeConfig, overrideTargets);
+            const possibleMakers = generateTargets(forgeConfig, overrideTargets);
 
-          for (const possibleMaker of possibleMakers) {
-            /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-            let maker: MakerBase<any>;
-            if (isElectronForgeMaker(possibleMaker)) {
-              maker = possibleMaker;
-              if (!maker.platforms.includes(platform)) continue;
-            } else {
-              const resolvableTarget = possibleMaker as IForgeResolvableMaker;
-              // non-false falsy values should be 'true'
-              if (resolvableTarget.enabled === false) continue;
+            for (const possibleMaker of possibleMakers) {
+              /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+              let maker: MakerBase<any>;
+              if (isElectronForgeMaker(possibleMaker)) {
+                maker = possibleMaker;
+                if (!maker.platforms.includes(platform)) continue;
+              } else {
+                const resolvableTarget = possibleMaker as IForgeResolvableMaker;
+                // non-false falsy values should be 'true'
+                if (resolvableTarget.enabled === false) continue;
 
-              if (!resolvableTarget.name) {
-                throw new Error(`The following maker config is missing a maker name: ${JSON.stringify(resolvableTarget)}`);
-              } else if (typeof resolvableTarget.name !== 'string') {
-                throw new Error(`The following maker config has a maker name that is not a string: ${JSON.stringify(resolvableTarget)}`);
+                if (!resolvableTarget.name) {
+                  throw new Error(`The following maker config is missing a maker name: ${JSON.stringify(resolvableTarget)}`);
+                } else if (typeof resolvableTarget.name !== 'string') {
+                  throw new Error(`The following maker config has a maker name that is not a string: ${JSON.stringify(resolvableTarget)}`);
+                }
+
+                const MakerClass = requireSearch<typeof MakerImpl>(dir, [resolvableTarget.name]);
+                if (!MakerClass) {
+                  throw new Error(
+                    `Could not find module with name '${resolvableTarget.name}'. If this is a package from NPM, make sure it's listed in the devDependencies of your package.json. If this is a local module, make sure you have the correct path to its entry point. Try using the DEBUG="electron-forge:require-search" environment variable for more information.`
+                  );
+                }
+
+                maker = new MakerClass(resolvableTarget.config, resolvableTarget.platforms || undefined);
+                if (!maker.platforms.includes(platform)) continue;
               }
 
-              const MakerClass = requireSearch<typeof MakerImpl>(dir, [resolvableTarget.name]);
-              if (!MakerClass) {
+              if (!maker.isSupportedOnCurrentPlatform) {
                 throw new Error(
-                  `Could not find module with name '${resolvableTarget.name}'. If this is a package from NPM, make sure it's listed in the devDependencies of your package.json. If this is a local module, make sure you have the correct path to its entry point. Try using the DEBUG="electron-forge:require-search" environment variable for more information.`
+                  [
+                    `Maker for target ${maker.name} is incompatible with this version of `,
+                    'Electron Forge, please upgrade or contact the maintainer ',
+                    "(needs to implement 'isSupportedOnCurrentPlatform)')",
+                  ].join('')
                 );
               }
 
-              maker = new MakerClass(resolvableTarget.config, resolvableTarget.platforms || undefined);
-              if (!maker.platforms.includes(platform)) continue;
+              if (!maker.isSupportedOnCurrentPlatform()) {
+                throw new Error(`Cannot make for ${platform} and target ${maker.name}: the maker declared that it cannot run on ${process.platform}.`);
+              }
+
+              maker.ensureExternalBinariesExist();
+
+              makers.push(() => maker.clone());
             }
 
-            if (!maker.isSupportedOnCurrentPlatform) {
-              throw new Error(
-                [
-                  `Maker for target ${maker.name} is incompatible with this version of `,
-                  'Electron Forge, please upgrade or contact the maintainer ',
-                  "(needs to implement 'isSupportedOnCurrentPlatform)')",
-                ].join('')
-              );
+            if (makers.length === 0) {
+              throw new Error(`Could not find any make targets configured for the "${platform}" platform.`);
             }
 
-            if (!maker.isSupportedOnCurrentPlatform()) {
-              throw new Error(`Cannot make for ${platform} and target ${maker.name}: the maker declared that it cannot run on ${process.platform}.`);
-            }
+            ctx.makers = makers;
 
-            maker.ensureExternalBinariesExist();
-
-            makers.push(() => maker.clone());
+            task.output = `Making for the following targets: ${chalk.magenta(`${makers.map((maker) => maker.name).join(', ')}`)}`;
           }
-
-          if (makers.length === 0) {
-            throw new Error(`Could not find any make targets configured for the "${platform}" platform.`);
-          }
-
-          ctx.makers = makers;
-
-          task.output = `Making for the following targets: ${chalk.magenta(`${makers.map((maker) => maker.name).join(', ')}`)}`;
-        },
+        ),
         options: {
           persistentOutput: true,
         },
       },
       {
         title: `Running ${chalk.yellow('package')} command`,
-        task: async (ctx, task) => {
+        task: childTrace<Parameters<ForgeListrTaskFn<MakeContext>>>({ name: 'package()', category: '@electron-forge/core' }, async (childTrace, ctx, task) => {
           if (!skipPackage) {
-            return listrPackage({
-              dir: ctx.dir,
-              interactive,
-              arch,
-              outDir: ctx.actualOutDir,
-              platform,
-            });
+            return delayTraceTillSignal(
+              childTrace,
+              listrPackage(childTrace, {
+                dir: ctx.dir,
+                interactive,
+                arch,
+                outDir: ctx.actualOutDir,
+                platform,
+              }),
+              'run'
+            );
           } else {
             task.output = chalk.yellow(`${logSymbols.warning} Skipping could result in an out of date build`);
             task.skip();
           }
-        },
+        }),
         options: {
           persistentOutput: true,
         },
       },
       {
         title: `Running ${chalk.yellow('preMake')} hook`,
-        task: async (ctx, task) => {
-          return task.newListr(await getHookListrTasks(ctx.forgeConfig, 'preMake'));
-        },
+        task: childTrace<Parameters<ForgeListrTaskFn<MakeContext>>>(
+          { name: 'run-preMake-hook', category: '@electron-forge/core' },
+          async (childTrace, ctx, task) => {
+            return delayTraceTillSignal(childTrace, task.newListr(await getHookListrTasks(childTrace, ctx.forgeConfig, 'preMake')), 'run');
+          }
+        ),
       },
       {
         title: 'Making distributables',
-        task: async (ctx, task) => {
-          const { actualOutDir, dir, forgeConfig, makers } = ctx;
-          const packageJSON = await readMutatedPackageJson(dir, forgeConfig);
-          const appName = filenamify(forgeConfig.packagerConfig.name || packageJSON.productName || packageJSON.name, { replacement: '-' });
-          const outputs: ForgeMakeResult[] = [];
-          ctx.outputs = outputs;
+        task: childTrace<Parameters<ForgeListrTaskFn<MakeContext>>>(
+          { name: 'make-distributables', category: '@electron-forge/core' },
+          async (childTrace, ctx, task) => {
+            const { actualOutDir, dir, forgeConfig, makers } = ctx;
+            const packageJSON = await readMutatedPackageJson(dir, forgeConfig);
+            const appName = filenamify(forgeConfig.packagerConfig.name || packageJSON.productName || packageJSON.name, { replacement: '-' });
+            const outputs: ForgeMakeResult[] = [];
+            ctx.outputs = outputs;
 
-          const subRunner = task.newListr([], {
-            ...listrOptions,
-            concurrent: true,
-            rendererOptions: {
-              collapse: false,
-              collapseErrors: false,
-            },
-          });
+            const subRunner = task.newListr([], {
+              ...listrOptions,
+              concurrent: true,
+              rendererOptions: {
+                collapse: false,
+                collapseErrors: false,
+              },
+            });
 
-          for (const targetArch of parseArchs(platform, arch, await getElectronVersion(dir, packageJSON))) {
-            const packageDir = path.resolve(actualOutDir, `${appName}-${platform}-${targetArch}`);
-            if (!(await fs.pathExists(packageDir))) {
-              throw new Error(`Couldn't find packaged app at: ${packageDir}`);
-            }
+            for (const targetArch of parseArchs(platform, arch, await getElectronVersion(dir, packageJSON))) {
+              const packageDir = path.resolve(actualOutDir, `${appName}-${platform}-${targetArch}`);
+              if (!(await fs.pathExists(packageDir))) {
+                throw new Error(`Couldn't find packaged app at: ${packageDir}`);
+              }
 
-            for (const maker of makers) {
-              const uniqMaker = maker();
-              subRunner.add({
-                title: `Making a ${chalk.magenta(uniqMaker.name)} distributable for ${chalk.cyan(`${platform}/${targetArch}`)}`,
-                task: async () => {
-                  try {
-                    await Promise.resolve(uniqMaker.prepareConfig(targetArch));
-                    const artifacts = await uniqMaker.make({
-                      appName,
-                      forgeConfig,
-                      packageJSON,
-                      targetArch,
-                      dir: packageDir,
-                      makeDir: path.resolve(actualOutDir, 'make'),
-                      targetPlatform: platform,
-                    });
+              for (const maker of makers) {
+                const uniqMaker = maker();
+                subRunner.add({
+                  title: `Making a ${chalk.magenta(uniqMaker.name)} distributable for ${chalk.cyan(`${platform}/${targetArch}`)}`,
+                  task: childTrace<[]>({ name: `make-${maker.name}`, category: '@electron-forge/core', newRoot: true }, async () => {
+                    try {
+                      await Promise.resolve(uniqMaker.prepareConfig(targetArch));
+                      const artifacts = await uniqMaker.make({
+                        appName,
+                        forgeConfig,
+                        packageJSON,
+                        targetArch,
+                        dir: packageDir,
+                        makeDir: path.resolve(actualOutDir, 'make'),
+                        targetPlatform: platform,
+                      });
 
-                    outputs.push({
-                      artifacts,
-                      packageJSON,
-                      platform,
-                      arch: targetArch,
-                    });
-                  } catch (err) {
-                    if (err) {
-                      throw err;
-                    } else {
-                      throw new Error(`An unknown error occurred while making for target: ${uniqMaker.name}`);
+                      outputs.push({
+                        artifacts,
+                        packageJSON,
+                        platform,
+                        arch: targetArch,
+                      });
+                    } catch (err) {
+                      if (err) {
+                        throw err;
+                      } else {
+                        throw new Error(`An unknown error occurred while making for target: ${uniqMaker.name}`);
+                      }
                     }
-                  }
-                },
-                options: {
-                  showTimer: true,
-                },
-              });
+                  }),
+                  options: {
+                    showTimer: true,
+                  },
+                });
+              }
             }
-          }
 
-          return subRunner;
-        },
+            return delayTraceTillSignal(childTrace, subRunner, 'run');
+          }
+        ),
       },
       {
         title: `Running ${chalk.yellow('postMake')} hook`,
-        task: async (ctx, task) => {
+        task: childTrace<Parameters<ForgeListrTaskFn<MakeContext>>>({ name: 'run-postMake-hook', category: '@electron-forge/core' }, async (_, ctx, task) => {
           // If the postMake hooks modifies the locations / names of the outputs it must return
           // the new locations so that the publish step knows where to look
           ctx.outputs = await runMutatingHook(ctx.forgeConfig, 'postMake', ctx.outputs);
           receiveMakeResults?.(ctx.outputs);
 
           task.output = `Artifacts available at: ${chalk.green(path.resolve(ctx.actualOutDir, 'make'))}`;
-        },
+        }),
         options: {
           persistentOutput: true,
         },
@@ -312,12 +335,10 @@ export const listrMake = (
   return runner;
 };
 
-const make = async (opts: MakeOptions): Promise<ForgeMakeResult[]> => {
-  const runner = listrMake(opts);
+export default autoTrace({ name: 'make()', category: '@electron-forge/core' }, async (childTrace, opts: MakeOptions): Promise<ForgeMakeResult[]> => {
+  const runner = listrMake(childTrace, opts);
 
   await runner.run();
 
   return runner.ctx.outputs;
-};
-
-export default make;
+});

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -2,7 +2,8 @@ import path from 'path';
 import { promisify } from 'util';
 
 import { getElectronVersion, listrCompatibleRebuildHook } from '@electron-forge/core-utils';
-import { ForgeArch, ForgeListrTask, ForgeListrTaskDefinition, ForgePlatform, ResolvedForgeConfig } from '@electron-forge/shared-types';
+import { ForgeArch, ForgeListrTask, ForgeListrTaskDefinition, ForgeListrTaskFn, ForgePlatform, ResolvedForgeConfig } from '@electron-forge/shared-types';
+import { autoTrace, delayTraceTillSignal } from '@electron-forge/tracer';
 import { getHostArch } from '@electron/get';
 import chalk from 'chalk';
 import debug from 'debug';
@@ -110,18 +111,21 @@ export interface PackageOptions {
   outDir?: string;
 }
 
-export const listrPackage = ({
-  dir: providedDir = process.cwd(),
-  interactive = false,
-  arch = getHostArch() as ForgeArch,
-  platform = process.platform as ForgePlatform,
-  outDir,
-}: PackageOptions) => {
+export const listrPackage = (
+  childTrace: typeof autoTrace,
+  {
+    dir: providedDir = process.cwd(),
+    interactive = false,
+    arch = getHostArch() as ForgeArch,
+    platform = process.platform as ForgePlatform,
+    outDir,
+  }: PackageOptions
+) => {
   const runner = new Listr<PackageContext>(
     [
       {
         title: 'Preparing to package application',
-        task: async (ctx) => {
+        task: childTrace<Parameters<ForgeListrTaskFn<PackageContext>>>({ name: 'package-prepare', category: '@electron-forge/core' }, async (_, ctx) => {
           const resolvedDir = await resolveDir(providedDir);
           if (!resolvedDir) {
             throw new Error('Failed to locate compilable Electron application');
@@ -136,299 +140,348 @@ export const listrPackage = ({
           }
 
           ctx.calculatedOutDir = outDir || getCurrentOutDir(resolvedDir, ctx.forgeConfig);
-        },
+        }),
       },
       {
         title: 'Running packaging hooks',
-        task: async ({ forgeConfig }, task) => {
-          return task.newListr([
-            {
-              title: `Running ${chalk.yellow('generateAssets')} hook`,
-              task: async (_, task) => {
-                return task.newListr(await getHookListrTasks(forgeConfig, 'generateAssets', platform, arch));
-              },
-            },
-            {
-              title: `Running ${chalk.yellow('prePackage')} hook`,
-              task: async (_, task) => {
-                return task.newListr(await getHookListrTasks(forgeConfig, 'prePackage', platform, arch));
-              },
-            },
-          ]);
-        },
+        task: childTrace<Parameters<ForgeListrTaskFn<PackageContext>>>(
+          { name: 'run-packaging-hooks', category: '@electron-forge/core' },
+          async (childTrace, { forgeConfig }, task) => {
+            return delayTraceTillSignal(
+              childTrace,
+              task.newListr([
+                {
+                  title: `Running ${chalk.yellow('generateAssets')} hook`,
+                  task: childTrace<Parameters<ForgeListrTaskFn>>(
+                    { name: 'run-generateAssets-hook', category: '@electron-forge/core' },
+                    async (childTrace, _, task) => {
+                      return delayTraceTillSignal(
+                        childTrace,
+                        task.newListr(await getHookListrTasks(childTrace, forgeConfig, 'generateAssets', platform, arch)),
+                        'run'
+                      );
+                    }
+                  ),
+                },
+                {
+                  title: `Running ${chalk.yellow('prePackage')} hook`,
+                  task: childTrace<Parameters<ForgeListrTaskFn>>(
+                    { name: 'run-prePackage-hook', category: '@electron-forge/core' },
+                    async (childTrace, _, task) => {
+                      return delayTraceTillSignal(
+                        childTrace,
+                        task.newListr(await getHookListrTasks(childTrace, forgeConfig, 'prePackage', platform, arch)),
+                        'run'
+                      );
+                    }
+                  ),
+                },
+              ]),
+              'run'
+            );
+          }
+        ),
       },
       {
         title: 'Packaging application',
-        task: async (ctx, task) => {
-          const { calculatedOutDir, forgeConfig, packageJSON } = ctx;
-          const getTargetKey = (target: TargetDefinition) => `${target.platform}/${target.arch}`;
+        task: childTrace<Parameters<ForgeListrTaskFn<PackageContext>>>(
+          { name: 'packaging-application', category: '@electron-forge/core' },
+          async (childTrace, ctx, task) => {
+            const { calculatedOutDir, forgeConfig, packageJSON } = ctx;
+            const getTargetKey = (target: TargetDefinition) => `${target.platform}/${target.arch}`;
 
-          task.output = 'Determining targets...';
+            task.output = 'Determining targets...';
 
-          type StepDoneSignalMap = Map<string, (() => void)[]>;
-          const signalCopyDone: StepDoneSignalMap = new Map();
-          const signalRebuildDone: StepDoneSignalMap = new Map();
-          const signalPackageDone: StepDoneSignalMap = new Map();
-          const rejects: ((err: any) => void)[] = [];
-          const signalDone = (map: StepDoneSignalMap, target: TargetDefinition) => {
-            map.get(getTargetKey(target))?.pop()?.();
-          };
-          const addSignalAndWait = async (map: StepDoneSignalMap, target: TargetDefinition) => {
-            const targetKey = getTargetKey(target);
-            await new Promise<void>((resolve, reject) => {
+            type StepDoneSignalMap = Map<string, (() => void)[]>;
+            const signalCopyDone: StepDoneSignalMap = new Map();
+            const signalRebuildDone: StepDoneSignalMap = new Map();
+            const signalPackageDone: StepDoneSignalMap = new Map();
+            const rejects: ((err: any) => void)[] = [];
+            const signalDone = (map: StepDoneSignalMap, target: TargetDefinition) => {
+              map.get(getTargetKey(target))?.pop()?.();
+            };
+            const addSignalAndWait = async (map: StepDoneSignalMap, target: TargetDefinition) => {
+              const targetKey = getTargetKey(target);
+              await new Promise<void>((resolve, reject) => {
+                rejects.push(reject);
+                map.set(targetKey, (map.get(targetKey) || []).concat([resolve]));
+              });
+            };
+
+            let provideTargets: (targets: TargetDefinition[]) => void;
+            const targetsPromise = new Promise<InternalTargetDefinition[]>((resolve, reject) => {
+              provideTargets = resolve;
               rejects.push(reject);
-              map.set(targetKey, (map.get(targetKey) || []).concat([resolve]));
             });
-          };
 
-          let provideTargets: (targets: TargetDefinition[]) => void;
-          const targetsPromise = new Promise<InternalTargetDefinition[]>((resolve, reject) => {
-            provideTargets = resolve;
-            rejects.push(reject);
-          });
+            const rebuildTasks = new Map<string, Promise<ForgeListrTask<never>>[]>();
+            const signalRebuildStart = new Map<string, ((task: ForgeListrTask<never>) => void)[]>();
 
-          const rebuildTasks = new Map<string, Promise<ForgeListrTask<never>>[]>();
-          const signalRebuildStart = new Map<string, ((task: ForgeListrTask<never>) => void)[]>();
+            const afterFinalizePackageTargetsHooks: FinalizePackageTargetsHookFunction[] = [
+              (targets, done) => {
+                provideTargets(targets);
+                done();
+              },
+              ...resolveHooks(forgeConfig.packagerConfig.afterFinalizePackageTargets, ctx.dir),
+            ];
 
-          const afterFinalizePackageTargetsHooks: FinalizePackageTargetsHookFunction[] = [
-            (targets, done) => {
-              provideTargets(targets);
-              done();
-            },
-            ...resolveHooks(forgeConfig.packagerConfig.afterFinalizePackageTargets, ctx.dir),
-          ];
+            const pruneEnabled = !('prune' in forgeConfig.packagerConfig) || forgeConfig.packagerConfig.prune;
 
-          const pruneEnabled = !('prune' in forgeConfig.packagerConfig) || forgeConfig.packagerConfig.prune;
-
-          const afterCopyHooks: HookFunction[] = [
-            async (buildPath, electronVersion, platform, arch, done) => {
-              signalDone(signalCopyDone, { platform, arch });
-              done();
-            },
-            async (buildPath, electronVersion, pPlatform, pArch, done) => {
-              const bins = await glob(path.join(buildPath, '**/.bin/**/*'));
-              for (const bin of bins) {
-                await fs.remove(bin);
-              }
-              done();
-            },
-            async (buildPath, electronVersion, pPlatform, pArch, done) => {
-              await runHook(forgeConfig, 'packageAfterCopy', buildPath, electronVersion, pPlatform, pArch);
-              done();
-            },
-            async (buildPath, electronVersion, pPlatform, pArch, done) => {
-              const targetKey = getTargetKey({ platform: pPlatform, arch: pArch });
-              await listrCompatibleRebuildHook(
-                buildPath,
-                electronVersion,
-                pPlatform,
-                pArch,
-                forgeConfig.rebuildConfig,
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                await rebuildTasks.get(targetKey)!.pop()!
-              );
-              signalRebuildDone.get(targetKey)?.pop()?.();
-              done();
-            },
-            async (buildPath, electronVersion, pPlatform, pArch, done) => {
-              const copiedPackageJSON = await readMutatedPackageJson(buildPath, forgeConfig);
-              if (copiedPackageJSON.config && copiedPackageJSON.config.forge) {
-                delete copiedPackageJSON.config.forge;
-              }
-              await fs.writeJson(path.resolve(buildPath, 'package.json'), copiedPackageJSON, { spaces: 2 });
-              done();
-            },
-            ...resolveHooks(forgeConfig.packagerConfig.afterCopy, ctx.dir),
-          ];
-
-          const afterCompleteHooks: HookFunction[] = [
-            async (buildPath, electronVersion, pPlatform, pArch, done) => {
-              signalPackageDone.get(getTargetKey({ platform: pPlatform, arch: pArch }))?.pop()?.();
-              done();
-            },
-            ...resolveHooks(forgeConfig.packagerConfig.afterComplete, ctx.dir),
-          ];
-
-          const afterPruneHooks = [];
-
-          if (pruneEnabled) {
-            afterPruneHooks.push(...resolveHooks(forgeConfig.packagerConfig.afterPrune, ctx.dir));
-          }
-
-          afterPruneHooks.push((async (buildPath, electronVersion, pPlatform, pArch, done) => {
-            await runHook(forgeConfig, 'packageAfterPrune', buildPath, electronVersion, pPlatform, pArch);
-            done();
-          }) as HookFunction);
-
-          const afterExtractHooks = [
-            (async (buildPath, electronVersion, pPlatform, pArch, done) => {
-              await runHook(forgeConfig, 'packageAfterExtract', buildPath, electronVersion, pPlatform, pArch);
-              done();
-            }) as HookFunction,
-          ];
-          afterExtractHooks.push(...resolveHooks(forgeConfig.packagerConfig.afterExtract, ctx.dir));
-
-          type PackagerArch = Exclude<ForgeArch, 'arm'>;
-
-          const packageOpts: packager.Options = {
-            asar: false,
-            overwrite: true,
-            ignore: [/^\/out\//g],
-            ...forgeConfig.packagerConfig,
-            quiet: true,
-            dir: ctx.dir,
-            arch: arch as PackagerArch,
-            platform,
-            afterFinalizePackageTargets: sequentialFinalizePackageTargetsHooks(afterFinalizePackageTargetsHooks),
-            afterComplete: sequentialHooks(afterCompleteHooks),
-            afterCopy: sequentialHooks(afterCopyHooks),
-            afterExtract: sequentialHooks(afterExtractHooks),
-            afterPrune: sequentialHooks(afterPruneHooks),
-            out: calculatedOutDir,
-            electronVersion: await getElectronVersion(ctx.dir, packageJSON),
-          };
-          packageOpts.quiet = true;
-
-          if (packageOpts.all) {
-            throw new Error('config.forge.packagerConfig.all is not supported by Electron Forge');
-          }
-
-          if (!packageJSON.version && !packageOpts.appVersion) {
-            warn(
-              interactive,
-              chalk.yellow('Please set "version" or "config.forge.packagerConfig.appVersion" in your application\'s package.json so auto-updates work properly')
-            );
-          }
-
-          if (packageOpts.prebuiltAsar) {
-            throw new Error('config.forge.packagerConfig.prebuiltAsar is not supported by Electron Forge');
-          }
-
-          d('packaging with options', packageOpts);
-
-          ctx.packagerPromise = packager(packageOpts);
-          // Handle error by failing this task
-          // rejects is populated by the reject handlers for every
-          // signal based promise in every subtask
-          ctx.packagerPromise.catch((err) => {
-            for (const reject of rejects) {
-              reject(err);
-            }
-          });
-
-          const targets = await targetsPromise;
-          // Copy the resolved targets into the context for later
-          ctx.targets = [...targets];
-          // If we are targetting a universal build we need to add the "fake"
-          // x64 and arm64 builds into the list of targets so that we can
-          // show progress for those
-          for (const target of targets) {
-            if (target.arch === 'universal') {
-              targets.push(
-                {
-                  platform: target.platform,
-                  arch: 'x64',
-                  forUniversal: true,
-                },
-                {
-                  platform: target.platform,
-                  arch: 'arm64',
-                  forUniversal: true,
+            const afterCopyHooks: HookFunction[] = [
+              async (buildPath, electronVersion, platform, arch, done) => {
+                signalDone(signalCopyDone, { platform, arch });
+                done();
+              },
+              async (buildPath, electronVersion, pPlatform, pArch, done) => {
+                const bins = await glob(path.join(buildPath, '**/.bin/**/*'));
+                for (const bin of bins) {
+                  await fs.remove(bin);
                 }
+                done();
+              },
+              async (buildPath, electronVersion, pPlatform, pArch, done) => {
+                await runHook(forgeConfig, 'packageAfterCopy', buildPath, electronVersion, pPlatform, pArch);
+                done();
+              },
+              async (buildPath, electronVersion, pPlatform, pArch, done) => {
+                const targetKey = getTargetKey({ platform: pPlatform, arch: pArch });
+                await listrCompatibleRebuildHook(
+                  buildPath,
+                  electronVersion,
+                  pPlatform,
+                  pArch,
+                  forgeConfig.rebuildConfig,
+                  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                  await rebuildTasks.get(targetKey)!.pop()!
+                );
+                signalRebuildDone.get(targetKey)?.pop()?.();
+                done();
+              },
+              async (buildPath, electronVersion, pPlatform, pArch, done) => {
+                const copiedPackageJSON = await readMutatedPackageJson(buildPath, forgeConfig);
+                if (copiedPackageJSON.config && copiedPackageJSON.config.forge) {
+                  delete copiedPackageJSON.config.forge;
+                }
+                await fs.writeJson(path.resolve(buildPath, 'package.json'), copiedPackageJSON, { spaces: 2 });
+                done();
+              },
+              ...resolveHooks(forgeConfig.packagerConfig.afterCopy, ctx.dir),
+            ];
+
+            const afterCompleteHooks: HookFunction[] = [
+              async (buildPath, electronVersion, pPlatform, pArch, done) => {
+                signalPackageDone.get(getTargetKey({ platform: pPlatform, arch: pArch }))?.pop()?.();
+                done();
+              },
+              ...resolveHooks(forgeConfig.packagerConfig.afterComplete, ctx.dir),
+            ];
+
+            const afterPruneHooks = [];
+
+            if (pruneEnabled) {
+              afterPruneHooks.push(...resolveHooks(forgeConfig.packagerConfig.afterPrune, ctx.dir));
+            }
+
+            afterPruneHooks.push((async (buildPath, electronVersion, pPlatform, pArch, done) => {
+              await runHook(forgeConfig, 'packageAfterPrune', buildPath, electronVersion, pPlatform, pArch);
+              done();
+            }) as HookFunction);
+
+            const afterExtractHooks = [
+              (async (buildPath, electronVersion, pPlatform, pArch, done) => {
+                await runHook(forgeConfig, 'packageAfterExtract', buildPath, electronVersion, pPlatform, pArch);
+                done();
+              }) as HookFunction,
+            ];
+            afterExtractHooks.push(...resolveHooks(forgeConfig.packagerConfig.afterExtract, ctx.dir));
+
+            type PackagerArch = Exclude<ForgeArch, 'arm'>;
+
+            const packageOpts: packager.Options = {
+              asar: false,
+              overwrite: true,
+              ignore: [/^\/out\//g],
+              ...forgeConfig.packagerConfig,
+              quiet: true,
+              dir: ctx.dir,
+              arch: arch as PackagerArch,
+              platform,
+              afterFinalizePackageTargets: sequentialFinalizePackageTargetsHooks(afterFinalizePackageTargetsHooks),
+              afterComplete: sequentialHooks(afterCompleteHooks),
+              afterCopy: sequentialHooks(afterCopyHooks),
+              afterExtract: sequentialHooks(afterExtractHooks),
+              afterPrune: sequentialHooks(afterPruneHooks),
+              out: calculatedOutDir,
+              electronVersion: await getElectronVersion(ctx.dir, packageJSON),
+            };
+            packageOpts.quiet = true;
+
+            if (packageOpts.all) {
+              throw new Error('config.forge.packagerConfig.all is not supported by Electron Forge');
+            }
+
+            if (!packageJSON.version && !packageOpts.appVersion) {
+              warn(
+                interactive,
+                chalk.yellow(
+                  'Please set "version" or "config.forge.packagerConfig.appVersion" in your application\'s package.json so auto-updates work properly'
+                )
               );
             }
-          }
 
-          // Populate rebuildTasks with promises that resolve with the rebuild tasks
-          // that will eventually run
-          for (const target of targets) {
-            // Skip universal tasks as they do not have rebuild sub-tasks
-            if (target.arch === 'universal') continue;
+            if (packageOpts.prebuiltAsar) {
+              throw new Error('config.forge.packagerConfig.prebuiltAsar is not supported by Electron Forge');
+            }
 
-            const targetKey = getTargetKey(target);
-            rebuildTasks.set(
-              targetKey,
-              (rebuildTasks.get(targetKey) || []).concat([
-                new Promise((resolve) => {
-                  signalRebuildStart.set(targetKey, (signalRebuildStart.get(targetKey) || []).concat([resolve]));
-                }),
-              ])
+            d('packaging with options', packageOpts);
+
+            ctx.packagerPromise = packager(packageOpts);
+            // Handle error by failing this task
+            // rejects is populated by the reject handlers for every
+            // signal based promise in every subtask
+            ctx.packagerPromise.catch((err) => {
+              for (const reject of rejects) {
+                reject(err);
+              }
+            });
+
+            const targets = await targetsPromise;
+            // Copy the resolved targets into the context for later
+            ctx.targets = [...targets];
+            // If we are targetting a universal build we need to add the "fake"
+            // x64 and arm64 builds into the list of targets so that we can
+            // show progress for those
+            for (const target of targets) {
+              if (target.arch === 'universal') {
+                targets.push(
+                  {
+                    platform: target.platform,
+                    arch: 'x64',
+                    forUniversal: true,
+                  },
+                  {
+                    platform: target.platform,
+                    arch: 'arm64',
+                    forUniversal: true,
+                  }
+                );
+              }
+            }
+
+            // Populate rebuildTasks with promises that resolve with the rebuild tasks
+            // that will eventually run
+            for (const target of targets) {
+              // Skip universal tasks as they do not have rebuild sub-tasks
+              if (target.arch === 'universal') continue;
+
+              const targetKey = getTargetKey(target);
+              rebuildTasks.set(
+                targetKey,
+                (rebuildTasks.get(targetKey) || []).concat([
+                  new Promise((resolve) => {
+                    signalRebuildStart.set(targetKey, (signalRebuildStart.get(targetKey) || []).concat([resolve]));
+                  }),
+                ])
+              );
+            }
+            d('targets:', targets);
+
+            return delayTraceTillSignal(
+              childTrace,
+              task.newListr(
+                targets.map(
+                  (target): ForgeListrTaskDefinition =>
+                    target.arch === 'universal'
+                      ? {
+                          title: `Stitching ${chalk.cyan(`${target.platform}/x64`)} and ${chalk.cyan(`${target.platform}/arm64`)} into a ${chalk.green(
+                            `${target.platform}/universal`
+                          )} package`,
+                          task: async () => {
+                            await addSignalAndWait(signalPackageDone, target);
+                          },
+                          options: {
+                            showTimer: true,
+                          },
+                        }
+                      : {
+                          title: `Packaging for ${chalk.cyan(target.arch)} on ${chalk.cyan(target.platform)}${
+                            target.forUniversal ? chalk.italic(' (for universal package)') : ''
+                          }`,
+                          task: childTrace<Parameters<ForgeListrTaskFn<never>>>(
+                            {
+                              name: `package-app-${target.platform}-${target.arch}${target.forUniversal ? '-universal-tmp' : ''}`,
+                              category: '@electron-forge/core',
+                              extraDetails: { arch: target.arch, platform: target.platform },
+                              newRoot: true,
+                            },
+                            async (childTrace, _, task) => {
+                              return delayTraceTillSignal(
+                                childTrace,
+                                task.newListr(
+                                  [
+                                    {
+                                      title: 'Copying files',
+                                      task: childTrace({ name: 'copy-files', category: '@electron-forge/core' }, async () => {
+                                        await addSignalAndWait(signalCopyDone, target);
+                                      }),
+                                    },
+                                    {
+                                      title: 'Preparing native dependencies',
+                                      task: childTrace({ name: 'prepare-native-dependencies', category: '@electron-forge/core' }, async (_, __, task) => {
+                                        signalRebuildStart.get(getTargetKey(target))?.pop()?.(task);
+                                        await addSignalAndWait(signalRebuildDone, target);
+                                      }),
+                                      options: {
+                                        persistentOutput: true,
+                                        bottomBar: Infinity,
+                                        showTimer: true,
+                                      },
+                                    },
+                                    {
+                                      title: 'Finalizing package',
+                                      task: childTrace({ name: 'finalize-package', category: '@electron-forge/core' }, async () => {
+                                        await addSignalAndWait(signalPackageDone, target);
+                                      }),
+                                    },
+                                  ],
+                                  { rendererOptions: { collapse: true, collapseErrors: false } }
+                                ),
+                                'run'
+                              );
+                            }
+                          ),
+                          options: {
+                            showTimer: true,
+                          },
+                        }
+                ),
+                { concurrent: true, rendererOptions: { collapse: false, collapseErrors: false } }
+              ),
+              'run'
             );
           }
-          d('targets:', targets);
-
-          return task.newListr(
-            targets.map(
-              (target): ForgeListrTaskDefinition =>
-                target.arch === 'universal'
-                  ? {
-                      title: `Stitching ${chalk.cyan(`${target.platform}/x64`)} and ${chalk.cyan(`${target.platform}/arm64`)} into a ${chalk.green(
-                        `${target.platform}/universal`
-                      )} package`,
-                      task: async () => {
-                        await addSignalAndWait(signalPackageDone, target);
-                      },
-                      options: {
-                        showTimer: true,
-                      },
-                    }
-                  : {
-                      title: `Packaging for ${chalk.cyan(target.arch)} on ${chalk.cyan(target.platform)}${
-                        target.forUniversal ? chalk.italic(' (for universal package)') : ''
-                      }`,
-                      task: async (_, task) => {
-                        return task.newListr(
-                          [
-                            {
-                              title: 'Copying files',
-                              task: async () => {
-                                await addSignalAndWait(signalCopyDone, target);
-                              },
-                            },
-                            {
-                              title: 'Preparing native dependencies',
-                              task: async (_, task) => {
-                                signalRebuildStart.get(getTargetKey(target))?.pop()?.(task);
-                                await addSignalAndWait(signalRebuildDone, target);
-                              },
-                              options: {
-                                persistentOutput: true,
-                                bottomBar: Infinity,
-                                showTimer: true,
-                              },
-                            },
-                            {
-                              title: 'Finalizing package',
-                              task: async () => {
-                                await addSignalAndWait(signalPackageDone, target);
-                              },
-                            },
-                          ],
-                          { rendererOptions: { collapse: true, collapseErrors: false } }
-                        );
-                      },
-                      options: {
-                        showTimer: true,
-                      },
-                    }
-            ),
-            { concurrent: true, rendererOptions: { collapse: false, collapseErrors: false } }
-          );
-        },
+        ),
       },
       {
         title: `Running ${chalk.yellow('postPackage')} hook`,
-        task: async ({ packagerPromise, forgeConfig }, task) => {
-          const outputPaths = await packagerPromise;
-          d('outputPaths:', outputPaths);
-          return task.newListr(
-            await getHookListrTasks(forgeConfig, 'postPackage', {
-              arch,
-              outputPaths,
-              platform,
-            })
-          );
-        },
+        task: childTrace<Parameters<ForgeListrTaskFn<PackageContext>>>(
+          { name: 'run-postPackage-hook', category: '@electron-forge/core' },
+          async (childTrace, { packagerPromise, forgeConfig }, task) => {
+            const outputPaths = await packagerPromise;
+            d('outputPaths:', outputPaths);
+            return delayTraceTillSignal(
+              childTrace,
+              task.newListr(
+                await getHookListrTasks(childTrace, forgeConfig, 'postPackage', {
+                  arch,
+                  outputPaths,
+                  platform,
+                })
+              ),
+              'run'
+            );
+          }
+        ),
       },
     ],
     {
@@ -446,8 +499,8 @@ export const listrPackage = ({
   return runner;
 };
 
-export default async (opts: PackageOptions): Promise<PackageResult[]> => {
-  const runner = listrPackage(opts);
+export default autoTrace({ name: 'package()', category: '@electron-forge/core' }, async (childTrace, opts: PackageOptions): Promise<PackageResult[]> => {
+  const runner = listrPackage(childTrace, opts);
 
   await runner.run();
 
@@ -457,4 +510,4 @@ export default async (opts: PackageOptions): Promise<PackageResult[]> => {
     arch: target.arch,
     packagedPath: outputPaths[index],
   }));
-};
+});

--- a/packages/api/core/src/api/publish.ts
+++ b/packages/api/core/src/api/publish.ts
@@ -4,12 +4,14 @@ import { PublisherBase } from '@electron-forge/publisher-base';
 import {
   ForgeConfigPublisher,
   ForgeListrTask,
+  ForgeListrTaskFn,
   ForgeMakeResult,
   IForgePublisher,
   IForgeResolvablePublisher,
   ResolvedForgeConfig,
   // ForgePlatform,
 } from '@electron-forge/shared-types';
+import { autoTrace, delayTraceTillSignal } from '@electron-forge/tracer';
 import chalk from 'chalk';
 import debug from 'debug';
 import fs from 'fs-extra';
@@ -66,227 +68,269 @@ export interface PublishOptions {
   dryRunResume?: boolean;
 }
 
-const publish = async ({
-  dir: providedDir = process.cwd(),
-  interactive = false,
-  makeOptions = {},
-  publishTargets = undefined,
-  dryRun = false,
-  dryRunResume = false,
-  outDir,
-}: PublishOptions): Promise<void> => {
-  if (dryRun && dryRunResume) {
-    throw new Error("Can't dry run and resume a dry run at the same time");
-  }
-
-  const listrOptions = {
-    concurrent: false,
-    rendererOptions: {
-      collapseErrors: false,
-    },
-    rendererSilent: !interactive,
-    rendererFallback: Boolean(process.env.DEBUG),
-  };
-
-  const publishDistributablesTasks = [
+export default autoTrace(
+  { name: 'publish()', category: '@electron-forge/core' },
+  async (
+    childTrace,
     {
-      title: 'Publishing distributables',
-      task: async ({ dir, forgeConfig, makeResults, publishers }: PublishContext, task: ForgeListrTask<PublishContext>) => {
-        if (publishers.length === 0) {
-          task.output = 'No publishers configured';
-          task.skip();
-          return;
-        }
+      dir: providedDir = process.cwd(),
+      interactive = false,
+      makeOptions = {},
+      publishTargets = undefined,
+      dryRun = false,
+      dryRunResume = false,
+      outDir,
+    }: PublishOptions
+  ): Promise<void> => {
+    if (dryRun && dryRunResume) {
+      throw new Error("Can't dry run and resume a dry run at the same time");
+    }
 
-        return task.newListr<never>(
-          publishers.map((publisher) => ({
-            title: `${chalk.cyan(`[publisher-${publisher.name}]`)} Running the ${chalk.yellow('publish')} command`,
-            task: async (_, task) => {
-              const setStatusLine = (s: string) => {
-                task.output = s;
-              };
-              await publisher.publish({
-                dir,
-                makeResults: makeResults!,
-                forgeConfig,
-                setStatusLine,
-              });
-            },
-            options: {
-              persistentOutput: true,
-            },
-          })),
-          {
-            rendererOptions: {
-              collapse: false,
-              collapseErrors: false,
-            },
-          }
-        );
+    const listrOptions = {
+      concurrent: false,
+      rendererOptions: {
+        collapseErrors: false,
       },
-      options: {
-        persistentOutput: true,
-      },
-    },
-  ];
+      rendererSilent: !interactive,
+      rendererFallback: Boolean(process.env.DEBUG),
+    };
 
-  const runner = new Listr<PublishContext>(
-    [
+    const publishDistributablesTasks = (childTrace: typeof autoTrace) => [
       {
-        title: 'Loading configuration',
-        task: async (ctx) => {
-          const resolvedDir = await resolveDir(providedDir);
-          if (!resolvedDir) {
-            throw new Error('Failed to locate publishable Electron application');
-          }
-
-          ctx.dir = resolvedDir;
-          ctx.forgeConfig = await getForgeConfig(resolvedDir);
-        },
-      },
-      {
-        title: 'Resolving publish targets',
-        task: async (ctx: PublishContext, task: ForgeListrTask<PublishContext>) => {
-          const { dir, forgeConfig } = ctx;
-
-          if (!publishTargets) {
-            publishTargets = forgeConfig.publishers || [];
-          }
-          publishTargets = (publishTargets as ForgeConfigPublisher[]).map((target) => {
-            if (typeof target === 'string') {
-              return (
-                (forgeConfig.publishers || []).find((p: ForgeConfigPublisher) => {
-                  if (typeof p === 'string') return false;
-                  if ((p as IForgePublisher).__isElectronForgePublisher) return false;
-                  return (p as IForgeResolvablePublisher).name === target;
-                }) || { name: target }
-              );
-            }
-            return target;
-          });
-
-          ctx.publishers = [];
-          for (const publishTarget of publishTargets) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            let publisher: PublisherBase<any>;
-            if ((publishTarget as IForgePublisher).__isElectronForgePublisher) {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              publisher = publishTarget as PublisherBase<any>;
-            } else {
-              const resolvablePublishTarget = publishTarget as IForgeResolvablePublisher;
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              const PublisherClass: any = requireSearch(dir, [resolvablePublishTarget.name]);
-              if (!PublisherClass) {
-                throw new Error(
-                  `Could not find a publish target with the name: ${resolvablePublishTarget.name}. Make sure it's listed in the devDependencies of your package.json`
-                );
-              }
-
-              publisher = new PublisherClass(resolvablePublishTarget.config || {}, resolvablePublishTarget.platforms);
+        title: 'Publishing distributables',
+        task: childTrace<Parameters<ForgeListrTaskFn<PublishContext>>>(
+          { name: 'publish-distributables', category: '@electron-forge/core' },
+          async (childTrace, { dir, forgeConfig, makeResults, publishers }, task: ForgeListrTask<PublishContext>) => {
+            if (publishers.length === 0) {
+              task.output = 'No publishers configured';
+              task.skip();
+              return;
             }
 
-            ctx.publishers.push(publisher);
+            return delayTraceTillSignal(
+              childTrace,
+              task.newListr<never>(
+                publishers.map((publisher) => ({
+                  title: `${chalk.cyan(`[publisher-${publisher.name}]`)} Running the ${chalk.yellow('publish')} command`,
+                  task: childTrace<Parameters<ForgeListrTaskFn>>(
+                    { name: `publish-${publisher.name}`, category: '@electron-forge/core' },
+                    async (childTrace, _, task) => {
+                      const setStatusLine = (s: string) => {
+                        task.output = s;
+                      };
+                      await publisher.publish({
+                        dir,
+                        makeResults: makeResults!,
+                        forgeConfig,
+                        setStatusLine,
+                      });
+                    }
+                  ),
+                  options: {
+                    persistentOutput: true,
+                  },
+                })),
+                {
+                  rendererOptions: {
+                    collapse: false,
+                    collapseErrors: false,
+                  },
+                }
+              ),
+              'run'
+            );
           }
-
-          if (ctx.publishers.length) {
-            task.output = `Publishing to the following targets: ${chalk.magenta(`${ctx.publishers.map((publisher) => publisher.name).join(', ')}`)}`;
-          }
-        },
+        ),
         options: {
           persistentOutput: true,
         },
       },
-      {
-        title: dryRunResume ? 'Resuming from dry run...' : `Running ${chalk.yellow('make')} command`,
-        task: async (ctx, task) => {
-          const { dir, forgeConfig } = ctx;
-          const calculatedOutDir = outDir || getCurrentOutDir(dir, forgeConfig);
-          const dryRunDir = path.resolve(calculatedOutDir, 'publish-dry-run');
+    ];
 
-          if (dryRunResume) {
-            d('attempting to resume from dry run');
-            const publishes = await PublishState.loadFromDirectory(dryRunDir, dir);
-            task.title = `Resuming ${publishes.length} found dry runs...`;
+    const runner = new Listr<PublishContext>(
+      [
+        {
+          title: 'Loading configuration',
+          task: childTrace<Parameters<ForgeListrTaskFn<PublishContext>>>(
+            { name: 'load-forge-config', category: '@electron-forge/core' },
+            async (childTrace, ctx) => {
+              const resolvedDir = await resolveDir(providedDir);
+              if (!resolvedDir) {
+                throw new Error('Failed to locate publishable Electron application');
+              }
 
-            return task.newListr<PublishContext>(
-              publishes.map((publishStates, index) => {
-                return {
-                  title: `Publishing dry-run ${chalk.blue(`#${index + 1}`)}`,
-                  task: async (ctx: PublishContext, task: ForgeListrTask<PublishContext>) => {
-                    const restoredMakeResults = publishStates.map(({ state }) => state);
-                    d('restoring publish settings from dry run');
+              ctx.dir = resolvedDir;
+              ctx.forgeConfig = await getForgeConfig(resolvedDir);
+            }
+          ),
+        },
+        {
+          title: 'Resolving publish targets',
+          task: childTrace<Parameters<ForgeListrTaskFn<PublishContext>>>(
+            { name: 'resolve-publish-targets', category: '@electron-forge/core' },
+            async (childTrace, ctx, task) => {
+              const { dir, forgeConfig } = ctx;
 
-                    for (const makeResult of restoredMakeResults) {
-                      makeResult.artifacts = await Promise.all(
-                        makeResult.artifacts.map(async (makePath: string) => {
-                          // standardize the path to artifacts across platforms
-                          const normalizedPath = makePath.split(/\/|\\/).join(path.sep);
-                          if (!(await fs.pathExists(normalizedPath))) {
-                            throw new Error(`Attempted to resume a dry run, but an artifact (${normalizedPath}) could not be found`);
+              if (!publishTargets) {
+                publishTargets = forgeConfig.publishers || [];
+              }
+              publishTargets = (publishTargets as ForgeConfigPublisher[]).map((target) => {
+                if (typeof target === 'string') {
+                  return (
+                    (forgeConfig.publishers || []).find((p: ForgeConfigPublisher) => {
+                      if (typeof p === 'string') return false;
+                      if ((p as IForgePublisher).__isElectronForgePublisher) return false;
+                      return (p as IForgeResolvablePublisher).name === target;
+                    }) || { name: target }
+                  );
+                }
+                return target;
+              });
+
+              ctx.publishers = [];
+              for (const publishTarget of publishTargets) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                let publisher: PublisherBase<any>;
+                if ((publishTarget as IForgePublisher).__isElectronForgePublisher) {
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  publisher = publishTarget as PublisherBase<any>;
+                } else {
+                  const resolvablePublishTarget = publishTarget as IForgeResolvablePublisher;
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  const PublisherClass: any = requireSearch(dir, [resolvablePublishTarget.name]);
+                  if (!PublisherClass) {
+                    throw new Error(
+                      `Could not find a publish target with the name: ${resolvablePublishTarget.name}. Make sure it's listed in the devDependencies of your package.json`
+                    );
+                  }
+
+                  publisher = new PublisherClass(resolvablePublishTarget.config || {}, resolvablePublishTarget.platforms);
+                }
+
+                ctx.publishers.push(publisher);
+              }
+
+              if (ctx.publishers.length) {
+                task.output = `Publishing to the following targets: ${chalk.magenta(`${ctx.publishers.map((publisher) => publisher.name).join(', ')}`)}`;
+              }
+            }
+          ),
+          options: {
+            persistentOutput: true,
+          },
+        },
+        {
+          title: dryRunResume ? 'Resuming from dry run...' : `Running ${chalk.yellow('make')} command`,
+          task: childTrace<Parameters<ForgeListrTaskFn<PublishContext>>>(
+            { name: dryRunResume ? 'resume-dry-run' : 'make()', category: '@electron-forge/core' },
+            async (childTrace, ctx, task) => {
+              const { dir, forgeConfig } = ctx;
+              const calculatedOutDir = outDir || getCurrentOutDir(dir, forgeConfig);
+              const dryRunDir = path.resolve(calculatedOutDir, 'publish-dry-run');
+
+              if (dryRunResume) {
+                d('attempting to resume from dry run');
+                const publishes = await PublishState.loadFromDirectory(dryRunDir, dir);
+                task.title = `Resuming ${publishes.length} found dry runs...`;
+
+                return delayTraceTillSignal(
+                  childTrace,
+                  task.newListr<PublishContext>(
+                    publishes.map((publishStates, index) => {
+                      return {
+                        title: `Publishing dry-run ${chalk.blue(`#${index + 1}`)}`,
+                        task: childTrace<Parameters<ForgeListrTaskFn<PublishContext>>>(
+                          { name: `publish-dry-run-${index + 1}`, category: '@electron-forge/core' },
+                          async (childTrace, ctx, task) => {
+                            const restoredMakeResults = publishStates.map(({ state }) => state);
+                            d('restoring publish settings from dry run');
+
+                            for (const makeResult of restoredMakeResults) {
+                              makeResult.artifacts = await Promise.all(
+                                makeResult.artifacts.map(async (makePath: string) => {
+                                  // standardize the path to artifacts across platforms
+                                  const normalizedPath = makePath.split(/\/|\\/).join(path.sep);
+                                  if (!(await fs.pathExists(normalizedPath))) {
+                                    throw new Error(`Attempted to resume a dry run, but an artifact (${normalizedPath}) could not be found`);
+                                  }
+                                  return normalizedPath;
+                                })
+                              );
+                            }
+
+                            d('publishing for given state set');
+                            return delayTraceTillSignal(
+                              childTrace,
+                              task.newListr(publishDistributablesTasks(childTrace), {
+                                ctx: {
+                                  ...ctx,
+                                  makeResults: restoredMakeResults,
+                                },
+                                rendererOptions: {
+                                  collapse: false,
+                                  collapseErrors: false,
+                                },
+                              }),
+                              'run'
+                            );
                           }
-                          return normalizedPath;
-                        })
-                      );
-                    }
-
-                    d('publishing for given state set');
-                    return task.newListr(publishDistributablesTasks, {
-                      ctx: {
-                        ...ctx,
-                        makeResults: restoredMakeResults,
-                      },
+                        ),
+                      };
+                    }),
+                    {
                       rendererOptions: {
                         collapse: false,
                         collapseErrors: false,
                       },
-                    });
-                  },
-                };
-              }),
-              {
-                rendererOptions: {
-                  collapse: false,
-                  collapseErrors: false,
-                },
+                    }
+                  ),
+                  'run'
+                );
               }
-            );
-          }
 
-          d('triggering make');
-          return listrMake(
-            {
-              dir,
-              interactive,
-              ...makeOptions,
-            },
-            (results) => {
-              ctx.makeResults = results;
+              d('triggering make');
+              return delayTraceTillSignal(
+                childTrace,
+                listrMake(
+                  childTrace,
+                  {
+                    dir,
+                    interactive,
+                    ...makeOptions,
+                  },
+                  (results) => {
+                    ctx.makeResults = results;
+                  }
+                ),
+                'run'
+              );
             }
-          );
+          ),
         },
-      },
-      ...(dryRunResume
-        ? []
-        : dryRun
-        ? [
-            {
-              title: 'Saving dry-run state',
-              task: async ({ dir, forgeConfig, makeResults }: PublishContext) => {
-                d('saving results of make in dry run state', makeResults);
-                const calculatedOutDir = outDir || getCurrentOutDir(dir, forgeConfig);
-                const dryRunDir = path.resolve(calculatedOutDir, 'publish-dry-run');
+        ...(dryRunResume
+          ? []
+          : dryRun
+          ? [
+              {
+                title: 'Saving dry-run state',
+                task: childTrace<Parameters<ForgeListrTaskFn<PublishContext>>>(
+                  { name: 'save-dry-run', category: '@electron-forge/core' },
+                  async (childTrace, { dir, forgeConfig, makeResults }) => {
+                    d('saving results of make in dry run state', makeResults);
+                    const calculatedOutDir = outDir || getCurrentOutDir(dir, forgeConfig);
+                    const dryRunDir = path.resolve(calculatedOutDir, 'publish-dry-run');
 
-                await fs.remove(dryRunDir);
-                await PublishState.saveToDirectory(dryRunDir, makeResults!, dir);
+                    await fs.remove(dryRunDir);
+                    await PublishState.saveToDirectory(dryRunDir, makeResults!, dir);
+                  }
+                ),
               },
-            },
-          ]
-        : publishDistributablesTasks),
-    ],
-    listrOptions
-  );
+            ]
+          : publishDistributablesTasks(childTrace)),
+      ],
+      listrOptions
+    );
 
-  await runner.run();
-};
-
-export default publish;
+    await runner.run();
+  }
+);

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -1,7 +1,8 @@
 import { spawn, SpawnOptions } from 'child_process';
 
 import { getElectronVersion, listrCompatibleRebuildHook } from '@electron-forge/core-utils';
-import { ElectronProcess, ForgeArch, ForgeListrTask, ForgePlatform, ResolvedForgeConfig, StartOptions } from '@electron-forge/shared-types';
+import { ElectronProcess, ForgeArch, ForgeListrTaskFn, ForgePlatform, ResolvedForgeConfig, StartOptions } from '@electron-forge/shared-types';
+import { autoTrace, delayTraceTillSignal } from '@electron-forge/tracer';
 import chalk from 'chalk';
 import debug from 'debug';
 import { Listr } from 'listr2';
@@ -23,198 +24,210 @@ type StartContext = {
   spawned: ElectronProcess;
 };
 
-export default async ({
-  dir: providedDir = process.cwd(),
-  appPath = '.',
-  interactive = false,
-  enableLogging = false,
-  args = [],
-  runAsNode = false,
-  inspect = false,
-  inspectBrk = false,
-}: StartOptions): Promise<ElectronProcess> => {
-  const platform = process.env.npm_config_platform || process.platform;
-  const arch = process.env.npm_config_arch || process.arch;
-  const listrOptions = {
-    concurrent: false,
-    rendererOptions: {
-      collapseErrors: false,
-    },
-    rendererSilent: !interactive,
-    rendererFallback: Boolean(process.env.DEBUG),
-  };
-
-  const runner = new Listr<StartContext>(
-    [
-      {
-        title: 'Locating application',
-        task: async (ctx) => {
-          const resolvedDir = await resolveDir(providedDir);
-          if (!resolvedDir) {
-            throw new Error('Failed to locate startable Electron application');
-          }
-          ctx.dir = resolvedDir;
-        },
+export default autoTrace(
+  { name: 'start()', category: '@electron-forge/core' },
+  async (
+    childTrace,
+    {
+      dir: providedDir = process.cwd(),
+      appPath = '.',
+      interactive = false,
+      enableLogging = false,
+      args = [],
+      runAsNode = false,
+      inspect = false,
+      inspectBrk = false,
+    }: StartOptions
+  ): Promise<ElectronProcess> => {
+    const platform = process.env.npm_config_platform || process.platform;
+    const arch = process.env.npm_config_arch || process.arch;
+    const listrOptions = {
+      concurrent: false,
+      rendererOptions: {
+        collapseErrors: false,
       },
-      {
-        title: 'Loading configuration',
-        task: async (ctx) => {
-          const { dir } = ctx;
-          ctx.forgeConfig = await getForgeConfig(dir);
-          ctx.packageJSON = await readMutatedPackageJson(dir, ctx.forgeConfig);
-
-          if (!ctx.packageJSON.version) {
-            throw new Error(`Please set your application's 'version' in '${dir}/package.json'.`);
-          }
-        },
-      },
-      {
-        title: 'Preparing native dependencies',
-        task: async ({ dir, forgeConfig, packageJSON }, task) => {
-          await listrCompatibleRebuildHook(
-            dir,
-            await getElectronVersion(dir, packageJSON),
-            platform as ForgePlatform,
-            arch as ForgeArch,
-            forgeConfig.rebuildConfig,
-            task as ForgeListrTask<never>
-          );
-        },
-        options: {
-          persistentOutput: true,
-          bottomBar: Infinity,
-          showTimer: true,
-        },
-      },
-      {
-        title: `Running ${chalk.yellow('generateAssets')} hook`,
-        task: async ({ forgeConfig }, task) => {
-          return task.newListr(await getHookListrTasks(forgeConfig, 'generateAssets', platform, arch));
-        },
-      },
-    ],
-    listrOptions
-  );
-
-  await runner.run();
-
-  const { dir, forgeConfig, packageJSON } = runner.ctx;
-  let lastSpawned: ElectronProcess | null = null;
-
-  const forgeSpawn = async () => {
-    let electronExecPath: string | null = null;
-
-    // If a plugin has taken over the start command let's stop here
-    let spawnedPluginChild = await forgeConfig.pluginInterface.overrideStartLogic({
-      dir,
-      appPath,
-      interactive,
-      enableLogging,
-      args,
-      runAsNode,
-      inspect,
-      inspectBrk,
-    });
-    if (typeof spawnedPluginChild === 'object' && 'tasks' in spawnedPluginChild) {
-      const innerRunner = new Listr<never>([], listrOptions);
-      for (const task of spawnedPluginChild.tasks) {
-        innerRunner.add(task);
-      }
-      await innerRunner.run();
-      spawnedPluginChild = spawnedPluginChild.result;
-    }
-    let prefixArgs: string[] = [];
-    if (typeof spawnedPluginChild === 'string') {
-      electronExecPath = spawnedPluginChild;
-    } else if (Array.isArray(spawnedPluginChild)) {
-      [electronExecPath, ...prefixArgs] = spawnedPluginChild;
-    } else if (spawnedPluginChild) {
-      await runHook(forgeConfig, 'postStart', spawnedPluginChild);
-      return spawnedPluginChild;
-    }
-
-    if (!electronExecPath) {
-      electronExecPath = await locateElectronExecutable(dir, packageJSON);
-    }
-
-    d('Electron binary path:', electronExecPath);
-
-    const spawnOpts = {
-      cwd: dir,
-      stdio: 'inherit',
-      env: {
-        ...process.env,
-        ...(enableLogging
-          ? {
-              ELECTRON_ENABLE_LOGGING: 'true',
-              ELECTRON_ENABLE_STACK_DUMPING: 'true',
-            }
-          : {}),
-      } as NodeJS.ProcessEnv,
+      rendererSilent: !interactive,
+      rendererFallback: Boolean(process.env.DEBUG),
     };
 
-    if (runAsNode) {
-      spawnOpts.env.ELECTRON_RUN_AS_NODE = 'true';
-    } else {
-      delete spawnOpts.env.ELECTRON_RUN_AS_NODE;
-    }
+    const runner = new Listr<StartContext>(
+      [
+        {
+          title: 'Locating application',
+          task: childTrace<Parameters<ForgeListrTaskFn<StartContext>>>({ name: 'locate-application', category: '@electron-forge/core' }, async (_, ctx) => {
+            const resolvedDir = await resolveDir(providedDir);
+            if (!resolvedDir) {
+              throw new Error('Failed to locate startable Electron application');
+            }
+            ctx.dir = resolvedDir;
+          }),
+        },
+        {
+          title: 'Loading configuration',
+          task: childTrace<Parameters<ForgeListrTaskFn<StartContext>>>({ name: 'load-forge-config', category: '@electron-forge/core' }, async (_, ctx) => {
+            const { dir } = ctx;
+            ctx.forgeConfig = await getForgeConfig(dir);
+            ctx.packageJSON = await readMutatedPackageJson(dir, ctx.forgeConfig);
 
-    if (inspect) {
-      args = ['--inspect' as string | number].concat(args);
-    }
-    if (inspectBrk) {
-      args = ['--inspect-brk' as string | number].concat(args);
-    }
+            if (!ctx.packageJSON.version) {
+              throw new Error(`Please set your application's 'version' in '${dir}/package.json'.`);
+            }
+          }),
+        },
+        {
+          title: 'Preparing native dependencies',
+          task: childTrace<Parameters<ForgeListrTaskFn<StartContext>>>(
+            { name: 'prepare-native-dependencies', category: '@electron-forge/core' },
+            async (_, { dir, forgeConfig, packageJSON }, task) => {
+              await listrCompatibleRebuildHook(
+                dir,
+                await getElectronVersion(dir, packageJSON),
+                platform as ForgePlatform,
+                arch as ForgeArch,
+                forgeConfig.rebuildConfig,
+                task as any
+              );
+            }
+          ),
+          options: {
+            persistentOutput: true,
+            bottomBar: Infinity,
+            showTimer: true,
+          },
+        },
+        {
+          title: `Running ${chalk.yellow('generateAssets')} hook`,
+          task: childTrace<Parameters<ForgeListrTaskFn<StartContext>>>(
+            { name: 'run-generateAssets-hook', category: '@electron-forge/core' },
+            async (childTrace, { forgeConfig }, task) => {
+              return delayTraceTillSignal(childTrace, task.newListr(await getHookListrTasks(childTrace, forgeConfig, 'generateAssets', platform, arch)), 'run');
+            }
+          ),
+        },
+      ],
+      listrOptions
+    );
 
-    const spawned = spawn(
-      electronExecPath!, // eslint-disable-line @typescript-eslint/no-non-null-assertion
-      prefixArgs.concat([appPath]).concat(args as string[]),
-      spawnOpts as SpawnOptions
-    ) as ElectronProcess;
+    await runner.run();
 
-    await runHook(forgeConfig, 'postStart', spawned);
-    return spawned;
-  };
+    const { dir, forgeConfig, packageJSON } = runner.ctx;
+    let lastSpawned: ElectronProcess | null = null;
 
-  const forgeSpawnWrapper = async () => {
-    const spawned = await forgeSpawn();
-    // When the child app is closed we should stop listening for stdin
-    if (spawned) {
-      if (interactive && process.stdin.isPaused()) {
-        process.stdin.resume();
-      }
-      spawned.on('exit', () => {
-        if (spawned.restarted) {
-          return;
+    const forgeSpawn = async () => {
+      let electronExecPath: string | null = null;
+
+      // If a plugin has taken over the start command let's stop here
+      let spawnedPluginChild = await forgeConfig.pluginInterface.overrideStartLogic({
+        dir,
+        appPath,
+        interactive,
+        enableLogging,
+        args,
+        runAsNode,
+        inspect,
+        inspectBrk,
+      });
+      if (typeof spawnedPluginChild === 'object' && 'tasks' in spawnedPluginChild) {
+        const innerRunner = new Listr<never>([], listrOptions);
+        for (const task of spawnedPluginChild.tasks) {
+          innerRunner.add(task);
         }
+        await innerRunner.run();
+        spawnedPluginChild = spawnedPluginChild.result;
+      }
+      let prefixArgs: string[] = [];
+      if (typeof spawnedPluginChild === 'string') {
+        electronExecPath = spawnedPluginChild;
+      } else if (Array.isArray(spawnedPluginChild)) {
+        [electronExecPath, ...prefixArgs] = spawnedPluginChild;
+      } else if (spawnedPluginChild) {
+        await runHook(forgeConfig, 'postStart', spawnedPluginChild);
+        return spawnedPluginChild;
+      }
 
-        if (interactive && !process.stdin.isPaused()) {
-          process.stdin.pause();
+      if (!electronExecPath) {
+        electronExecPath = await locateElectronExecutable(dir, packageJSON);
+      }
+
+      d('Electron binary path:', electronExecPath);
+
+      const spawnOpts = {
+        cwd: dir,
+        stdio: 'inherit',
+        env: {
+          ...process.env,
+          ...(enableLogging
+            ? {
+                ELECTRON_ENABLE_LOGGING: 'true',
+                ELECTRON_ENABLE_STACK_DUMPING: 'true',
+              }
+            : {}),
+        } as NodeJS.ProcessEnv,
+      };
+
+      if (runAsNode) {
+        spawnOpts.env.ELECTRON_RUN_AS_NODE = 'true';
+      } else {
+        delete spawnOpts.env.ELECTRON_RUN_AS_NODE;
+      }
+
+      if (inspect) {
+        args = ['--inspect' as string | number].concat(args);
+      }
+      if (inspectBrk) {
+        args = ['--inspect-brk' as string | number].concat(args);
+      }
+
+      const spawned = spawn(
+        electronExecPath!, // eslint-disable-line @typescript-eslint/no-non-null-assertion
+        prefixArgs.concat([appPath]).concat(args as string[]),
+        spawnOpts as SpawnOptions
+      ) as ElectronProcess;
+
+      await runHook(forgeConfig, 'postStart', spawned);
+      return spawned;
+    };
+
+    const forgeSpawnWrapper = async () => {
+      const spawned = await forgeSpawn();
+      // When the child app is closed we should stop listening for stdin
+      if (spawned) {
+        if (interactive && process.stdin.isPaused()) {
+          process.stdin.resume();
+        }
+        spawned.on('exit', () => {
+          if (spawned.restarted) {
+            return;
+          }
+
+          if (interactive && !process.stdin.isPaused()) {
+            process.stdin.pause();
+          }
+        });
+      } else if (interactive && !process.stdin.isPaused()) {
+        process.stdin.pause();
+      }
+
+      lastSpawned = spawned;
+      return lastSpawned;
+    };
+
+    if (interactive) {
+      process.stdin.on('data', async (data) => {
+        if (data.toString().trim() === 'rs' && lastSpawned) {
+          console.info(chalk.cyan('\nRestarting App\n'));
+          lastSpawned.restarted = true;
+          lastSpawned.kill('SIGTERM');
+          lastSpawned.emit('restarted', await forgeSpawnWrapper());
         }
       });
-    } else if (interactive && !process.stdin.isPaused()) {
-      process.stdin.pause();
+      process.stdin.resume();
     }
 
-    lastSpawned = spawned;
-    return lastSpawned;
-  };
+    const spawned = await forgeSpawnWrapper();
 
-  if (interactive) {
-    process.stdin.on('data', async (data) => {
-      if (data.toString().trim() === 'rs' && lastSpawned) {
-        console.info(chalk.cyan('\nRestarting App\n'));
-        lastSpawned.restarted = true;
-        lastSpawned.kill('SIGTERM');
-        lastSpawned.emit('restarted', await forgeSpawnWrapper());
-      }
-    });
-    process.stdin.resume();
+    if (interactive) console.log('');
+
+    return spawned;
   }
-
-  const spawned = await forgeSpawnWrapper();
-
-  if (interactive) console.log('');
-
-  return spawned;
-};
+);

--- a/packages/api/core/src/util/plugin-interface.ts
+++ b/packages/api/core/src/util/plugin-interface.ts
@@ -10,6 +10,7 @@ import {
   ResolvedForgeConfig,
   StartResult,
 } from '@electron-forge/shared-types';
+import { autoTrace } from '@electron-forge/tracer';
 import chalk from 'chalk';
 import debug from 'debug';
 
@@ -82,6 +83,7 @@ export default class PluginInterface implements IForgePluginInterface {
   }
 
   async getHookListrTasks<Hook extends keyof ForgeSimpleHookSignatures>(
+    childTrace: typeof autoTrace,
     hookName: Hook,
     hookArgs: ForgeSimpleHookSignatures[Hook]
   ): Promise<ForgeListrTaskDefinition[]> {
@@ -95,14 +97,17 @@ export default class PluginInterface implements IForgePluginInterface {
           for (const hook of hooks) {
             tasks.push({
               title: `${chalk.cyan(`[plugin-${plugin.name}]`)} ${(hook as any).__hookName || `Running ${chalk.yellow(hookName)} hook`}`,
-              task: async (_, task) => {
-                if ((hook as any).__hookName) {
-                  // Also give it the task
-                  await (hook as any).call(task, this.config, ...(hookArgs as any[]));
-                } else {
-                  await hook(this.config, ...hookArgs);
+              task: childTrace(
+                { name: 'forge-plugin-hook', category: '@electron-forge/hooks', extraDetails: { plugin: plugin.name, hook: hookName } },
+                async (_, task) => {
+                  if ((hook as any).__hookName) {
+                    // Also give it the task
+                    await (hook as any).call(task, this.config, ...(hookArgs as any[]));
+                  } else {
+                    await hook(this.config, ...hookArgs);
+                  }
                 }
-              },
+              ),
               options: {},
             });
           }

--- a/packages/api/core/src/util/plugin-interface.ts
+++ b/packages/api/core/src/util/plugin-interface.ts
@@ -99,7 +99,7 @@ export default class PluginInterface implements IForgePluginInterface {
               title: `${chalk.cyan(`[plugin-${plugin.name}]`)} ${(hook as any).__hookName || `Running ${chalk.yellow(hookName)} hook`}`,
               task: childTrace(
                 { name: 'forge-plugin-hook', category: '@electron-forge/hooks', extraDetails: { plugin: plugin.name, hook: hookName } },
-                async (_, task) => {
+                async (_, __, task) => {
                   if ((hook as any).__hookName) {
                     // Also give it the task
                     await (hook as any).call(task, this.config, ...(hookArgs as any[]));

--- a/packages/api/core/test/fast/publish_spec.ts
+++ b/packages/api/core/test/fast/publish_spec.ts
@@ -112,7 +112,7 @@ describe('publish', () => {
   });
 
   it('should call the resolved publisher with the appropriate args', async () => {
-    makeStub.onCall(0).callsArgWith(1, [{ artifacts: ['artifact1', 'artifact2'] }]);
+    makeStub.onCall(0).callsArgWith(2, [{ artifacts: ['artifact1', 'artifact2'] }]);
     await publish({
       dir: __dirname,
       interactive: false,
@@ -136,7 +136,7 @@ describe('publish', () => {
   });
 
   it('should call the provided publisher with the appropriate args', async () => {
-    makeStub.onCall(0).callsArgWith(1, [{ artifacts: ['artifact1', 'artifact2'] }]);
+    makeStub.onCall(0).callsArgWith(2, [{ artifacts: ['artifact1', 'artifact2'] }]);
     await publish({
       dir: __dirname,
       interactive: false,
@@ -234,8 +234,8 @@ describe('publish', () => {
 
     describe('when creating a dry run', () => {
       beforeEach(async () => {
-        makeStub.onCall(0).callsArgWith(1, fakeMake('darwin'));
-        makeStub.onCall(1).callsArgWith(1, fakeMake('win32'));
+        makeStub.onCall(0).callsArgWith(2, fakeMake('darwin'));
+        makeStub.onCall(1).callsArgWith(2, fakeMake('win32'));
 
         const dryPath = path.resolve(dir, 'out', 'publish-dry-run');
         await fs.mkdirs(dryPath);

--- a/packages/utils/tracer/package.json
+++ b/packages/utils/tracer/package.json
@@ -1,17 +1,14 @@
 {
-  "name": "@electron-forge/shared-types",
+  "name": "@electron-forge/tracer",
   "version": "6.4.2",
-  "description": "Shared types across Electron Forge",
+  "description": "Tracing helpers for Electron Forge",
   "repository": "https://github.com/electron/forge",
   "author": "Samuel Attard",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "dependencies": {
-    "@electron-forge/tracer": "6.4.2",
-    "@electron/rebuild": "^3.2.10",
-    "electron-packager": "^17.1.2",
-    "listr2": "^5.0.3"
+    "chrome-trace-event": "^1.0.3"
   },
   "engines": {
     "node": ">= 14.17.5"

--- a/packages/utils/tracer/src/index.ts
+++ b/packages/utils/tracer/src/index.ts
@@ -1,0 +1,75 @@
+import * as fs from 'fs';
+
+import { Fields, Tracer } from 'chrome-trace-event';
+
+const store = global as any;
+store._forgeTracer = store._forgeTracer || {
+  tracer: new Tracer(),
+  traceIdCounter: 1,
+};
+const forgeTracer: {
+  tracer: Tracer;
+  traceIdCounter: number;
+} = store._forgeTracer;
+
+if (process.env.ELECTRON_FORGE_TRACE_FILE) {
+  store._forgeTracer.pipe(fs.createWriteStream(process.env.ELECTRON_FORGE_TRACE_FILE));
+}
+
+const nextRoot = () => `forge-auto-trace-root-${forgeTracer.traceIdCounter++}`;
+
+type TraceOptions = {
+  name: string;
+  category: string;
+  extraDetails?: Record<string, string>;
+  newRoot?: boolean;
+};
+
+function _autoTrace<Args extends any[], R = void>(
+  tracer: Tracer,
+  autoTraceId: string,
+  opts: TraceOptions,
+  fn: (childTrace: typeof autoTrace, ...args: Args) => R
+): (...args: Args) => R {
+  return (async (...args: Args) => {
+    const traceArgs: Fields = {
+      id: autoTraceId,
+      name: opts.name,
+      cat: [opts.category],
+      args: opts.extraDetails,
+      tid: autoTraceId.split('-')[autoTraceId.split('-').length - 1],
+    };
+    tracer.begin(traceArgs);
+    const childTrace = (opts: TraceOptions, fn: any) => {
+      return _autoTrace(tracer.child(traceArgs), opts.newRoot ? nextRoot() : autoTraceId, opts, fn);
+    };
+    (childTrace as any)._autoEnd = true;
+    (childTrace as any)._end = () => tracer.end(traceArgs);
+    try {
+      return await Promise.resolve(fn(childTrace as any, ...args));
+    } finally {
+      if ((childTrace as any)._autoEnd) {
+        (childTrace as any)._end();
+      }
+    }
+  }) as any;
+}
+
+export function delayTraceTillSignal<O extends object, K extends keyof O>(trace: typeof autoTrace, signaller: O, signal: K) {
+  const original: any = signaller[signal];
+  (trace as any)._autoEnd = false;
+  signaller[signal] = function (...args: any[]) {
+    const result = original.call(signaller, ...args);
+    if (typeof result === 'object' && result.then && result.catch) {
+      result.then(() => (trace as any)._end()).catch(() => (trace as any)._end());
+    } else {
+      (trace as any)._end();
+    }
+    return result;
+  } as any;
+  return signaller;
+}
+
+export function autoTrace<Args extends any[], R = void>(opts: TraceOptions, fn: (childTrace: typeof autoTrace, ...args: Args) => R): (...args: Args) => R {
+  return _autoTrace(forgeTracer.tracer, nextRoot(), opts, fn as any);
+}

--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -1,10 +1,12 @@
 import { ChildProcess } from 'child_process';
 
+import { autoTrace } from '@electron-forge/tracer';
 import { RebuildOptions } from '@electron/rebuild';
 import { ArchOption, Options as ElectronPackagerOptions, TargetPlatform } from 'electron-packager';
 import { ListrDefaultRenderer, ListrTask, ListrTaskWrapper } from 'listr2';
 
 export type ForgeListrTask<T> = ListrTaskWrapper<T, ListrDefaultRenderer>;
+export type ForgeListrTaskFn<Ctx = any> = ListrTask<Ctx, ListrDefaultRenderer>['task'];
 export type ElectronProcess = ChildProcess & { restarted: boolean };
 
 export type ForgePlatform = TargetPlatform;
@@ -61,6 +63,7 @@ export type ForgeMultiHookMap = {
 export interface IForgePluginInterface {
   triggerHook<Hook extends keyof ForgeSimpleHookSignatures>(hookName: Hook, hookArgs: ForgeSimpleHookSignatures[Hook]): Promise<void>;
   getHookListrTasks<Hook extends keyof ForgeSimpleHookSignatures>(
+    childTrace: typeof autoTrace,
     hookName: Hook,
     hookArgs: ForgeSimpleHookSignatures[Hook]
   ): Promise<ForgeListrTaskDefinition[]>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4401,7 +4401,7 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chrome-trace-event@^1.0.2:
+chrome-trace-event@^1.0.2, chrome-trace-event@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"
   integrity sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==


### PR DESCRIPTION
Please review this diff with whitespace disabled 🙇 

This is kinda ready but also kinda a WIP, this adds all the tracing but no flags for actually getting the trace output.  Just want folks thoughts on the approach

<img width="1503" alt="image" src="https://github.com/electron/forge/assets/6634592/640da6d3-d181-4e66-80ed-bc84e124920c">

The idea here is the sub ecosystem modules + makers + publishers + plugins will also call into `@electron-forge/tracer`