### PR TITLE
chore: fix sha1 for `packageManager`

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
   "prettier": {
     "singleQuote": true
   },
-  "packageManager": "yarn@1.22.18+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447",
+  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447",
   "workspaces": {
     "packages": [
       "packages/api/*",


### PR DESCRIPTION
fast follow-up to a typo in #3359