### PR TITLE
fix: set empty publicPath for preload scripts

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -302,7 +302,7 @@ export default class WebpackConfigGenerator {
         path: path.resolve(this.webpackDir, 'renderer'),
         filename: '[name]/preload.js',
         globalObject: 'self',
-        ...(this.isProd ? {} : { publicPath: '/' }),
+        ...(this.isProd ? { publicPath: '' } : { publicPath: '/' }),
       },
       plugins: target === RendererTarget.ElectronPreload ? [] : [new webpack.ExternalsPlugin('commonjs2', externals)],
     };

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -446,6 +446,7 @@ describe('WebpackConfigGenerator', () => {
         path: path.join(mockProjectDir, '.webpack', 'renderer'),
         filename: '[name]/preload.js',
         globalObject: 'self',
+        publicPath: '',
       });
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(webpackConfig[0].plugins!.length).to.equal(2);
@@ -476,6 +477,7 @@ describe('WebpackConfigGenerator', () => {
         path: path.join(mockProjectDir, '.webpack', 'renderer'),
         filename: '[name]/preload.js',
         globalObject: 'self',
+        publicPath: '',
       });
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(webpackConfig[0].plugins!.length).to.equal(2);


### PR DESCRIPTION
This avoids an error in packaged apps "Automatic publicPath is not supported in this browser".  This is only emitted by sandboxed preload scripts as I guess they struggle to realize they're in a browser 😆 