### PR TITLE
fix(publisher-github): update error message to reflect the correct property names

### DIFF
--- a/packages/publisher/github/src/PublisherGithub.ts
+++ b/packages/publisher/github/src/PublisherGithub.ts
@@ -36,7 +36,7 @@ export default class PublisherGithub extends PublisherBase<PublisherGitHubConfig
 
     if (!(config.repository && typeof config.repository === 'object' && config.repository.owner && config.repository.name)) {
       throw new Error(
-        'In order to publish to github you must set the "github_repository.owner" and "github_repository.name" properties in your Forge config. See the docs for more info'
+        'In order to publish to Github, you must set the "repository.owner" and "repository.name" properties in your Forge config. See the docs for more info'
       );
     }
 

--- a/packages/publisher/github/src/PublisherGithub.ts
+++ b/packages/publisher/github/src/PublisherGithub.ts
@@ -36,7 +36,7 @@ export default class PublisherGithub extends PublisherBase<PublisherGitHubConfig
 
     if (!(config.repository && typeof config.repository === 'object' && config.repository.owner && config.repository.name)) {
       throw new Error(
-        'In order to publish to Github, you must set the "repository.owner" and "repository.name" properties in your Forge config. See the docs for more info'
+        'In order to publish to GitHub, you must set the "repository.owner" and "repository.name" properties in your Forge config. See the docs for more info'
       );
     }
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Fixing a misleading error message I came across in https://github.com/electron/forge/issues/3392