### PR TITLE
fix: Replace spaces in package directory name with a hyphen

### DIFF
--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -17,6 +17,7 @@ import parseArchs from '../util/parse-archs';
 import { readMutatedPackageJson } from '../util/read-package-json';
 import requireSearch from '../util/require-search';
 import resolveDir from '../util/resolve-dir';
+import getSafeDirName from '../util/safe-dir-name';
 
 import { listrPackage } from './package';
 
@@ -241,7 +242,8 @@ export const listrMake = (
           });
 
           for (const targetArch of parseArchs(platform, arch, await getElectronVersion(dir, packageJSON))) {
-            const packageDir = path.resolve(actualOutDir, `${appName}-${platform}-${targetArch}`);
+            const dirName = getSafeDirName(`${appName}-${platform}-${targetArch}`);
+            const packageDir = path.resolve(actualOutDir, dirName);
             if (!(await fs.pathExists(packageDir))) {
               throw new Error(`Couldn't find packaged app at: ${packageDir}`);
             }

--- a/packages/api/core/src/util/safe-dir-name.ts
+++ b/packages/api/core/src/util/safe-dir-name.ts
@@ -1,0 +1,12 @@
+import filenamify from 'filenamify';
+
+/**
+ * Returns a name safe to be used as a directory. This
+ * boils down to filenamify but with spaces replaced, too.
+ *
+ * @param input
+ * @returns {string}
+ */
+export default function getSafeDirName(input: string): string {
+  return filenamify(input, { replacement: '-' }).replace(/ /g, '-');
+}

--- a/packages/api/core/test/fast/safe-dir-name_spec.ts
+++ b/packages/api/core/test/fast/safe-dir-name_spec.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+
+import getSafeDirName from '../../src/util/safe-dir-name';
+
+describe('getSafeDirName', () => {
+  it('returns a safe dir name', () => {
+    const appName = 'My Co/ol App';
+    const dirName = getSafeDirName(appName);
+
+    expect(dirName).to.equal('My-Co-ol-App');
+  });
+});


### PR DESCRIPTION
If your app's name contains a space, [the temporary package directory will also contain a space](https://github.com/electron/forge/blob/739c5904f5643f6c476bbdc0bae78c21af40f3c6/packages/api/core/src/api/make.ts#L244). That works fine for everything Electron and Node, but if you have a native module that uses the classic gyp/make combo, paths with spaces are not allowed and things will break. An earlier filenamify does not replace spaces because spaces are generally legal, they just break (some) native module builds.

With this PR, spaces in your app name in `packageDir` will be replaced with a `-`, just the same we replace other special characters. 

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:** fix: Don't create package directories with spaces
