### PR TITLE
fix: handle webpack configs exported as default

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -79,7 +79,7 @@ export default class WebpackConfigGenerator {
           (require(path.resolve(this.projectDir, config)) as MaybeESM<Configuration | ConfigurationFactory>)
         : config;
 
-    if ('default' in rawConfig) {
+    if (rawConfig && typeof rawConfig === 'object' && 'default' in rawConfig) {
       rawConfig = rawConfig.default;
     }
 

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -71,11 +71,17 @@ export default class WebpackConfigGenerator {
   }
 
   async resolveConfig(config: Configuration | ConfigurationFactory | string): Promise<Configuration> {
-    const rawConfig =
+    type MaybeESM<T> = T | { default: T };
+
+    let rawConfig =
       typeof config === 'string'
         ? // eslint-disable-next-line @typescript-eslint/no-var-requires
-          (require(path.resolve(this.projectDir, config)) as Configuration | ConfigurationFactory)
+          (require(path.resolve(this.projectDir, config)) as MaybeESM<Configuration | ConfigurationFactory>)
         : config;
+
+    if ('default' in rawConfig) {
+      rawConfig = rawConfig.default;
+    }
 
     return processConfig(this.preprocessConfig, rawConfig);
   }

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -277,6 +277,19 @@ describe('WebpackConfigGenerator', () => {
       expect(webpackConfig.entry).to.equal(path.resolve(baseDir, 'foo/main.js'));
     });
 
+    it('generates a config from a requirable transpiled module file', async () => {
+      const config = {
+        mainConfig: 'mainConfig.module.js',
+        renderer: {
+          entryPoints: [] as WebpackPluginEntryPoint[],
+        },
+      } as WebpackPluginConfig;
+      const baseDir = path.resolve(__dirname, 'fixtures/main_config_external');
+      const generator = new WebpackConfigGenerator(config, baseDir, true, 3000);
+      const webpackConfig = await generator.getMainConfig();
+      expect(webpackConfig.entry).to.equal(path.resolve(baseDir, 'foo/main.js'));
+    });
+
     it('generates a config from function', async () => {
       const generateWebpackConfig = (webpackConfig: WebpackConfiguration) => {
         const config = {

--- a/packages/plugin/webpack/test/fixtures/main_config_external/mainConfig.module.js
+++ b/packages/plugin/webpack/test/fixtures/main_config_external/mainConfig.module.js
@@ -1,0 +1,3 @@
+module.exports.default = {
+  entry: './foo/main.js',
+};


### PR DESCRIPTION
Although you can do `./webpack.main.config.ts` currently you still have to do `module.exports = config` instead of `export default config`.  This handles the default export in the same way that our forge config resolver does