### PR TITLE
fix(electron-release-publisher): change api/version endpoint in PublisherERS to use versions/sorted

### DIFF
--- a/packages/publisher/electron-release-server/src/PublisherERS.ts
+++ b/packages/publisher/electron-release-server/src/PublisherERS.ts
@@ -96,7 +96,7 @@ export default class PublisherERS extends PublisherBase<PublisherERSConfig> {
       const versions: ERSVersionSorted = await (await authFetch('versions/sorted')).json();
       
       // Find the version with the same name and flavor
-      const existingVersion = versions.items.find((version) => version.name === packageJSON.version && version.flavor.name === flavor);
+      const existingVersion = versions['items'].find((version) => version.name === packageJSON.version && version.flavor.name === flavor);
 
       let channel = 'stable';
       if (config.channel) {

--- a/packages/publisher/electron-release-server/src/PublisherERS.ts
+++ b/packages/publisher/electron-release-server/src/PublisherERS.ts
@@ -26,6 +26,13 @@ interface ERSVersion {
   flavor: ERSFlavor;
 }
 
+interface ERSVersionSorted {
+  total: number;
+  offset: number;
+  page: number;
+  items: ERSVersion[];
+}
+
 const fetchAndCheckStatus = async (url: RequestInfo, init?: RequestInit): Promise<Response> => {
   const result = await fetch(url, init);
   if (result.ok) {
@@ -86,9 +93,10 @@ export default class PublisherERS extends PublisherBase<PublisherERSConfig> {
       const { packageJSON } = makeResult;
       const artifacts = makeResult.artifacts.filter((artifactPath) => path.basename(artifactPath).toLowerCase() !== 'releases');
 
-      const versions: ERSVersion[] = await (await authFetch('api/version')).json();
+      const versions: ERSVersionSorted = await (await authFetch('versions/sorted')).json();
+      
       // Find the version with the same name and flavor
-      const existingVersion = versions.find((version) => version.name === packageJSON.version && version.flavor.name === flavor);
+      const existingVersion = versions.items.find((version) => version.name === packageJSON.version && version.flavor.name === flavor);
 
       let channel = 'stable';
       if (config.channel) {

--- a/packages/publisher/electron-release-server/src/PublisherERS.ts
+++ b/packages/publisher/electron-release-server/src/PublisherERS.ts
@@ -94,7 +94,7 @@ export default class PublisherERS extends PublisherBase<PublisherERSConfig> {
       const artifacts = makeResult.artifacts.filter((artifactPath) => path.basename(artifactPath).toLowerCase() !== 'releases');
 
       const versions: ERSVersionSorted = await (await authFetch('versions/sorted')).json();
-      
+
       // Find the version with the same name and flavor
       const existingVersion = versions['items'].find((version) => version.name === packageJSON.version && version.flavor.name === flavor);
 

--- a/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
+++ b/packages/publisher/electron-release-server/test/PublisherERS_spec.ts
@@ -35,7 +35,10 @@ describe('PublisherERS', () => {
       // mock login
       fetch.postOnce('path:/api/auth/login', { body: { token }, status: 200 });
       // mock fetch all existing versions
-      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [], flavor: { name: 'default' } }], status: 200 });
+      fetch.getOnce('path:/versions/sorted', {
+        body: { total: 1, offset: 0, page: 0, items: [{ name: '2.0.0', assets: [], flavor: { name: 'default' } }] },
+        status: 200,
+      });
       // mock creating a new version
       fetch.postOnce('path:/api/version', { status: 200 });
       // mock asset upload
@@ -83,7 +86,10 @@ describe('PublisherERS', () => {
       // mock login
       fetch.postOnce('path:/api/auth/login', { body: { token }, status: 200 });
       // mock fetch all existing versions
-      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [], flavor: { name: 'lite' } }], status: 200 });
+      fetch.getOnce('path:/versions/sorted', {
+        body: { total: 1, offset: 0, page: 0, items: [{ name: '2.0.0', assets: [], flavor: { name: 'lite' } }] },
+        status: 200,
+      });
       // mock asset upload
       fetch.post('path:/api/asset', { status: 200 });
 
@@ -123,8 +129,13 @@ describe('PublisherERS', () => {
       // mock login
       fetch.postOnce('path:/api/auth/login', { body: { token }, status: 200 });
       // mock fetch all existing versions
-      fetch.getOnce('path:/api/version', {
-        body: [{ name: '2.0.0', assets: [{ name: 'existing-artifact', platform: 'linux_64' }], flavor: { name: 'default' } }],
+      fetch.getOnce('path:/versions/sorted', {
+        body: {
+          total: 1,
+          offset: 0,
+          page: 0,
+          items: [{ name: '2.0.0', assets: [{ name: 'existing-artifact', platform: 'linux_64' }], flavor: { name: 'default' } }],
+        },
         status: 200,
       });
 
@@ -161,7 +172,10 @@ describe('PublisherERS', () => {
       // mock login
       fetch.postOnce('path:/api/auth/login', { body: { token }, status: 200 });
       // mock fetch all existing versions
-      fetch.getOnce('path:/api/version', { body: [{ name: '2.0.0', assets: [{ name: 'existing-artifact' }], flavor: { name: 'default' } }], status: 200 });
+      fetch.getOnce('path:/versions/sorted', {
+        body: { total: 1, offset: 0, page: 0, items: [{ name: '2.0.0', assets: [{ name: 'existing-artifact' }], flavor: { name: 'default' } }] },
+        status: 200,
+      });
       // mock creating a new version
       fetch.postOnce('path:/api/version', { status: 200 });
       // mock asset upload


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [X] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [X] The changes are appropriately documented (if applicable).
- [X] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Issue: https://github.com/electron/forge/issues/3430

Electron Release Server, specifically the Sails blueprint, only allows a maximum of 30 records to be returned on the endpoint **/api/version**. The problem with this is when you call:

`const versions: ERSVersion[] = await (await authFetch('api/version')).json();
`

You get back a random 30 records. If you have 30 or more versions that have been created, this poses a problem. If you don't get the version that you are creating, say, **0.0.1_stable**, on that **/api/version** call, it will try to create it again even though it's already been created in the database. It will result in the error:

`Error: ERS publish failed with status code: 400 (*** /api/version)
`

If you look at the Electron Release Server error, it's giving you:

`AdapterError: Would violate uniqueness constraint-- a record already exists with conflicting value(s).
`

Because the record has been created, but because **/api/version** only returns 30 records, you may not have been given that version on the call, so the check will come back that it does not exist.

**Solution:**

This change simply switches the GET call from **/api/version** to **/versions/sorted**, so you won't run into this issue when you have exceeded 30 versions. The endpoint I changed it to gets all versions using semvr and is documented on Electron Release Server https://github.com/ArekSredzki/electron-release-server/blob/master/docs/api.md

I also updated the type for:

`const versions: ERSVersion[] 
`

so it corresponds correctly with the return value of /versions/sorted from Electron Release Server.

**Images of the errors that get thrown because of this**
![Screenshot 2023-11-29 at 10 09 09 PM](https://github.com/electron/forge/assets/22155915/e62f9e4b-17c2-4066-9028-061a3b302812)
![Screenshot 2023-11-29 at 10 09 14 PM](https://github.com/electron/forge/assets/22155915/31135e69-724c-45d7-a81a-d690295d5c89)
