### PR TITLE
fix(template-webpack-typescript): use fork-ts-checker-webpack-plugin in main webpack config

### DIFF
--- a/packages/template/webpack-typescript/tmpl/webpack.main.config.ts
+++ b/packages/template/webpack-typescript/tmpl/webpack.main.config.ts
@@ -1,6 +1,7 @@
 import type { Configuration } from 'webpack';
 
 import { rules } from './webpack.rules';
+import { plugins } from './webpack.plugins';
 
 export const mainConfig: Configuration = {
   /**
@@ -12,6 +13,7 @@ export const mainConfig: Configuration = {
   module: {
     rules,
   },
+  plugins,
   resolve: {
     extensions: ['.js', '.ts', '.jsx', '.tsx', '.css', '.json'],
   },


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

This PR modifies the the `webpack-typescript` template to enable type-checking in the main webpack config, rather than just the renderer's webpack config. Without this change, Typescript compile errors in both the renderer and main process Typescript files did not appear to get printed anywhere at all. @MarshallOfSound did you verify that type-checking worked in the original version of the `typescript-webpack` template?

With this change, Typescript errors in either the renderer or main process source code get printed to the console that `npm start` is launched from.