### PR TITLE
refactor: dedupe key resolver for static publishers

### DIFF
--- a/packages/publisher/base-static/package.json
+++ b/packages/publisher/base-static/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@electron-forge/publisher-static",
+  "version": "7.1.0",
+  "description": "Base publisher for Electron Forge",
+  "repository": "https://github.com/electron/forge",
+  "author": "Samuel Attard",
+  "license": "MIT",
+  "main": "dist/PublisherStatic.js",
+  "typings": "dist/PublisherStatic.d.ts",
+  "scripts": {
+    "test": "yarn test:base test/**/*_spec.ts",
+    "test:base": "cross-env TS_NODE_FILES=1 mocha --config ../../../.mocharc.js"
+  },
+  "dependencies": {
+    "@electron-forge/publisher-base": "7.1.0",
+    "@electron-forge/shared-types": "7.1.0"
+  },
+  "devDependencies": {
+    "chai": "^4.3.3",
+    "mocha": "^9.0.1"
+  },
+  "engines": {
+    "node": ">= 16.4.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "src"
+  ]
+}

--- a/packages/publisher/base-static/src/PublisherStatic.ts
+++ b/packages/publisher/base-static/src/PublisherStatic.ts
@@ -1,0 +1,30 @@
+import path from 'path';
+
+import { PublisherBase, PublisherOptions } from '@electron-forge/publisher-base';
+import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';
+
+interface StaticArtifact {
+  path: string;
+  platform: ForgePlatform;
+  arch: ForgeArch;
+  keyPrefix: string;
+}
+
+interface StaticPublisherConfig {
+  /**
+   * Custom function to provide the key to upload a given file to
+   */
+  keyResolver?: (fileName: string, platform: string, arch: string) => string;
+}
+
+export default abstract class PublisherStatic<C extends StaticPublisherConfig> extends PublisherBase<C> {
+  protected keyForArtifact(artifact: StaticArtifact): string {
+    if (this.config.keyResolver) {
+      return this.config.keyResolver(path.basename(artifact.path), artifact.platform, artifact.arch);
+    }
+
+    return `${artifact.keyPrefix}/${artifact.platform}/${artifact.arch}/${path.basename(artifact.path)}`;
+  }
+}
+
+export { PublisherStatic, StaticPublisherConfig, PublisherOptions };

--- a/packages/publisher/base-static/test/StaticPublisher_spec.ts
+++ b/packages/publisher/base-static/test/StaticPublisher_spec.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+
+import { PublisherStatic, StaticPublisherConfig } from '../src/PublisherStatic';
+
+class PublisherImpl extends PublisherStatic<StaticPublisherConfig> {
+  defaultPlatforms = [];
+
+  name = 'test';
+
+  public exposedKeyForArtifact = this.keyForArtifact;
+}
+
+describe('PublisherStatic', () => {
+  describe('keyForArtifact', () => {
+    it('should by default concat prefix, platform, arch and filename', () => {
+      const publisher = new PublisherImpl({});
+      expect(
+        publisher.exposedKeyForArtifact({
+          platform: 'plat',
+          arch: 'arch',
+          keyPrefix: 'stuff',
+          path: __filename,
+        })
+      ).to.equal('stuff/plat/arch/StaticPublisher_spec.ts');
+    });
+
+    it('should call the provided method', () => {
+      const publisher = new PublisherImpl({
+        keyResolver: () => 'lololol',
+      });
+      expect(
+        publisher.exposedKeyForArtifact({
+          platform: 'plat',
+          arch: 'arch',
+          keyPrefix: 'stuff',
+          path: __filename,
+        })
+      ).to.equal('lololol');
+    });
+  });
+});

--- a/packages/publisher/gcs/package.json
+++ b/packages/publisher/gcs/package.json
@@ -15,7 +15,7 @@
     "node": ">= 16.4.0"
   },
   "dependencies": {
-    "@electron-forge/publisher-base": "7.1.0",
+    "@electron-forge/publisher-static": "7.1.0",
     "@electron-forge/shared-types": "7.1.0",
     "@google-cloud/storage": "^7.5.0",
     "debug": "^4.3.1"

--- a/packages/publisher/gcs/src/PublisherGCS.ts
+++ b/packages/publisher/gcs/src/PublisherGCS.ts
@@ -1,6 +1,4 @@
-import path from 'path';
-
-import { PublisherBase, PublisherOptions } from '@electron-forge/publisher-base';
+import { PublisherOptions, PublisherStatic } from '@electron-forge/publisher-static';
 import { Storage } from '@google-cloud/storage';
 import debug from 'debug';
 
@@ -15,7 +13,7 @@ type GCSArtifact = {
   arch: string;
 };
 
-export default class PublisherGCS extends PublisherBase<PublisherGCSConfig> {
+export default class PublisherGCS extends PublisherStatic<PublisherGCSConfig> {
   name = 'gcs';
 
   private GCSKeySafe = (key: string) => {
@@ -66,14 +64,6 @@ export default class PublisherGCS extends PublisherBase<PublisherGCSConfig> {
         updateStatusLine();
       })
     );
-  }
-
-  keyForArtifact(artifact: GCSArtifact): string {
-    if (this.config.keyResolver) {
-      return this.config.keyResolver(path.basename(artifact.path), artifact.platform, artifact.arch);
-    }
-
-    return `${artifact.keyPrefix}/${artifact.platform}/${artifact.arch}/${path.basename(artifact.path)}`;
   }
 }
 

--- a/packages/publisher/s3/package.json
+++ b/packages/publisher/s3/package.json
@@ -19,7 +19,7 @@
     "@aws-sdk/client-s3": "^3.28.0",
     "@aws-sdk/lib-storage": "^3.28.0",
     "@aws-sdk/types": "^3.25.0",
-    "@electron-forge/publisher-base": "7.1.0",
+    "@electron-forge/publisher-static": "7.1.0",
     "@electron-forge/shared-types": "7.1.0",
     "debug": "^4.3.1"
   },

--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { S3Client } from '@aws-sdk/client-s3';
 import { Progress, Upload } from '@aws-sdk/lib-storage';
 import { Credentials } from '@aws-sdk/types';
-import { PublisherBase, PublisherOptions } from '@electron-forge/publisher-base';
+import { PublisherOptions, PublisherStatic } from '@electron-forge/publisher-static';
 import debug from 'debug';
 
 import { PublisherS3Config } from './Config';
@@ -18,7 +18,7 @@ type S3Artifact = {
   arch: string;
 };
 
-export default class PublisherS3 extends PublisherBase<PublisherS3Config> {
+export default class PublisherS3 extends PublisherStatic<PublisherS3Config> {
   name = 's3';
 
   private s3KeySafe = (key: string) => {
@@ -82,14 +82,6 @@ export default class PublisherS3 extends PublisherBase<PublisherS3Config> {
         updateStatusLine();
       })
     );
-  }
-
-  keyForArtifact(artifact: S3Artifact): string {
-    if (this.config.keyResolver) {
-      return this.config.keyResolver(path.basename(artifact.path), artifact.platform, artifact.arch);
-    }
-
-    return `${artifact.keyPrefix}/${artifact.platform}/${artifact.arch}/${path.basename(artifact.path)}`;
   }
 
   generateCredentials(): Credentials | undefined {


### PR DESCRIPTION
Bit of some fancy class inheritance stuff going on here 😆 But basically all to dedupe the key resolver logic for the two static publishers we have and I guess all future ones we add / others want to make