### PR TITLE
fix(maker-dmg): make 'name' optional in DMGContents interface

### DIFF
--- a/packages/maker/dmg/src/Config.ts
+++ b/packages/maker/dmg/src/Config.ts
@@ -8,7 +8,7 @@ export interface DMGContents {
   y: number;
   type: 'link' | 'file' | 'position';
   path: string;
-  name: string;
+  name?: string;
 }
 
 export interface WindowPositionOptions {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This PR updates the `DMGContents` interface to align with the [appdmg](https://github.com/LinusU/node-appdmg#specification) dependency, where the `name` property is optional. 
