### PR TITLE
refactor(core): allow restart logic to be triggered using an event

### DIFF
--- a/packages/api/core/src/api/index.ts
+++ b/packages/api/core/src/api/index.ts
@@ -7,7 +7,7 @@ import init, { InitOptions } from './init';
 import make, { MakeOptions } from './make';
 import _package, { PackageOptions } from './package';
 import publish, { PublishOptions } from './publish';
-import start, { StartOptions } from './start';
+import start, { restartApp, StartOptions } from './start';
 
 export class ForgeAPI {
   /**
@@ -61,4 +61,17 @@ export class ForgeAPI {
 const api = new ForgeAPI();
 const utils = new ForgeUtils();
 
-export { ForgeMakeResult, ElectronProcess, ForgeUtils, ImportOptions, InitOptions, MakeOptions, PackageOptions, PublishOptions, StartOptions, api, utils };
+export {
+  ElectronProcess,
+  ForgeMakeResult,
+  ForgeUtils,
+  ImportOptions,
+  InitOptions,
+  MakeOptions,
+  PackageOptions,
+  PublishOptions,
+  StartOptions,
+  api,
+  restartApp,
+  utils,
+};

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -213,14 +213,21 @@ export default autoTrace(
     };
 
     if (interactive) {
-      process.stdin.on('data', async (data) => {
-        if (data.toString().trim() === 'rs' && lastSpawned) {
-          console.info(chalk.cyan('\nRestarting App\n'));
-          lastSpawned.restarted = true;
-          lastSpawned.kill('SIGTERM');
-          lastSpawned.emit('restarted', await forgeSpawnWrapper());
-        }
-      });
+      process.on('FORGE_RESTART_APP', async () => {
+        if (lastSpawned) {
+        console.info(chalk.cyan('\nRestarting App\n'));
+        lastSpawned.restarted = true;
+        lastSpawned.kill('SIGTERM');
+        lastSpawned.emit('restarted', await forgeSpawnWrapper());
+      }
+    });
+
+    process.stdin.on('data', async (data) => {
+      if (data.toString().trim() === 'rs') {
+        process.emit('FORGE_RESTART_APP');
+      }
+    });
+
       process.stdin.resume();
     }
 

--- a/typings/nodejs/index.d.ts
+++ b/typings/nodejs/index.d.ts
@@ -1,0 +1,7 @@
+declare namespace NodeJS {
+  interface Process extends EventEmitter {
+    emit(event: 'FORGE_RESTART_APP'): boolean;
+
+    on(event: 'FORGE_RESTART_APP', listener: () => void): NodeJS.Process;
+  }
+}

--- a/typings/nodejs/index.d.ts
+++ b/typings/nodejs/index.d.ts
@@ -1,7 +1,0 @@
-declare namespace NodeJS {
-  interface Process extends EventEmitter {
-    emit(event: 'FORGE_RESTART_APP'): boolean;
-
-    on(event: 'FORGE_RESTART_APP', listener: () => void): NodeJS.Process;
-  }
-}


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
This allows the restart event to be triggered from anywhere in Forge and should make it possible for @caoxiemeihao to address the `process.stdin.emit` issue mentioned in https://github.com/electron/forge/pull/3203#discussion_r1319202584:
> Ideally, we should instead expose additional start logic from the @electron-forge/core API to expose this functionality so that plugins can hook into it.

At first, I was thinking of creating a dedicated `EventEmitter` instance for this, but `process` _is_ an event emitter and is available everywhere, so that makes things simpler if a bit hacky.