### PR TITLE
fix(plugin-fuses): use target platform in the executable path

### DIFF
--- a/packages/plugin/fuses/src/util/getElectronExecutablePath.ts
+++ b/packages/plugin/fuses/src/util/getElectronExecutablePath.ts
@@ -9,5 +9,10 @@ type GetElectronExecutablePathParams = {
 };
 
 export function getElectronExecutablePath({ appName, basePath, platform }: GetElectronExecutablePathParams): string {
-  return path.join(basePath, ['darwin', 'mas'].includes(platform) ? path.join('MacOS', appName) : [appName, platform === 'win32' ? '.exe' : ''].join(''));
+  if (['darwin', 'mas'].includes(platform)) {
+    return path.join(basePath, 'MacOS', appName);
+  }
+
+  const suffix = platform === 'win32' ? '.exe' : '';
+  return path.join(basePath, `${appName}${suffix}`);
 }

--- a/packages/plugin/fuses/src/util/getElectronExecutablePath.ts
+++ b/packages/plugin/fuses/src/util/getElectronExecutablePath.ts
@@ -9,8 +9,5 @@ type GetElectronExecutablePathParams = {
 };
 
 export function getElectronExecutablePath({ appName, basePath, platform }: GetElectronExecutablePathParams): string {
-  return path.join(
-    basePath,
-    ['darwin', 'mas'].includes(platform) ? path.join('MacOS', appName) : [appName, process.platform === 'win32' ? '.exe' : ''].join('')
-  );
+  return path.join(basePath, ['darwin', 'mas'].includes(platform) ? path.join('MacOS', appName) : [appName, platform === 'win32' ? '.exe' : ''].join(''));
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
We're using the host platform instead of the target platform to get the binary path, which results in an incorrect path when making for a different platform (like `/path/to/electron.exe` instead of `/path/to/electron` when making for Linux on Windows).