### PR TITLE
feat(plugin): add setup to rspack plugin

### DIFF
--- a/packages/plugin/rspack/README.md
+++ b/packages/plugin/rspack/README.md
@@ -1,0 +1,29 @@
+## plugin-webpack
+
+This plugin makes it easy to set up standard webpack tooling to compile both your main process code and your renderer process code, with built-in support for Hot Module Replacement (HMR) in the renderer process and support for multiple renderers.
+
+```javascript
+// forge.config.js
+
+module.exports = {
+  plugins: [
+    {
+      name: '@electron-forge/plugin-webpack',
+      config: {
+        mainConfig: './webpack.main.config.js',
+        renderer: {
+          config: './webpack.renderer.config.js',
+          entryPoints: [{
+            name: 'main_window',
+            html: './src/renderer/index.html',
+            js: './src/renderer/index.js',
+            preload: {
+              js: './src/preload.js'
+            }
+          }]
+        }
+      }
+    }
+  ]
+};
+```

--- a/packages/plugin/rspack/README.md
+++ b/packages/plugin/rspack/README.md
@@ -1,4 +1,4 @@
-## plugin-webpack
+## plugin-rspack
 
 This plugin makes it easy to set up standard webpack tooling to compile both your main process code and your renderer process code, with built-in support for Hot Module Replacement (HMR) in the renderer process and support for multiple renderers.
 
@@ -8,11 +8,11 @@ This plugin makes it easy to set up standard webpack tooling to compile both you
 module.exports = {
   plugins: [
     {
-      name: '@electron-forge/plugin-webpack',
+      name: '@electron-forge/plugin-rspack',
       config: {
-        mainConfig: './webpack.main.config.js',
+        mainConfig: './rspack.main.config.js',
         renderer: {
-          config: './webpack.renderer.config.js',
+          config: './rspack.renderer.config.js',
           entryPoints: [{
             name: 'main_window',
             html: './src/renderer/index.html',

--- a/packages/plugin/rspack/package.json
+++ b/packages/plugin/rspack/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@electron-forge/plugin-rspack",
+  "version": "7.2.0",
+  "description": "Rspack plugin for Electron Forge, lets you use Rspack directly in your tooling",
+  "repository": "https://github.com/electron/forge",
+  "author": "noghartt",
+  "license": "MIT",
+  "main": "dist/RspackPlugin.js",
+  "typings": "dist/RspackPlugin.d.ts",
+  "scripts": {
+    "test": "xvfb-maybe mocha --config ../../../.mocharc.js test/**/*_spec.ts test/*_spec.ts"
+  },
+  "engines": {
+    "node": ">= 16.4.0"
+  },
+  "devDependencies": {
+    "@electron/packager": "^18.1.2",
+    "@malept/cross-spawn-promise": "^2.0.0",
+    "@types/node": "^18.0.3",
+    "chai": "^4.3.3",
+    "mocha": "^9.0.1",
+    "sinon": "^13.0.1",
+    "which": "^2.0.2",
+    "xvfb-maybe": "^0.2.1"
+  },
+  "dependencies": {
+    "@electron-forge/core-utils": "7.2.0",
+    "@electron-forge/plugin-base": "7.2.0",
+    "@electron-forge/shared-types": "7.2.0",
+    "@electron-forge/web-multi-logger": "7.2.0",
+    "@rspack/cli": "0.4.4",
+    "@rspack/core": "0.4.4",
+    "@rspack/dev-server": "0.4.4",
+    "chalk": "^4.0.0",
+    "debug": "^4.3.1",
+    "fast-glob": "^3.2.7",
+    "fs-extra": "^10.0.0",
+    "html-webpack-plugin": "^5.5.3",
+    "webpack": "^5.69.1",
+    "webpack-merge": "^5.7.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "src"
+  ]
+}

--- a/packages/plugin/rspack/src/Config.ts
+++ b/packages/plugin/rspack/src/Config.ts
@@ -1,0 +1,127 @@
+import { Configuration as RawRspackConfiguration } from '@rspack/core';
+import { Configuration as RspackDevServerConfiguration } from '@rspack/dev-server';
+
+export type RspackConfigurationFactory = (
+  env: string | Record<string, string | boolean | number> | unknown,
+  args: Record<string, unknown>
+) => RspackConfiguration | Promise<RspackConfiguration>;
+
+export type RspackConfiguration = RawRspackConfiguration | RspackConfigurationFactory;
+
+export interface RspackPreloadEntryPoint {
+  /**
+   * Relative or absolute path to the preload JS file.
+   */
+  js: string;
+  /**
+   * Additional entries to put in the array of entries for this preload script,
+   * useful if you need to set up things like error reporting as separate
+   * entry files into your application.
+   */
+  prefixedEntries?: string[];
+  /**
+   * The optional webpack config for your preload process.
+   * Defaults to the renderer webpack config if blank.
+   */
+  config?: RspackConfiguration | string;
+}
+
+export interface RspackPluginEntryPointBase {
+  /**
+   * Human friendly name of your entry point
+   */
+  name: string;
+  /**
+   * Additional entries to put in the array of entries for this entry point,
+   * useful if you need to set up things like error reporting as separate
+   * entry files into your application.
+   */
+  prefixedEntries?: string[];
+  /**
+   * Additional chunks to include in the outputted HTML file. Use this if you
+   * set up some custom chunking (e.g. using SplitChunksPlugin).
+   */
+  additionalChunks?: string[];
+  /**
+   * Override the webpack config for this renderer based on whether `nodeIntegration` for
+   * the `BrowserWindow` is enabled. For webpack's `target` option:
+   *
+   * * When `nodeIntegration` is true, the `target` is `electron-renderer`.
+   * * When `nodeIntegration` is false, the `target` is `web`.
+   *
+   * Unfortunately, we cannot derive the value from the main process code as it can be
+   * dynamically generated at run-time, and webpack processes at build-time.
+   *
+   * Defaults to `false` (as it is disabled by default in Electron \>= 5) or the value set
+   * for all entries.
+   */
+  nodeIntegration?: boolean;
+}
+
+export interface RspackPluginEntryPointLocalWindow extends RspackPluginEntryPointBase {
+  /**
+   * Relative or absolute path to the HTML template file for this entry point.
+   */
+  html: string;
+  /**
+   * Relative or absolute path to the main JS file for this entry point.
+   */
+  js: string;
+  /**
+   * Information about the preload script for this entry point. If you don't use
+   * preload scripts, you don't need to set this.
+   */
+  preload?: RspackPreloadEntryPoint;
+}
+
+export interface RspackPluginEntryPointPreloadOnly extends RspackPluginEntryPointBase {
+  /**
+   * Information about the preload script for this entry point.
+   */
+  preload: RspackPluginEntryPoint;
+}
+
+export interface RspackPluginEntryPointNoWindow extends RspackPluginEntryPointBase {
+  /**
+   * Relative or absolute path to the main JS file for this entry point.
+   */
+  js: string;
+}
+
+export type RspackPluginEntryPoint = RspackPluginEntryPointLocalWindow | RspackPluginEntryPointNoWindow | RspackPluginEntryPointPreloadOnly;
+
+export interface RspackPluginConfig {
+  /**
+   * The webpack config for your main process
+   */
+  mainConfig: RspackConfiguration | string;
+  renderer: RspackPluginRendererConfig | RspackPluginRendererConfig[];
+  /**
+   * The TCP port for the dev servers.
+   * @defaultValue 3000
+   */
+  port?: number;
+  /**
+   * The TCP port for web-multi-logger.
+   * @defaultValue 9000
+   */
+  loggerPort?: number;
+  devContentSecurityPolicy?: string;
+  devServer?: Omit<RspackDevServerConfiguration, 'port' | 'static' | 'setupExitSignals' | 'Content-Security-Policy'>;
+  jsonStats?: boolean;
+  packageSourceMaps?: boolean;
+}
+
+export interface RspackPluginRendererConfig {
+  /**
+   * The rspack config for your renderer process
+   */
+  config: RspackConfiguration | string;
+  jsonStats?: boolean;
+  nodeIntegration?: boolean;
+  entryPoints: RspackPluginEntryPoint[];
+}
+
+export interface EntryPointPluginConfig {
+  name: string;
+}

--- a/packages/plugin/rspack/src/RspackConfig.ts
+++ b/packages/plugin/rspack/src/RspackConfig.ts
@@ -1,0 +1,356 @@
+import path from 'path';
+
+import { Configuration, DefinePlugin, Entry, ExternalsPlugin, Mode, RspackPluginInstance } from '@rspack/core';
+import debug from 'debug';
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import { merge } from 'webpack-merge';
+
+import {
+  RspackConfigurationFactory,
+  RspackPluginConfig,
+  RspackPluginEntryPoint,
+  RspackPluginEntryPointLocalWindow,
+  RspackPluginEntryPointPreloadOnly,
+  RspackPluginRendererConfig,
+} from './Config';
+import AssetRelocatorPatch from './utils/AssetRelocatorPath';
+import processConfig from './utils/processConfig';
+import { isLocalOrNoWindowEntries, isLocalWindow, isNoWindow, isPreloadOnly, isPreloadOnlyEntries } from './utils/rendererTypeUtils';
+
+const d = debug('electron-forge:plugin:rspack:rspackconfig');
+
+type EntryType = string | string[] | Record<string, string | string[]>;
+
+enum RendererTarget {
+  Web,
+  ElectronRenderer,
+  ElectronPreload,
+  SandboxedPreload,
+}
+
+enum RspackTarget {
+  Web = 'web',
+  ElectronPreload = 'electron-preload',
+  ElectronRenderer = 'electron-renderer',
+}
+
+const isNotNull = <T>(item: T | null): item is T => item !== null;
+
+const rendererTargetToRspackTarget = (target: RendererTarget): RspackTarget => {
+  switch (target) {
+    case RendererTarget.Web:
+    case RendererTarget.SandboxedPreload:
+      return RspackTarget.Web;
+    case RendererTarget.ElectronPreload:
+      return RspackTarget.ElectronPreload;
+    case RendererTarget.ElectronRenderer:
+      return RspackTarget.ElectronRenderer;
+  }
+};
+
+export default class RspackConfigGenerator {
+  private isProd: boolean;
+  private pluginConfig: RspackPluginConfig;
+  private port: number;
+  private projectDir: string;
+  private rspackDir: string;
+
+  constructor(pluginConfig: RspackPluginConfig, projectDir: string, isProd: boolean, port: number) {
+    this.pluginConfig = pluginConfig;
+    this.projectDir = projectDir;
+    this.rspackDir = path.resolve(projectDir, 'dist');
+    this.isProd = isProd;
+    this.port = port;
+
+    d('Config mode:', this.mode);
+  }
+
+  get mode(): Mode {
+    return this.isProd ? 'production' : 'development';
+  }
+
+  get rendererSourceMapOption(): Configuration['devtool'] {
+    return this.isProd ? 'source-map' : 'eval-source-map';
+  }
+
+  private get allPluginRendererOptions() {
+    return Array.isArray(this.pluginConfig.renderer) ? this.pluginConfig.renderer : [this.pluginConfig.renderer];
+  }
+
+  async getMainConfig(): Promise<Configuration> {
+    const mainConfig = await this.resolveConfig(this.pluginConfig.mainConfig);
+
+    if (!mainConfig.entry) {
+      throw new Error('Required option "mainConfig.entry" has not been defined');
+    }
+    const fix = (item: EntryType): EntryType => {
+      if (typeof item === 'string') return (fix([item]) as string[])[0];
+      if (Array.isArray(item)) {
+        return item.map((val) => (val.startsWith('./') ? path.resolve(this.projectDir, val) : val));
+      }
+      const ret: Record<string, string | string[]> = {};
+      for (const key of Object.keys(item)) {
+        ret[key] = fix(item[key]) as string | string[];
+      }
+      return ret;
+    };
+    mainConfig.entry = fix(mainConfig.entry as EntryType);
+
+    return merge(
+      {
+        devtool: 'source-map',
+        target: 'electron-main',
+        mode: this.mode,
+        output: {
+          path: path.resolve(this.rspackDir, 'main'),
+          filename: 'index.js',
+          libraryTarget: 'commonjs2',
+        },
+        plugins: [new DefinePlugin(this.getDefines())],
+        node: {
+          __dirname: false,
+          __filename: false,
+        },
+      },
+      mainConfig || {}
+    );
+  }
+
+  async getRendererConfig(rendererOptions: RspackPluginRendererConfig): Promise<Configuration[]> {
+    const entryPointsForTarget = {
+      web: [] as (RspackPluginEntryPointLocalWindow | RspackPluginEntryPoint)[],
+      electronRenderer: [] as (RspackPluginEntryPointLocalWindow | RspackPluginEntryPoint)[],
+      electronPreload: [] as RspackPluginEntryPointPreloadOnly[],
+      sandboxedPreload: [] as RspackPluginEntryPointPreloadOnly[],
+    };
+
+    for (const entry of rendererOptions.entryPoints) {
+      const target = entry.nodeIntegration ?? rendererOptions.nodeIntegration ? 'electronRenderer' : 'web';
+      const preloadTarget = entry.nodeIntegration ?? rendererOptions.nodeIntegration ? 'electronPreload' : 'sandboxedPreload';
+
+      if (isPreloadOnly(entry)) {
+        entryPointsForTarget[preloadTarget].push(entry);
+      } else {
+        entryPointsForTarget[target].push(entry);
+        if (isLocalWindow(entry) && entry.preload) {
+          entryPointsForTarget[preloadTarget].push({ ...entry, preload: entry.preload });
+        }
+      }
+    }
+
+    const rendererConfigs = await Promise.all(
+      [
+        await this.buildRendererConfigs(rendererOptions, entryPointsForTarget.web, RendererTarget.Web),
+        await this.buildRendererConfigs(rendererOptions, entryPointsForTarget.electronRenderer, RendererTarget.ElectronRenderer),
+        await this.buildRendererConfigs(rendererOptions, entryPointsForTarget.electronPreload, RendererTarget.ElectronPreload),
+        await this.buildRendererConfigs(rendererOptions, entryPointsForTarget.sandboxedPreload, RendererTarget.SandboxedPreload),
+      ].reduce((configs, allConfigs) => allConfigs.concat(configs), [])
+    );
+
+    return rendererConfigs.filter(isNotNull);
+  }
+
+  async buildRendererConfigs(
+    rendererOptions: RspackPluginRendererConfig,
+    entryPoints: RspackPluginEntryPoint[],
+    target: RendererTarget
+  ): Promise<Promise<Configuration | null>[]> {
+    if (entryPoints.length === 0) {
+      return [];
+    }
+
+    const rendererConfigs = [];
+    if (target === RendererTarget.Web || target === RendererTarget.ElectronRenderer) {
+      rendererConfigs.push(this.buildRendererConfigForWebOrRendererTarget(rendererOptions, entryPoints, target));
+      return rendererConfigs;
+    } else if (target === RendererTarget.ElectronPreload || target === RendererTarget.SandboxedPreload) {
+      if (!isPreloadOnlyEntries(entryPoints)) {
+        throw new Error('Invalid renderer entry point detected.');
+      }
+
+      const entryPointsWithPreloadConfig: RspackPluginEntryPointPreloadOnly[] = [];
+      const entryPointsWithoutPreloadConfig: RspackPluginEntryPointPreloadOnly[] = [];
+      entryPoints.forEach((entryPoint) => (entryPoint.preload.config ? entryPointsWithPreloadConfig : entryPointsWithoutPreloadConfig).push(entryPoint));
+
+      rendererConfigs.push(this.buildRendererConfigForPreloadOrSandboxedPreloadTarget(rendererOptions, entryPointsWithoutPreloadConfig, target));
+      entryPointsWithPreloadConfig.forEach((entryPoint) => {
+        rendererConfigs.push(this.buildRendererConfigForPreloadOrSandboxedPreloadTarget(rendererOptions, [entryPoint], target));
+      });
+
+      return rendererConfigs;
+    } else {
+      throw new Error('Invalid renderer entry point detected.');
+    }
+  }
+
+  private async buildRendererConfigForPreloadOrSandboxedPreloadTarget(
+    rendererOptions: RspackPluginRendererConfig,
+    entryPoints: RspackPluginEntryPointPreloadOnly[],
+    target: RendererTarget.ElectronPreload | RendererTarget.SandboxedPreload
+  ): Promise<Configuration | null> {
+    if (entryPoints.length === 0) {
+      return null;
+    }
+
+    const externals = ['electron', 'electron/renderer', 'electron/common', 'events', 'timers', 'url'];
+
+    const entry: Entry = {};
+    const baseConfig: Configuration = this.buildRendererBaseConfig(target);
+    const rendererConfig = await this.resolveConfig(entryPoints[0].preload?.config || rendererOptions.config);
+
+    for (const entryPoint of entryPoints) {
+      entry[entryPoint.name] = (entryPoint.prefixedEntries || []).concat([entryPoint.preload.js]);
+    }
+
+    const config: Configuration = {
+      target: rendererTargetToRspackTarget(target),
+      entry,
+      output: {
+        path: path.resolve(this.rspackDir, 'renderer'),
+        filename: '[name]/preload.js',
+        globalObject: 'self',
+        ...(this.isProd ? { publicPath: '' } : { publicPath: '/' }),
+      },
+      plugins: target === RendererTarget.ElectronPreload ? [] : [new ExternalsPlugin('commonjs2', externals)],
+    };
+
+    return merge(baseConfig, rendererConfig || {}, config);
+  }
+
+  private async buildRendererConfigForWebOrRendererTarget(
+    rendererOptions: RspackPluginRendererConfig,
+    entryPoints: RspackPluginEntryPoint[],
+    target: RendererTarget.Web | RendererTarget.ElectronRenderer
+  ): Promise<Configuration | null> {
+    if (!isLocalOrNoWindowEntries(entryPoints)) {
+      throw new Error('Invalid renderer entry point detected.');
+    }
+
+    const entry: Entry = {};
+    const baseConfig: Configuration = this.buildRendererBaseConfig(target);
+    const rendererConfig = await this.resolveConfig(rendererOptions.config);
+
+    const output = {
+      path: path.resolve(this.rspackDir, 'renderer'),
+      filename: '[name]/index.js',
+      globalObject: 'self',
+      ...(this.isProd ? {} : { publicPath: '/' }),
+    };
+
+    const plugins: RspackPluginInstance[] = [];
+    for (const entryPoint of entryPoints) {
+      entry[entryPoint.name] = (entryPoint.prefixedEntries || []).concat([entryPoint.js]);
+
+      if (isLocalWindow(entryPoint)) {
+        plugins.push(
+          new HtmlWebpackPlugin({
+            title: entryPoint.name,
+            template: entryPoint.html,
+            filename: `${entryPoint.name}/index.html`,
+            chunks: [entryPoint.name].concat(entryPoint.additionalChunks || []),
+          }) as unknown as RspackPluginInstance
+        );
+      }
+    }
+
+    return merge(baseConfig, rendererConfig || {}, { entry, output, plugins });
+  }
+
+  private buildRendererBaseConfig(target: RendererTarget): Configuration {
+    return {
+      target: rendererTargetToRspackTarget(target),
+      devtool: this.rendererSourceMapOption,
+      mode: this.mode,
+      output: {
+        path: path.resolve(this.rspackDir, 'renderer'),
+        filename: '[name]/index.js',
+        globalObject: 'self',
+        ...(this.isProd ? {} : { publicPath: '/' }),
+      },
+      node: {
+        __dirname: false,
+        __filename: false,
+      },
+      plugins: [new AssetRelocatorPatch(this.isProd, target === RendererTarget.ElectronRenderer || target === RendererTarget.ElectronPreload)],
+    };
+  }
+
+  // Users can override this method in a subclass to provide custom logic or
+  // configuration parameters.
+  preprocessConfig = async (config: RspackConfigurationFactory): Promise<Configuration> =>
+    config(
+      {},
+      {
+        mode: this.mode,
+      }
+    ) as Configuration;
+  private async resolveConfig(config: Configuration | RspackConfigurationFactory | string): Promise<Configuration> {
+    type MaybeESM<T> = T | { default: T };
+
+    let rawConfig =
+      typeof config === 'string'
+        ? // eslint-disable-next-line @typescript-eslint/no-var-requires
+          (require(path.resolve(this.projectDir, config)) as MaybeESM<Configuration | RspackConfigurationFactory>)
+        : config;
+
+    if (rawConfig && typeof rawConfig === 'object' && 'default' in rawConfig) {
+      rawConfig = rawConfig.default;
+    }
+
+    return processConfig(this.preprocessConfig, rawConfig);
+  }
+
+  private rendererEntryPoint(entryPoint: RspackPluginEntryPoint, basename: string): string {
+    if (this.isProd) {
+      return `\`file://$\{require('path').resolve(__dirname, '..', 'renderer', '${entryPoint.name}', '${basename}')}\``;
+    }
+    const baseUrl = `http://localhost:${this.port}/${entryPoint.name}`;
+    if (basename !== 'index.html') {
+      return `'${baseUrl}/${basename}'`;
+    }
+    return `'${baseUrl}'`;
+  }
+
+  private toEnvironmentVariable(entryPoint: RspackPluginEntryPoint, preload = false): string {
+    const suffix = preload ? '_PRELOAD_RSPACK_ENTRY' : '_RSPACK_ENTRY';
+    return `${entryPoint.name.toUpperCase().replace(/ /g, '_')}${suffix}`;
+  }
+
+  private getPreloadDefine(entryPoint: RspackPluginEntryPoint): string {
+    if (!isNoWindow(entryPoint)) {
+      if (this.isProd) {
+        return `require('path').resolve(__dirname, '../renderer', '${entryPoint.name}', 'preload.js')`;
+      }
+      return `'${path.resolve(this.rspackDir, 'renderer', entryPoint.name, 'preload.js').replace(/\\/g, '\\\\')}'`;
+    } else {
+      // If this entry-point has no configured preload script just map this constant to `undefined`
+      // so that any code using it still works.  This makes quick-start / docs simpler.
+      return 'undefined';
+    }
+  }
+
+  private getDefines(): Record<string, string> {
+    const defines: Record<string, string> = {};
+
+    for (const pluginRendererOptions of this.allPluginRendererOptions) {
+      if (!pluginRendererOptions.entryPoints || !Array.isArray(pluginRendererOptions.entryPoints)) {
+        throw new Error('Required config option "renderer.entryPoints" has not been defined');
+      }
+      for (const entryPoint of pluginRendererOptions.entryPoints) {
+        const entryKey = this.toEnvironmentVariable(entryPoint);
+        if (isLocalWindow(entryPoint)) {
+          defines[entryKey] = this.rendererEntryPoint(entryPoint, 'index.html');
+        } else {
+          defines[entryKey] = this.rendererEntryPoint(entryPoint, 'index.js');
+        }
+        defines[`process.env.${entryKey}`] = defines[entryKey];
+
+        const preloadDefineKey = this.toEnvironmentVariable(entryPoint, true);
+        defines[preloadDefineKey] = this.getPreloadDefine(entryPoint);
+        defines[`process.env.${preloadDefineKey}`] = defines[preloadDefineKey];
+      }
+    }
+
+    return defines;
+  }
+}

--- a/packages/plugin/rspack/src/RspackPlugin.ts
+++ b/packages/plugin/rspack/src/RspackPlugin.ts
@@ -1,0 +1,598 @@
+import crypto from 'crypto';
+import http from 'http';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+
+import { getElectronVersion, listrCompatibleRebuildHook } from '@electron-forge/core-utils';
+import { namedHookWithTaskFn, PluginBase } from '@electron-forge/plugin-base';
+import { ForgeMultiHookMap, ListrTask, ResolvedForgeConfig, StartResult } from '@electron-forge/shared-types';
+import Logger, { Tab } from '@electron-forge/web-multi-logger';
+import { Compiler, Configuration, MultiStats, rspack, Stats, Watching } from '@rspack/core';
+import { RspackDevServer, Configuration as RspackDevServerConfiguration } from '@rspack/dev-server';
+import chalk from 'chalk';
+import debug from 'debug';
+import glob from 'fast-glob';
+import fs from 'fs-extra';
+import { merge } from 'webpack-merge';
+
+import { RspackPluginConfig, RspackPluginRendererConfig } from './Config';
+import RspackConfigGenerator from './RspackConfig';
+import ElectronForgeLoggingPlugin from './utils/ElectronForgeLogging';
+import EntryPointPreloadPlugin from './utils/EntryPointPreloadPlugin';
+import once from './utils/once';
+
+type RspackToJsonOptions = Parameters<Stats['toJson']>[0];
+type RspackWatchHandler = Parameters<Compiler['watch']>[1];
+
+type NativeDepsCtx = {
+  nativeDeps: Record<string, string[]>;
+};
+
+const d = debug('electron-forge:plugin:rspack');
+const DEFAULT_PORT = 3000;
+const DEFAULT_LOGGER_PORT = 9000;
+
+export default class RspackPlugin extends PluginBase<RspackPluginConfig> {
+  name = 'rspack';
+
+  private isProd = false;
+  private port = DEFAULT_PORT;
+  private loggerPort = DEFAULT_LOGGER_PORT;
+  private projectDir!: string;
+  private baseDir!: string;
+  private loggers: Logger[] = [];
+  private _configGenerator!: RspackConfigGenerator;
+  private watchers: Watching[] = [];
+  private servers: http.Server[] = [];
+
+  constructor(c: RspackPluginConfig) {
+    super(c);
+
+    if (c.port) {
+      if (this.isValidPort(c.port)) {
+        this.port = c.port;
+      }
+    }
+
+    if (c.loggerPort) {
+      if (this.isValidPort(c.loggerPort)) {
+        this.loggerPort = c.loggerPort;
+      }
+    }
+
+    this.startLogic = this.startLogic.bind(this);
+    this.getHooks = this.getHooks.bind(this);
+  }
+
+  get configGenerator(): RspackConfigGenerator {
+    if (!this._configGenerator) {
+      this._configGenerator = new RspackConfigGenerator(this.config, this.projectDir, this.isProd, this.port);
+    }
+
+    return this._configGenerator;
+  }
+
+  private get allRendererOptions() {
+    return Array.isArray(this.config.renderer) ? this.config.renderer : [this.config.renderer];
+  }
+
+  private alreadyStarted = false;
+  async startLogic(): Promise<StartResult> {
+    if (this.alreadyStarted) {
+      return false;
+    }
+
+    this.alreadyStarted = true;
+
+    await fs.remove(this.baseDir);
+
+    const logger = new Logger(this.loggerPort);
+    this.loggers.push(logger);
+    await logger.start();
+
+    return {
+      tasks: [
+        {
+          title: 'Compiling main process code',
+          task: async () => {
+            await this.compileMain(true, logger);
+          },
+          options: {
+            showTimer: true,
+          },
+        },
+        {
+          title: 'Launching dev servers for renderer process code',
+          task: async (_, task) => {
+            await this.launchRendererDevServers(logger);
+            task.output = `Output Available: ${chalk.cyan(`http://localhost:${this.loggerPort}`)}\n`;
+          },
+          options: {
+            persistentOutput: true,
+            showTimer: true,
+          },
+        },
+      ],
+      result: false,
+    };
+  }
+
+  init(dir: string) {
+    this.setDirectories(dir);
+
+    d('hooking process events');
+    process.on('exit', (_code) => this.exitHandler({ cleanup: true }));
+    process.on('SIGINT' as NodeJS.Signals, (_signal) => this.exitHandler({ exit: true }));
+  }
+
+  getHooks(): ForgeMultiHookMap {
+    return {
+      prePackage: [
+        namedHookWithTaskFn<'prePackage'>(async (task, config, platform, arch) => {
+          if (!task) {
+            throw new Error('Incompatible usage of rspack-plugin prePackage hook');
+          }
+
+          this.isProd = true;
+          await fs.remove(this.baseDir);
+
+          // TODO: Figure out how to get matrix from packager
+          const arches: string[] = Array.from(
+            new Set(arch.split(',').reduce<string[]>((all, pArch) => (pArch === 'universal' ? all.concat(['arm64', 'x64']) : all.concat([pArch])), []))
+          );
+
+          const firstArch = arches[0];
+          const otherArches = arches.slice(1);
+
+          const multiArchTasks: ListrTask<NativeDepsCtx>[] =
+            otherArches.length === 0
+              ? []
+              : [
+                  {
+                    title: 'Mapping native dependencies',
+                    task: async (ctx: NativeDepsCtx) => {
+                      const firstArchDir = path.resolve(this.baseDir, firstArch);
+                      const nodeModulesDir = path.resolve(this.projectDir, 'node_modules');
+                      const mapping: Record<string, string[]> = Object.create(null);
+
+                      const rspackNodeFiles = await glob('**/*.node', {
+                        cwd: firstArchDir,
+                      });
+                      const nodeModulesNodeFiles = await glob('**/*.node', {
+                        cwd: nodeModulesDir,
+                      });
+                      const hashToNodeModules: Record<string, string[]> = Object.create(null);
+
+                      for (const nodeModulesNodeFile of nodeModulesNodeFiles) {
+                        const hash = crypto.createHash('sha256');
+                        const resolvedNodeFile = path.resolve(nodeModulesDir, nodeModulesNodeFile);
+                        await pipeline(fs.createReadStream(resolvedNodeFile), hash);
+                        const digest = hash.digest('hex');
+
+                        hashToNodeModules[digest] = hashToNodeModules[digest] || [];
+                        hashToNodeModules[digest].push(resolvedNodeFile);
+                      }
+
+                      for (const rspackNodeFile of rspackNodeFiles) {
+                        const hash = crypto.createHash('sha256');
+                        await pipeline(fs.createReadStream(path.resolve(firstArchDir, rspackNodeFile)), hash);
+                        const matchedNodeModule = hashToNodeModules[hash.digest('hex')];
+                        if (!matchedNodeModule || !matchedNodeModule.length) {
+                          throw new Error(`Could not find originating native module for "${rspackNodeFile}"`);
+                        }
+
+                        mapping[rspackNodeFile] = matchedNodeModule;
+                      }
+
+                      ctx.nativeDeps = mapping;
+                    },
+                  },
+                  {
+                    title: `Generating multi-arch bundles`,
+                    task: async (_, task) => {
+                      return task.newListr(
+                        otherArches.map(
+                          (pArch): ListrTask<NativeDepsCtx> => ({
+                            title: `Generating ${chalk.magenta(pArch)} bundle`,
+                            task: async (_, innerTask) => {
+                              return innerTask.newListr(
+                                [
+                                  {
+                                    title: 'Preparing native dependencies',
+                                    task: async (_, innerTask) => {
+                                      await listrCompatibleRebuildHook(
+                                        this.projectDir,
+                                        await getElectronVersion(this.projectDir, await fs.readJson(path.join(this.projectDir, 'package.json'))),
+                                        platform,
+                                        pArch,
+                                        config.rebuildConfig,
+                                        innerTask
+                                      );
+                                    },
+                                    options: {
+                                      persistentOutput: true,
+                                      bottomBar: Infinity,
+                                      showTimer: true,
+                                    },
+                                  },
+                                  {
+                                    title: 'Mapping native dependencies',
+                                    task: async (ctx) => {
+                                      const nodeModulesDir = path.resolve(this.projectDir, 'node_modules');
+
+                                      // Duplicate the firstArch build
+                                      const firstDir = path.resolve(this.baseDir, firstArch);
+                                      const targetDir = path.resolve(this.baseDir, pArch);
+                                      await fs.mkdirp(targetDir);
+                                      for (const child of await fs.readdir(firstDir)) {
+                                        await fs.promises.cp(path.resolve(firstDir, child), path.resolve(targetDir, child), {
+                                          recursive: true,
+                                        });
+                                      }
+
+                                      const nodeModulesNodeFiles = await glob('**/*.node', {
+                                        cwd: nodeModulesDir,
+                                      });
+                                      const nodeModuleToHash: Record<string, string> = Object.create(null);
+
+                                      for (const nodeModulesNodeFile of nodeModulesNodeFiles) {
+                                        const hash = crypto.createHash('sha256');
+                                        const resolvedNodeFile = path.resolve(nodeModulesDir, nodeModulesNodeFile);
+                                        await pipeline(fs.createReadStream(resolvedNodeFile), hash);
+
+                                        nodeModuleToHash[resolvedNodeFile] = hash.digest('hex');
+                                      }
+
+                                      // Use the native module map to find the newly built native modules
+                                      for (const nativeDep of Object.keys(ctx.nativeDeps)) {
+                                        const archPath = path.resolve(targetDir, nativeDep);
+                                        await fs.remove(archPath);
+
+                                        const mappedPaths = ctx.nativeDeps[nativeDep];
+                                        if (!mappedPaths || !mappedPaths.length) {
+                                          throw new Error(`The "${nativeDep}" module could not be mapped to any native modules on disk`);
+                                        }
+
+                                        if (!mappedPaths.every((mappedPath) => nodeModuleToHash[mappedPath] === nodeModuleToHash[mappedPaths[0]])) {
+                                          throw new Error(
+                                            `The "${nativeDep}" mapped to multiple modules "${mappedPaths.join(
+                                              ', '
+                                            )}" but the same modules post rebuild did not map to the same native code`
+                                          );
+                                        }
+
+                                        await fs.promises.cp(mappedPaths[0], archPath);
+                                      }
+                                    },
+                                  },
+                                ],
+                                { concurrent: false }
+                              );
+                            },
+                          })
+                        )
+                      );
+                    },
+                  },
+                ];
+
+          return task.newListr<NativeDepsCtx>(
+            [
+              {
+                title: `Preparing native dependencies for ${chalk.magenta(firstArch)}`,
+                task: async (_, innerTask) => {
+                  await listrCompatibleRebuildHook(
+                    this.projectDir,
+                    await getElectronVersion(this.projectDir, await fs.readJson(path.join(this.projectDir, 'package.json'))),
+                    platform,
+                    firstArch,
+                    config.rebuildConfig,
+                    innerTask
+                  );
+                },
+                options: {
+                  persistentOutput: true,
+                  bottomBar: Infinity,
+                  showTimer: true,
+                },
+              },
+              {
+                title: 'Building rspack bundles',
+                task: async () => {
+                  await this.compileMain();
+                  await this.compileRenderers();
+                  // Store it in a place that won't get messed with
+                  // We'll restore the right "arch" in the afterCopy hook further down
+                  const preExistingChildren = await fs.readdir(this.baseDir);
+                  const targetDir = path.resolve(this.baseDir, firstArch);
+                  await fs.mkdirp(targetDir);
+                  for (const child of preExistingChildren) {
+                    await fs.move(path.resolve(this.baseDir, child), path.resolve(targetDir, child));
+                  }
+                },
+                options: {
+                  showTimer: true,
+                },
+              },
+              ...multiArchTasks,
+            ],
+            { concurrent: false }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ) as any;
+        }, 'Preparing rspack bundles'),
+      ],
+      postStart: async (_config, child) => {
+        d('hooking electron process exit');
+        child.on('exit', () => {
+          if (child.restarted) return;
+          this.exitHandler({ cleanup: true, exit: true });
+        });
+      },
+      resolveForgeConfig: this.resolveForgeConfig,
+      packageAfterCopy: [
+        async (_forgeConfig: ResolvedForgeConfig, buildPath: string, _electronVersion: string, _platform: string, pArch: string): Promise<void> => {
+          // Restore the correct 'arch' build of rspabk
+          // Steal the correct arch, wipe the folder, move it back to pretend to be "dist" root
+          const tmpRspackDir = path.resolve(buildPath, 'dist.tmp');
+          await fs.move(path.resolve(buildPath, 'dist', pArch), tmpRspackDir);
+          await fs.remove(path.resolve(buildPath, 'dist'));
+          await fs.move(tmpRspackDir, path.resolve(buildPath, 'dist'));
+        },
+        this.packageAfterCopy,
+      ],
+    };
+  }
+
+  private exitHandler(options: { cleanup?: boolean; exit?: boolean }, err?: Error) {
+    d('handling process exit with:', options);
+    if (options.cleanup) {
+      for (const watcher of this.watchers) {
+        d('cleaning rspack watcher');
+        watcher.close(() => {
+          /* Do nothing when the watcher closes */
+        });
+      }
+      this.watchers = [];
+      for (const server of this.servers) {
+        d('cleaning http server');
+        server.close();
+      }
+      this.servers = [];
+      for (const logger of this.loggers) {
+        d('stopping logger');
+        logger.stop();
+      }
+      this.loggers = [];
+    }
+    if (err) console.error(err.stack);
+    // Why: This is literally what the option says to do.
+    // eslint-disable-next-line no-process-exit
+    if (options.exit) process.exit();
+  }
+
+  private async compileMain(watch = false, logger?: Logger): Promise<void> {
+    let tab: Tab;
+    if (logger) {
+      tab = logger.createTab('Main Process');
+    }
+
+    const mainConfig = await this.configGenerator.getMainConfig();
+    await new Promise((resolve, reject) => {
+      const compiler = rspack(mainConfig);
+      const [onceResolve, onceReject] = once(resolve, reject);
+      const cb: RspackWatchHandler = async (err, stats) => {
+        if (tab && stats) {
+          tab.log(
+            stats.toString({
+              colors: true,
+            })
+          );
+        }
+        if (this.config.jsonStats) {
+          await this.writeJSONStats('main', stats, mainConfig.stats as RspackToJsonOptions, 'main');
+        }
+
+        if (err) return onceReject(err);
+        if (!watch && stats?.hasErrors()) {
+          return onceReject(new Error(`Compilation errors in the main process: ${stats.toString()}`));
+        }
+
+        return onceResolve(undefined);
+      };
+      if (watch) {
+        this.watchers.push(compiler.watch({}, cb));
+      } else {
+        compiler.run(cb);
+      }
+    });
+  }
+
+  private async compileRenderers(watch = false): Promise<void> {
+    for (const rendererOptions of this.allRendererOptions) {
+      const stats = await this.runRspack(await this.configGenerator.getRendererConfig(rendererOptions), rendererOptions);
+      if (!watch && stats?.hasErrors()) {
+        throw new Error(`Compilation errors in the renderer: ${stats.toString(undefined)}`);
+      }
+    }
+  }
+
+  private async runRspack(options: Configuration[], rendererOptions: RspackPluginRendererConfig | null): Promise<MultiStats | undefined> {
+    return new Promise((resolve, reject) => {
+      rspack(options).run(async (err, stats) => {
+        if (rendererOptions && rendererOptions.jsonStats) {
+          for (const [index, entryStats] of (stats?.stats ?? []).entries()) {
+            const name = rendererOptions.entryPoints[index].name;
+            await this.writeJSONStats('renderer', entryStats, options[index].stats as RspackToJsonOptions, name);
+          }
+        }
+        if (err) {
+          return reject(err);
+        }
+        return resolve(stats);
+      });
+    });
+  }
+
+  private setDirectories(dir: string) {
+    this.projectDir = dir;
+    this.baseDir = path.resolve(dir, 'dist');
+  }
+
+  private async launchRendererDevServers(logger: Logger): Promise<void> {
+    const configs: Configuration[] = [];
+    const rollingDependencies: string[] = [];
+    for (const [i, rendererOptions] of this.allRendererOptions.entries()) {
+      const groupName = `group_${i}`;
+      const rendererConfig = await this.configGenerator.getRendererConfig(rendererOptions);
+      configs.push(
+        ...rendererConfig.map((config) => ({
+          ...config,
+          name: groupName,
+          dependencies: [...rollingDependencies],
+        }))
+      );
+      rollingDependencies.push(groupName);
+    }
+
+    if (configs.length === 0) {
+      return;
+    }
+
+    const preloadPlugins: string[] = [];
+    let numPreloadEntriesWithConfig = 0;
+    for (const entryConfig of configs) {
+      if (!entryConfig.plugins) entryConfig.plugins = [];
+      entryConfig.plugins.push(new ElectronForgeLoggingPlugin(logger.createTab(`Renderer Target Bundle (${entryConfig.target})`)));
+
+      const filename = entryConfig.output?.filename as string;
+      if (filename?.endsWith('preload.js')) {
+        let name = `entry-point-preload-${entryConfig.target}`;
+        if (preloadPlugins.includes(name)) {
+          name = `${name}-${++numPreloadEntriesWithConfig}`;
+        }
+        entryConfig.plugins.push(new EntryPointPreloadPlugin({ name }));
+        preloadPlugins.push(name);
+      }
+
+      entryConfig.infrastructureLogging = {
+        level: 'none',
+      };
+      entryConfig.stats = 'none';
+    }
+
+    const compiler = rspack(configs);
+
+    const promises = preloadPlugins.map((preloadPlugin) => {
+      return new Promise((resolve, reject) => {
+        compiler.hooks.done.tap(preloadPlugin, (stats) => {
+          if (stats.hasErrors()) {
+            return reject(new Error(`Compilation errors in the preload: ${stats.toString(undefined)}`));
+          }
+          return resolve(undefined);
+        });
+      });
+    });
+
+    const rspackDevServer = new RspackDevServer(this.devServerOptions(), compiler);
+    await rspackDevServer.start();
+    this.servers.push(rspackDevServer.server!);
+    await Promise.all(promises);
+  }
+
+  private isValidPort = (port: number) => {
+    if (port < 1024) {
+      throw new Error(`Cannot specify port (${port}) below 1024, as they are privileged`);
+    } else if (port > 65535) {
+      throw new Error(`Port specified (${port}) is not a valid TCP port.`);
+    } else {
+      return true;
+    }
+  };
+
+  private devServerOptions(): RspackDevServerConfiguration {
+    const cspDirectives =
+      this.config.devContentSecurityPolicy ?? "default-src 'self' 'unsafe-inline' data:; script-src 'self' 'unsafe-eval' 'unsafe-inline' data:";
+
+    const defaults: Partial<RspackDevServerConfiguration> = {
+      hot: true,
+      devMiddleware: {
+        writeToDisk: true,
+      },
+      historyApiFallback: true,
+    };
+    const overrides: Partial<RspackDevServerConfiguration> = {
+      port: this.port,
+      setupExitSignals: true,
+      static: path.resolve(this.baseDir, 'renderer'),
+      headers: {
+        'Content-Security-Policy': cspDirectives,
+      },
+    };
+
+    return merge(defaults, this.config.devServer ?? {}, overrides);
+  }
+
+  private async writeJSONStats(type: string, stats: Stats | undefined, statsOptions: RspackToJsonOptions, suffix: string): Promise<void> {
+    if (!stats) return;
+    d(`Writing JSON stats for ${type} config`);
+    const jsonStats = stats.toJson(statsOptions);
+    const jsonStatsFilename = path.resolve(this.baseDir, type, `stats-${suffix}.json`);
+    await fs.writeJson(jsonStatsFilename, jsonStats, { spaces: 2 });
+  }
+
+  private async resolveForgeConfig(forgeConfig: ResolvedForgeConfig): Promise<ResolvedForgeConfig> {
+    if (!forgeConfig.packagerConfig) {
+      forgeConfig.packagerConfig = {};
+    }
+    if (forgeConfig.packagerConfig.ignore) {
+      if (typeof forgeConfig.packagerConfig.ignore !== 'function') {
+        console.error(
+          chalk.red(`You have set packagerConfig.ignore, the Electron Forge rspack plugin normally sets this automatically.
+
+Your packaged app may be larger than expected if you dont ignore everything other than the 'dist/' folder`)
+        );
+      }
+      return forgeConfig;
+    }
+    forgeConfig.packagerConfig.ignore = (file: string) => {
+      if (!file) return false;
+
+      if (this.config.jsonStats && file.endsWith(path.join('dist', 'main', 'stats.json'))) {
+        return true;
+      }
+
+      if (this.allRendererOptions.some((r) => r.jsonStats) && file.endsWith(path.join('dist', 'renderer', 'stats.json'))) {
+        return true;
+      }
+
+      if (!this.config.packageSourceMaps && /[^/\\]+\.js\.map$/.test(file)) {
+        return true;
+      }
+
+      return !/^[/\\]\dist($|[/\\]).*$/.test(file);
+    };
+    return forgeConfig;
+  }
+
+  private async packageAfterCopy(_forgeConfig: ResolvedForgeConfig, buildPath: string): Promise<void> {
+    const pj = await fs.readJson(path.resolve(this.projectDir, 'package.json'));
+
+    if (!pj.main?.endsWith('dist/main')) {
+      throw new Error(`Electron Forge is configured to use the Rspack plugin. The plugin expects the
+"main" entry point in "package.json" to be "dist/main" (where the plugin outputs
+the generated files). Instead, it is ${JSON.stringify(pj.main)}`);
+    }
+
+    if (pj.config) {
+      delete pj.config.forge;
+    }
+
+    await fs.writeJson(path.resolve(buildPath, 'package.json'), pj, {
+      spaces: 2,
+    });
+
+    await fs.mkdirp(path.resolve(buildPath, 'node_modules'));
+  }
+}
+
+export { RspackPlugin, RspackPluginConfig };

--- a/packages/plugin/rspack/src/utils/AssetRelocatorPath.ts
+++ b/packages/plugin/rspack/src/utils/AssetRelocatorPath.ts
@@ -1,0 +1,68 @@
+import { Compiler } from '@rspack/core';
+import { Chunk } from 'webpack';
+
+export default class AssetRelocatorPatch {
+  private readonly isProd: boolean;
+  private readonly nodeIntegration: boolean;
+
+  constructor(isProd: boolean, nodeIntegration: boolean) {
+    this.isProd = isProd;
+    this.nodeIntegration = nodeIntegration;
+  }
+
+  private injectedProductionDirnameCode(): string {
+    if (this.nodeIntegration) {
+      // In production the assets are found one directory up from
+      // __dirname
+      return 'require("path").resolve(__dirname, "..")';
+    }
+
+    // If nodeIntegration is disabled, we replace __dirname
+    // with an empty string so no error is thrown at runtime
+    return '""';
+  }
+
+  public apply(compiler: Compiler): void {
+    compiler.hooks.compilation.tap('asset-relocator-forge-patch', (compilation) => {
+      // We intercept the Vercel loader code injection and replace __dirname with
+      // code that works with Electron Forge
+      //
+      // Here is where the injection occurs:
+      // https://github.com/vercel/webpack-asset-relocator-loader/blob/4710a018fc8fb64ad51efb368759616fb273618f/src/asset-relocator.js#L331-L339
+      compilation.mainTemplate.hooks.requireExtensions.intercept({
+        register: (tapInfo) => {
+          if (tapInfo.name === 'asset-relocator-loader') {
+            const originalFn = tapInfo.fn as (source: string, chunk: Chunk) => string;
+
+            tapInfo.fn = (source: string, chunk: Chunk) => {
+              const originalInjectCode = originalFn(source, chunk);
+
+              // Since this is not a public API of the Vercel loader, it could
+              // change on patch versions and break things.
+              //
+              // If the injected code changes substantially, we throw an error
+              if (!originalInjectCode.includes('__webpack_require__.ab = __dirname + ')) {
+                throw new Error('The installed version of @vercel/webpack-asset-relocator-loader does not appear to be compatible with Forge');
+              }
+
+              if (this.isProd) {
+                return originalInjectCode.replace('__dirname', this.injectedProductionDirnameCode());
+              }
+
+              return originalInjectCode.replace(
+                '__dirname',
+                // In development, the app is loaded via webpack-dev-server
+                // so __dirname is useless because it points to Electron
+                // internal code. Instead we hard-code the absolute path to
+                // the webpack output.
+                JSON.stringify(compiler.options.output.path)
+              );
+            };
+          }
+
+          return tapInfo;
+        },
+      });
+    });
+  }
+}

--- a/packages/plugin/rspack/src/utils/ElectronForgeLogging.ts
+++ b/packages/plugin/rspack/src/utils/ElectronForgeLogging.ts
@@ -1,0 +1,29 @@
+import { Tab } from '@electron-forge/web-multi-logger';
+import { Compiler } from '@rspack/core';
+
+const pluginName = 'ElectronForgeLogging';
+
+export default class LoggingPlugin {
+  tab: Tab;
+
+  constructor(tab: Tab) {
+    this.tab = tab;
+  }
+
+  apply(compiler: Compiler): void {
+    compiler.hooks.done.tap(pluginName, (stats) => {
+      if (stats) {
+        this.tab.log(
+          stats.toString({
+            colors: true,
+          })
+        );
+      }
+    });
+    compiler.hooks.failed.tap(pluginName, (err) => this.tab.log(err.message));
+    compiler.hooks.infrastructureLog.tap(pluginName, (name: string, _type: string, args: string[]) => {
+      this.tab.log(`${name} - ${args.join(' ')}\n`);
+      return true;
+    });
+  }
+}

--- a/packages/plugin/rspack/src/utils/EntryPointPreloadPlugin.ts
+++ b/packages/plugin/rspack/src/utils/EntryPointPreloadPlugin.ts
@@ -1,0 +1,10 @@
+import { PluginBase } from '@electron-forge/plugin-base';
+
+import { EntryPointPluginConfig } from '../Config';
+
+export default class EntryPointPreloadPlugin extends PluginBase<EntryPointPluginConfig> {
+  name = this.config.name;
+  apply() {
+    // noop
+  }
+}

--- a/packages/plugin/rspack/src/utils/once.ts
+++ b/packages/plugin/rspack/src/utils/once.ts
@@ -1,0 +1,14 @@
+/* eslint "arrow-parens": "off", "@typescript-eslint/no-explicit-any": "off" */
+export default <A, B>(fn1: A, fn2: B): [A, B] => {
+  let once = true;
+  let val: any;
+  const make = <T>(fn: T): T =>
+    ((...args: any[]) => {
+      if (once) {
+        val = (fn as any)(...args);
+        once = false;
+      }
+      return val;
+    }) as unknown as T;
+  return [make(fn1), make(fn2)];
+};

--- a/packages/plugin/rspack/src/utils/processConfig.ts
+++ b/packages/plugin/rspack/src/utils/processConfig.ts
@@ -1,0 +1,19 @@
+import { Configuration } from '@rspack/core';
+
+import { RspackConfigurationFactory } from '../Config';
+
+const trivialConfigurationFactory =
+  (config: Configuration): RspackConfigurationFactory =>
+  () =>
+    config;
+
+export type ConfigProcessor = (config: RspackConfigurationFactory) => Promise<Configuration>;
+
+// Ensure processing logic is run for both `Configuration` and
+// `RspackConfigurationFactory` config variants.
+const processConfig = async (processor: ConfigProcessor, config: Configuration | RspackConfigurationFactory): Promise<Configuration> => {
+  const configFactory = typeof config === 'function' ? config : trivialConfigurationFactory(config);
+  return processor(configFactory);
+};
+
+export default processConfig;

--- a/packages/plugin/rspack/src/utils/rendererTypeUtils.ts
+++ b/packages/plugin/rspack/src/utils/rendererTypeUtils.ts
@@ -1,0 +1,37 @@
+import { RspackPluginEntryPoint, RspackPluginEntryPointLocalWindow, RspackPluginEntryPointNoWindow, RspackPluginEntryPointPreloadOnly } from '../Config';
+
+export const isLocalWindow = (entry: RspackPluginEntryPoint): entry is RspackPluginEntryPointLocalWindow => {
+  return !!(entry as any).html;
+};
+
+export const isNoWindow = (entry: RspackPluginEntryPoint): entry is RspackPluginEntryPointNoWindow => {
+  return !(entry as any).html && !!(entry as any).js;
+};
+
+export const isLocalOrNoWindowEntries = (
+  entries: RspackPluginEntryPoint[]
+): entries is (RspackPluginEntryPointLocalWindow | RspackPluginEntryPointNoWindow)[] => {
+  for (const entry of entries) {
+    if (!isLocalWindow(entry) && !isNoWindow(entry)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+export const isPreloadOnly = (entry: RspackPluginEntryPoint): entry is RspackPluginEntryPointPreloadOnly => {
+  return !(entry as any).html && !(entry as any).js && !!(entry as any).preload;
+};
+
+export const hasPreloadScript = (entry: RspackPluginEntryPoint): entry is RspackPluginEntryPointPreloadOnly => {
+  return 'preload' in entry;
+};
+
+export const isPreloadOnlyEntries = (entries: RspackPluginEntryPoint[]): entries is RspackPluginEntryPointPreloadOnly[] => {
+  for (const entry of entries) {
+    if (!hasPreloadScript(entry)) {
+      return false;
+    }
+  }
+  return true;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -896,6 +896,11 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
+"@discoveryjs/json-ext@^0.5.7":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
+  integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
+
 "@doyensec/csp-evaluator@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@doyensec/csp-evaluator/-/csp-evaluator-1.0.3.tgz#0d0405cbfb5bb814c24b8a73736a9700da2c681f"
@@ -2216,6 +2221,128 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@polka/url@^1.0.0-next.20":
+  version "1.0.0-next.24"
+  resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.24.tgz#58601079e11784d20f82d0585865bb42305c4df3"
+  integrity sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==
+
+"@rspack/binding-darwin-arm64@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-0.4.4.tgz#ecabeb41127382a48907659c8b420edf702eef64"
+  integrity sha512-40HUmnT/zHBcajcdTtIzorI1zpGZCpJBnis2rR3DzmBnD1fDLgu7PcW7iE11/MPmdwOYAZbCSzTZwe8hv0Skxw==
+
+"@rspack/binding-darwin-x64@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rspack/binding-darwin-x64/-/binding-darwin-x64-0.4.4.tgz#934d6c88a77972f39d4a7ea1aab4b9b4cf1bb05d"
+  integrity sha512-8vXoqA0S+D7LnwGAsO5dEpxKV3np/iONPvwRhVl2cBtsFKYmnh3jG0oxtDamCUUw38Jc3VZQTeH7kUt5F8HB5g==
+
+"@rspack/binding-linux-arm64-gnu@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.4.4.tgz#52a84a365bc52f832fe0e2f5095694bba01d89c7"
+  integrity sha512-lmLy9W14WcVjI1PuZVeq0TAGNFoeYjQswQHl0KCDURcxaBbVqGcNjPovhbib+5w9Gj4jQqqnVIUHs86vIqDwHQ==
+
+"@rspack/binding-linux-arm64-musl@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.4.4.tgz#cb739262fe110a98417a787cf50a583e5c12fba0"
+  integrity sha512-wnranY+QPbGzrkfNneZkq839imrt+pfup1RpynfgrvjiWApDwvagTi9S8M7Og3u9m1CmJDrBq6yXgy4ffweygQ==
+
+"@rspack/binding-linux-x64-gnu@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.4.4.tgz#f374c6df0ea40f73daff3947795ab9e87bfd7588"
+  integrity sha512-J0n+91NL9quEWYaStFitXC3+rbM+wklxCEHvkwfuzC46fGcG9673aTVfcrod1fx2jTHHaftXKb5Hpru77W0JAA==
+
+"@rspack/binding-linux-x64-musl@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-0.4.4.tgz#87bb9c672b69d4a1d1f71ad3abf67137dba8fd26"
+  integrity sha512-ulIhvLzimHB5Ggp9TRJEFvyak/7OPzeVxFdP8nYNBHzPoYiqnK2MQUVOK7CT2hTpco1QJbh3jZTZxzdKIY5asw==
+
+"@rspack/binding-win32-arm64-msvc@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.4.4.tgz#ba5286ea74fd99ab2cde66532f8e65b7b11db695"
+  integrity sha512-t4u3jlx+0LDOY7Y8m9tLDHAsPN9aiyz/5NDHKqdDeke5NJZ2A4jbv+h/dvcyGH+Nxj056XW1aa9wzvzT9jb//A==
+
+"@rspack/binding-win32-ia32-msvc@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.4.4.tgz#7bb30955848eded381424be4ba99453a650f1644"
+  integrity sha512-ijw4bmB8Zh8BkawPqIc8Q7VWr6bSw9trMqTtXwHrXAyKYCdyXMCYsGnj7Rc6CKKrV6D6nsDXtA8ANFqoKCuvyw==
+
+"@rspack/binding-win32-x64-msvc@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.4.4.tgz#985f5d933c33fc8caa10419fca1a9eaeac773eb2"
+  integrity sha512-jpJPjfNTEbHBCOuZotXhpBpR0C1jTvHh6wlgPjP286JXaAhGv/PEzriuRdXw0RSet1tf1vqn/V4lFU5hZbXZIA==
+
+"@rspack/binding@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rspack/binding/-/binding-0.4.4.tgz#3dc1da11ae39b760ba08287096e77b75e25d3c39"
+  integrity sha512-CrZH2Vpf4Axi23GlD8qesyxmpplkYo6o5MlPuUtqNGrIA3JpPSRtBVLOE1NsMZ3+hnDHJ5GWtWoWkEB0p3beBA==
+  optionalDependencies:
+    "@rspack/binding-darwin-arm64" "0.4.4"
+    "@rspack/binding-darwin-x64" "0.4.4"
+    "@rspack/binding-linux-arm64-gnu" "0.4.4"
+    "@rspack/binding-linux-arm64-musl" "0.4.4"
+    "@rspack/binding-linux-x64-gnu" "0.4.4"
+    "@rspack/binding-linux-x64-musl" "0.4.4"
+    "@rspack/binding-win32-arm64-msvc" "0.4.4"
+    "@rspack/binding-win32-ia32-msvc" "0.4.4"
+    "@rspack/binding-win32-x64-msvc" "0.4.4"
+
+"@rspack/cli@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rspack/cli/-/cli-0.4.4.tgz#40abb143a9392a443c99d6149af6b09224cfa88a"
+  integrity sha512-hLF91sDzeFde7Hm8VustRPsowd6g9Nf7uZ0CJugwxx4IE+zcKULHm74GkpLGsiPWlf18uuIX7GVOtobX2NyF6g==
+  dependencies:
+    "@discoveryjs/json-ext" "^0.5.7"
+    "@rspack/dev-server" "0.4.4"
+    colorette "2.0.19"
+    exit-hook "^3.2.0"
+    interpret "^3.1.1"
+    rechoir "^0.8.0"
+    semver "6.3.1"
+    webpack-bundle-analyzer "4.6.1"
+    yargs "17.6.2"
+
+"@rspack/core@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rspack/core/-/core-0.4.4.tgz#b26c49a618822112436c77f50fa45164e3f9f843"
+  integrity sha512-SL6g6ZPPOqPI1wuQrZlSXD73HUg7GO5+wFRSATRak9hZ3wzSvYmD0kRGSCc6Kpndn21pmMLeOXNHbk2bL+x37g==
+  dependencies:
+    "@rspack/binding" "0.4.4"
+    "@swc/helpers" "0.5.1"
+    browserslist "^4.21.3"
+    compare-versions "6.0.0-rc.1"
+    enhanced-resolve "5.12.0"
+    graceful-fs "4.2.10"
+    json-parse-even-better-errors "^3.0.0"
+    neo-async "2.6.2"
+    react-refresh "0.14.0"
+    tapable "2.2.1"
+    terminal-link "^2.1.1"
+    watchpack "^2.4.0"
+    webpack-sources "3.2.3"
+    zod "^3.21.4"
+    zod-validation-error "1.3.1"
+
+"@rspack/dev-server@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rspack/dev-server/-/dev-server-0.4.4.tgz#b690ecb6e5d61a50089f944052c93b625101231b"
+  integrity sha512-mvlUp3DrZY7RwRIPpEPtqpFbut6x3eRc+F+Vj4c9IABX/OCdxS57xJM3yPZM4CH7H4VCgikWCiJEzszxoYjISA==
+  dependencies:
+    "@rspack/plugin-react-refresh" "0.4.4"
+    chokidar "3.5.3"
+    connect-history-api-fallback "2.0.0"
+    express "4.18.1"
+    http-proxy-middleware "2.0.6"
+    mime-types "2.1.35"
+    webpack "5.76.0"
+    webpack-dev-middleware "6.0.2"
+    webpack-dev-server "4.13.1"
+    ws "8.8.1"
+
+"@rspack/plugin-react-refresh@0.4.4":
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/@rspack/plugin-react-refresh/-/plugin-react-refresh-0.4.4.tgz#6813560f33d1e75b330b6c93cbe84b1ee2c6cdd9"
+  integrity sha512-AWC1VirWqKalVJpUi0i09cjYf7bfSG0qCoMNOym45bs9D2Hi3mxqrGEaMupTfkaSDdmJ/9VsUgUCHpgxAshJuw==
+
 "@sigstore/bundle@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@sigstore/bundle/-/bundle-1.1.0.tgz#17f8d813b09348b16eeed66a8cf1c3d6bd3d04f1"
@@ -2730,6 +2857,13 @@
     "@smithy/types" "^2.6.0"
     tslib "^2.5.0"
 
+"@swc/helpers@0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.1.tgz#e9031491aa3f26bfcc974a67f48bd456c8a5357a"
+  integrity sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==
+  dependencies:
+    tslib "^2.4.0"
+
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.6.tgz#b4a914bb62e7c272d4e5989fe4440f812ab1d807"
@@ -2869,7 +3003,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*":
+"@types/estree@*", "@types/estree@^0.0.51":
   version "0.0.51"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
@@ -3320,6 +3454,14 @@
   resolved "https://registry.yarnpkg.com/@vscode/l10n/-/l10n-0.0.10.tgz#9c513107c690c0dd16e3ec61e453743de15ebdb0"
   integrity sha512-E1OCmDcDWa0Ya7vtSjp/XfHFGqYJfh+YPC1RkATU71fTac+j1JjCcB3qwSzmlKAighx2WxhLlfhS0RwAN++PFQ==
 
+"@webassemblyjs/ast@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"
+  integrity sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==
+  dependencies:
+    "@webassemblyjs/helper-numbers" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+
 "@webassemblyjs/ast@1.11.6", "@webassemblyjs/ast@^1.11.5":
   version "1.11.6"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.6.tgz#db046555d3c413f8966ca50a95176a0e2c642e24"
@@ -3328,20 +3470,44 @@
     "@webassemblyjs/helper-numbers" "1.11.6"
     "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
 
+"@webassemblyjs/floating-point-hex-parser@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz#f6c61a705f0fd7a6aecaa4e8198f23d9dc179e4f"
+  integrity sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==
+
 "@webassemblyjs/floating-point-hex-parser@1.11.6":
   version "1.11.6"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz#dacbcb95aff135c8260f77fa3b4c5fea600a6431"
   integrity sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==
+
+"@webassemblyjs/helper-api-error@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz#1a63192d8788e5c012800ba6a7a46c705288fd16"
+  integrity sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==
 
 "@webassemblyjs/helper-api-error@1.11.6":
   version "1.11.6"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz#6132f68c4acd59dcd141c44b18cbebbd9f2fa768"
   integrity sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==
 
+"@webassemblyjs/helper-buffer@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz#832a900eb444884cde9a7cad467f81500f5e5ab5"
+  integrity sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==
+
 "@webassemblyjs/helper-buffer@1.11.6":
   version "1.11.6"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz#b66d73c43e296fd5e88006f18524feb0f2c7c093"
   integrity sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==
+
+"@webassemblyjs/helper-numbers@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz#64d81da219fbbba1e3bd1bfc74f6e8c4e10a62ae"
+  integrity sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser" "1.11.1"
+    "@webassemblyjs/helper-api-error" "1.11.1"
+    "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/helper-numbers@1.11.6":
   version "1.11.6"
@@ -3352,10 +3518,25 @@
     "@webassemblyjs/helper-api-error" "1.11.6"
     "@xtuc/long" "4.2.2"
 
+"@webassemblyjs/helper-wasm-bytecode@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz#f328241e41e7b199d0b20c18e88429c4433295e1"
+  integrity sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==
+
 "@webassemblyjs/helper-wasm-bytecode@1.11.6":
   version "1.11.6"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz#bb2ebdb3b83aa26d9baad4c46d4315283acd51e9"
   integrity sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==
+
+"@webassemblyjs/helper-wasm-section@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz#21ee065a7b635f319e738f0dd73bfbda281c097a"
+  integrity sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
 
 "@webassemblyjs/helper-wasm-section@1.11.6":
   version "1.11.6"
@@ -3367,12 +3548,26 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.11.6"
     "@webassemblyjs/wasm-gen" "1.11.6"
 
+"@webassemblyjs/ieee754@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz#963929e9bbd05709e7e12243a099180812992614"
+  integrity sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
 "@webassemblyjs/ieee754@1.11.6":
   version "1.11.6"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz#bb665c91d0b14fffceb0e38298c329af043c6e3a"
   integrity sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
+
+"@webassemblyjs/leb128@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.1.tgz#ce814b45574e93d76bae1fb2644ab9cdd9527aa5"
+  integrity sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==
+  dependencies:
+    "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/leb128@1.11.6":
   version "1.11.6"
@@ -3381,10 +3576,29 @@
   dependencies:
     "@xtuc/long" "4.2.2"
 
+"@webassemblyjs/utf8@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.1.tgz#d1f8b764369e7c6e6bae350e854dec9a59f0a3ff"
+  integrity sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==
+
 "@webassemblyjs/utf8@1.11.6":
   version "1.11.6"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.6.tgz#90f8bc34c561595fe156603be7253cdbcd0fab5a"
   integrity sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==
+
+"@webassemblyjs/wasm-edit@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz#ad206ebf4bf95a058ce9880a8c092c5dec8193d6"
+  integrity sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/helper-wasm-section" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
+    "@webassemblyjs/wasm-opt" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    "@webassemblyjs/wast-printer" "1.11.1"
 
 "@webassemblyjs/wasm-edit@^1.11.5":
   version "1.11.6"
@@ -3400,6 +3614,17 @@
     "@webassemblyjs/wasm-parser" "1.11.6"
     "@webassemblyjs/wast-printer" "1.11.6"
 
+"@webassemblyjs/wasm-gen@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz#86c5ea304849759b7d88c47a32f4f039ae3c8f76"
+  integrity sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/ieee754" "1.11.1"
+    "@webassemblyjs/leb128" "1.11.1"
+    "@webassemblyjs/utf8" "1.11.1"
+
 "@webassemblyjs/wasm-gen@1.11.6":
   version "1.11.6"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz#fb5283e0e8b4551cc4e9c3c0d7184a65faf7c268"
@@ -3411,6 +3636,16 @@
     "@webassemblyjs/leb128" "1.11.6"
     "@webassemblyjs/utf8" "1.11.6"
 
+"@webassemblyjs/wasm-opt@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz#657b4c2202f4cf3b345f8a4c6461c8c2418985f2"
+  integrity sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-buffer" "1.11.1"
+    "@webassemblyjs/wasm-gen" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+
 "@webassemblyjs/wasm-opt@1.11.6":
   version "1.11.6"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz#d9a22d651248422ca498b09aa3232a81041487c2"
@@ -3420,6 +3655,18 @@
     "@webassemblyjs/helper-buffer" "1.11.6"
     "@webassemblyjs/wasm-gen" "1.11.6"
     "@webassemblyjs/wasm-parser" "1.11.6"
+
+"@webassemblyjs/wasm-parser@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz#86ca734534f417e9bd3c67c7a1c75d8be41fb199"
+  integrity sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/helper-api-error" "1.11.1"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.1"
+    "@webassemblyjs/ieee754" "1.11.1"
+    "@webassemblyjs/leb128" "1.11.1"
+    "@webassemblyjs/utf8" "1.11.1"
 
 "@webassemblyjs/wasm-parser@1.11.6", "@webassemblyjs/wasm-parser@^1.11.5":
   version "1.11.6"
@@ -3432,6 +3679,14 @@
     "@webassemblyjs/ieee754" "1.11.6"
     "@webassemblyjs/leb128" "1.11.6"
     "@webassemblyjs/utf8" "1.11.6"
+
+"@webassemblyjs/wast-printer@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz#d0c73beda8eec5426f10ae8ef55cee5e7084c2f0"
+  integrity sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.1"
+    "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/wast-printer@1.11.6":
   version "1.11.6"
@@ -3509,7 +3764,7 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-acorn-import-assertions@^1.9.0:
+acorn-import-assertions@^1.7.6, acorn-import-assertions@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
   integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
@@ -3518,6 +3773,11 @@ acorn-jsx@^5.3.1, acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
+acorn-walk@^8.0.0:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.1.tgz#2f10f5b69329d90ae18c58bf1fa8fccd8b959a43"
+  integrity sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==
 
 acorn-walk@^8.1.1:
   version "8.2.0"
@@ -3529,15 +3789,15 @@ acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
+acorn@^8.0.4, acorn@^8.8.2:
+  version "8.11.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b"
+  integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
+
 acorn@^8.4.1, acorn@^8.5.0, acorn@^8.7.0, acorn@^8.7.1, acorn@^8.8.0:
   version "8.8.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
-
-acorn@^8.8.2:
-  version "8.11.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b"
-  integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -4032,6 +4292,24 @@ bluebird@^3.0.6, bluebird@^3.1.1, bluebird@^3.5.0:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
+body-parser@1.20.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.0.tgz#3de69bd89011c11573d7bfee6a64f11b6bd27cc5"
+  integrity sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==
+  dependencies:
+    bytes "3.1.2"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    on-finished "2.4.1"
+    qs "6.10.3"
+    raw-body "2.5.1"
+    type-is "~1.6.18"
+    unpipe "1.0.0"
+
 body-parser@1.20.1:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
@@ -4129,6 +4407,16 @@ browserslist@^4.14.5, browserslist@^4.17.5:
     escalade "^3.1.1"
     node-releases "^2.0.1"
     picocolors "^1.0.0"
+
+browserslist@^4.21.3:
+  version "4.22.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.22.2.tgz#704c4943072bd81ea18997f3bd2180e89c77874b"
+  integrity sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==
+  dependencies:
+    caniuse-lite "^1.0.30001565"
+    electron-to-chromium "^1.4.601"
+    node-releases "^2.0.14"
+    update-browserslist-db "^1.0.13"
 
 buffer-crc32@~0.2.3:
   version "0.2.13"
@@ -4300,6 +4588,11 @@ caniuse-lite@^1.0.30001286:
   version "1.0.30001418"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001418.tgz"
   integrity sha512-oIs7+JL3K9JRQ3jPZjlH6qyYDp+nBTCais7hjh0s+fuBwufc7uZ7hPYMXrDOJhV360KGMTcczMRObk0/iMqZRg==
+
+caniuse-lite@^1.0.30001565:
+  version "1.0.30001571"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001571.tgz#4182e93d696ff42930f4af7eba515ddeb57917ac"
+  integrity sha512-tYq/6MoXhdezDLFZuCO/TKboTzuQ/xR5cFdgXPfDtM7/kchBO3b4VWghE/OAi/DV7tTdhmLjZiZBZi1fA/GheQ==
 
 chai-as-promised@^7.0.0:
   version "7.1.1"
@@ -4589,7 +4882,7 @@ color-support@^1.1.2, color-support@^1.1.3:
   resolved "https://registry.yarnpkg.com/color-support/-/color-support-1.1.3.tgz#93834379a1cc9a0c61f82f52f0d04322251bd5a2"
   integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
 
-colorette@^2.0.10, colorette@^2.0.19:
+colorette@2.0.19, colorette@^2.0.10, colorette@^2.0.19:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
@@ -4639,6 +4932,11 @@ commander@^5.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
+commander@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
+  integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
 commander@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
@@ -4661,6 +4959,11 @@ compare-version@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/compare-version/-/compare-version-0.1.2.tgz#0162ec2d9351f5ddd59a9202cba935366a725080"
   integrity sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==
+
+compare-versions@6.0.0-rc.1:
+  version "6.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.0.0-rc.1.tgz#93e6beb8767c2375333ee168fa64c28b75ace2c6"
+  integrity sha512-cFhkjbGY1jLFWIV7KegECbfuyYPxSGvgGkdkfM+ibboQDoPwg2FRHm5BSNTOApiauRBzJIQH7qvOJs2sW5ueKQ==
 
 compressible@^2.0.12, compressible@~2.0.16:
   version "2.0.18"
@@ -4705,7 +5008,7 @@ config-chain@1.1.12:
     ini "^1.3.4"
     proto-list "~1.2.1"
 
-connect-history-api-fallback@^2.0.0:
+connect-history-api-fallback@2.0.0, connect-history-api-fallback@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz#647264845251a0daf25b97ce87834cace0f5f1c8"
   integrity sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==
@@ -5319,7 +5622,7 @@ ds-store@^0.1.5:
     macos-alias "~0.2.5"
     tn1150 "^0.1.0"
 
-duplexer@^0.1.1:
+duplexer@^0.1.1, duplexer@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.2.tgz#3abe43aef3835f8ae077d136ddce0f276b0400e6"
   integrity sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==
@@ -5433,6 +5736,11 @@ electron-to-chromium@^1.4.17:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz#17056914465da0890ce00351a3b946fd4cd51ff6"
   integrity sha512-Hk61vXXKRb2cd3znPE9F+2pLWdIOmP7GjiTj45y6L3W/lO+hSnUSUhq+6lEaERWBdZOHbk2s3YV5c9xVl3boVw==
 
+electron-to-chromium@^1.4.601:
+  version "1.4.616"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.616.tgz#4bddbc2c76e1e9dbf449ecd5da3d8119826ea4fb"
+  integrity sha512-1n7zWYh8eS0L9Uy+GskE0lkBUNK83cXTVJI0pU3mGprFsbfSdAc15VTFbo+A+Bq4pwstmL30AVcEU3Fo463lNg==
+
 electron-windows-store@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/electron-windows-store/-/electron-windows-store-2.1.0.tgz#c217f0c0617fd70afd2d475c88eb35e8f9bb615e"
@@ -5509,7 +5817,15 @@ end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^5.15.0:
+enhanced-resolve@5.12.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz#300e1c90228f5b570c4d35babf263f6da7155634"
+  integrity sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
+enhanced-resolve@^5.10.0, enhanced-resolve@^5.15.0:
   version "5.15.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz#1af946c7d93603eb88e9896cee4904dc012e9c35"
   integrity sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==
@@ -5640,6 +5956,11 @@ es-array-method-boxes-properly@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz#873f3e84418de4ee19c5be752990b2e44718d09e"
   integrity sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==
+
+es-module-lexer@^0.9.0:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.9.3.tgz#6f13db00cc38417137daf74366f535c8eb438f19"
+  integrity sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==
 
 es-module-lexer@^1.2.1:
   version "1.4.1"
@@ -6310,6 +6631,11 @@ execa@^5.0.0, execa@^5.1.1:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
+exit-hook@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-3.2.0.tgz#7d86bc361a4d79278001b72a0509318a6f468f20"
+  integrity sha512-aIQN7Q04HGAV/I5BszisuHTZHXNoC23WtLkxdCLuYZMdWviRD0TMIt2bnUBi9MrHaF/hH8b3gwG9iaAUHKnJGA==
+
 expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
@@ -6328,6 +6654,43 @@ express-ws@^5.0.2:
   integrity sha512-0uvmuk61O9HXgLhGl3QhNSEtRsQevtmbL94/eILaliEADZBHZOQUAiHFrGPrgsjikohyrmSG5g+sCfASTt0lkQ==
   dependencies:
     ws "^7.4.6"
+
+express@4.18.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.18.1.tgz#7797de8b9c72c857b9cd0e14a5eea80666267caf"
+  integrity sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==
+  dependencies:
+    accepts "~1.3.8"
+    array-flatten "1.1.1"
+    body-parser "1.20.0"
+    content-disposition "0.5.4"
+    content-type "~1.0.4"
+    cookie "0.5.0"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "2.0.0"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "1.2.0"
+    fresh "0.5.2"
+    http-errors "2.0.0"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "2.4.1"
+    parseurl "~1.3.3"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.7"
+    qs "6.10.3"
+    range-parser "~1.2.1"
+    safe-buffer "5.2.1"
+    send "0.18.0"
+    serve-static "1.15.0"
+    setprototypeof "1.2.0"
+    statuses "2.0.1"
+    type-is "~1.6.18"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
 
 express@^4.17.1, express@^4.17.3:
   version "4.18.2"
@@ -6819,6 +7182,11 @@ fs-monkey@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.3.tgz#ae3ac92d53bb328efe0e9a1d9541f6ad8d48e2d3"
   integrity sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==
+
+fs-monkey@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.5.tgz#fe450175f0db0d7ea758102e1d84096acb925788"
+  integrity sha512-8uMbBjrhzW76TYgEV27Y5E//W2f/lTFmx78P2w19FZSxarhI/798APGQyuGCwmkNxgwGRhrLfvWyLBvNtuOmew==
 
 fs-temp@^1.0.0:
   version "1.2.1"
@@ -7384,6 +7752,13 @@ gtoken@^7.0.0:
     gaxios "^6.0.0"
     jws "^4.0.0"
 
+gzip-size@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
+  integrity sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==
+  dependencies:
+    duplexer "^0.1.2"
+
 handle-thing@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
@@ -7606,7 +7981,7 @@ http-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-http-proxy-middleware@^2.0.3:
+http-proxy-middleware@2.0.6, http-proxy-middleware@^2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz#e1a4dd6979572c7ab5a4e4b55095d1f32a74963f"
   integrity sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==
@@ -8469,6 +8844,14 @@ kleur@^4.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
   integrity sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==
 
+launch-editor@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.6.1.tgz#f259c9ef95cbc9425620bbbd14b468fcdb4ffe3c"
+  integrity sha512-eB/uXmFVpY4zezmGp5XtU21kwo7GBbKB+EQ+UZeWtGb9yAM5xt/Evk+lYH3eRNAtId+ej4u7TYPFZ07w4s7rRw==
+  dependencies:
+    picocolors "^1.0.0"
+    shell-quote "^1.8.1"
+
 lerna@^6.6.2:
   version "6.6.2"
   resolved "https://registry.yarnpkg.com/lerna/-/lerna-6.6.2.tgz#ad921f913aca4e7307123a598768b6f15ca5804f"
@@ -9076,6 +9459,13 @@ memfs@^3.4.1, memfs@^3.4.3:
   dependencies:
     fs-monkey "^1.0.3"
 
+memfs@^3.4.12:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.6.0.tgz#d7a2110f86f79dd950a8b6df6d57bc984aa185f6"
+  integrity sha512-EGowvkkgbMcIChjMTMkESFDbZeSh8xZ7kNSF0hAiAN4Jh6jgHCRS0Ga/+C8y6Au+oqpezRHCfPsmJ2+DwAgiwQ==
+  dependencies:
+    fs-monkey "^1.0.4"
+
 meow@^8.0.0:
   version "8.1.2"
   resolved "https://registry.yarnpkg.com/meow/-/meow-8.1.2.tgz#bcbe45bda0ee1729d350c03cffc8395a36c4e897"
@@ -9320,7 +9710,7 @@ mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.0.8, mime-types@^2.1.12, mime-types@^2.1.25, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@2.1.35, mime-types@^2.0.8, mime-types@^2.1.12, mime-types@^2.1.25, mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -9636,6 +10026,11 @@ mri@^1.1.0:
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
   integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
+mrmime@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-1.0.1.tgz#5f90c825fad4bdd41dc914eff5d1a8cfdaf24f27"
+  integrity sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -9726,7 +10121,7 @@ negotiator@0.6.3, negotiator@^0.6.3:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
 
-neo-async@^2.6.0, neo-async@^2.6.2:
+neo-async@2.6.2, neo-async@^2.6.0, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -9840,6 +10235,11 @@ node-releases@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.2.tgz#7139fe71e2f4f11b47d4d2986aaf8c48699e0c01"
   integrity sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==
+
+node-releases@^2.0.14:
+  version "2.0.14"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.14.tgz#2ffb053bceb8b2be8495ece1ab6ce600c4461b0b"
+  integrity sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==
 
 nopt@^5.0.0:
   version "5.0.0"
@@ -10285,6 +10685,11 @@ open@^8.0.9, open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
+
+opener@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
+  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
 optionator@^0.9.1:
   version "0.9.1"
@@ -10955,6 +11360,13 @@ q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==
 
+qs@6.10.3:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
+  integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@6.11.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
@@ -11045,6 +11457,11 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react-refresh@0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
+  integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
 
 read-cmd-shim@3.0.0:
   version "3.0.0"
@@ -11544,19 +11961,19 @@ safe-regex-test@^1.0.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-schema-utils@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
-  integrity sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==
+schema-utils@^3.1.0, schema-utils@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
+  integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
   dependencies:
     "@types/json-schema" "^7.0.8"
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-schema-utils@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
-  integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
+schema-utils@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.1.1.tgz#bc74c4b6b6995c1d88f76a8b77bea7219e0c8281"
+  integrity sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==
   dependencies:
     "@types/json-schema" "^7.0.8"
     ajv "^6.12.5"
@@ -11594,6 +12011,11 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
+semver@6.3.1, semver@^6.0.0, semver@^6.1.0, semver@^6.2.0, semver@^6.3.0:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
+  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
 semver@7.3.8:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
@@ -11607,11 +12029,6 @@ semver@7.5.4, semver@^7.0.0, semver@^7.1.1, semver@^7.1.3, semver@^7.2.1, semver
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
-
-semver@^6.0.0, semver@^6.1.0, semver@^6.2.0, semver@^6.3.0:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
 send@0.18.0:
   version "0.18.0"
@@ -11722,6 +12139,11 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shell-quote@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.1.tgz#6dbf4db75515ad5bac63b4f1894c3a154c766680"
+  integrity sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==
+
 shiki@^0.10.1:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.10.1.tgz#6f9a16205a823b56c072d0f1a0bcd0f2646bef14"
@@ -11777,6 +12199,15 @@ sinon@^13.0.1:
     diff "^5.0.0"
     nise "^5.1.1"
     supports-color "^7.2.0"
+
+sirv@^1.0.7:
+  version "1.0.19"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-1.0.19.tgz#1d73979b38c7fe91fcba49c85280daa9c2363b49"
+  integrity sha512-JuLThK3TnZG1TAKDwNIqNq6QA2afLOCcm+iE8D1Kj3GA40pSPsxQjjJl0J8X3tsR7T+CP1GavpzLwYkgVLWrZQ==
+  dependencies:
+    "@polka/url" "^1.0.0-next.20"
+    mrmime "^1.0.0"
+    totalist "^1.0.0"
 
 slash@3.0.0, slash@^3.0.0:
   version "3.0.0"
@@ -12247,7 +12678,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.1.0, supports-color@^7.2.0:
+supports-color@^7.0.0, supports-color@^7.1.0, supports-color@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -12258,6 +12689,14 @@ supports-color@^9.2.2:
   version "9.2.3"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-9.2.3.tgz#a6e2c97fc20c80abecd69e50aebe4783ff77d45a"
   integrity sha512-aszYUX/DVK/ed5rFLb/dDinVJrQjG/vmU433wtqVSD800rYsJNWxh2R3USV90aLSU+UsyQkbNeffVLzc6B6foA==
+
+supports-hyperlinks@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz#3943544347c1ff90b15effb03fc14ae45ec10624"
+  integrity sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==
+  dependencies:
+    has-flag "^4.0.0"
+    supports-color "^7.0.0"
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
@@ -12291,7 +12730,7 @@ table@^6.0.9:
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
 
-tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0, tapable@^2.2.1:
+tapable@2.2.1, tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0, tapable@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
@@ -12359,7 +12798,15 @@ tempy@1.0.0:
     type-fest "^0.16.0"
     unique-string "^2.0.0"
 
-terser-webpack-plugin@^5.3.7:
+terminal-link@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
+  integrity sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    supports-hyperlinks "^2.0.0"
+
+terser-webpack-plugin@^5.1.3, terser-webpack-plugin@^5.3.7:
   version "5.3.9"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz#832536999c51b46d468067f9e37662a3b96adfe1"
   integrity sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==
@@ -12494,6 +12941,11 @@ toidentifier@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
+
+totalist@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/totalist/-/totalist-1.1.0.tgz#a4d65a3e546517701e3e5c37a47a70ac97fe56df"
+  integrity sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==
 
 tr46@^1.0.1:
   version "1.0.1"
@@ -12844,6 +13296,14 @@ upath@2.0.1, upath@^2.0.1:
   resolved "https://registry.yarnpkg.com/upath/-/upath-2.0.1.tgz#50c73dea68d6f6b990f51d279ce6081665d61a8b"
   integrity sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==
 
+update-browserslist-db@^1.0.13:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz#3c5e4f5c083661bd38ef64b6328c26ed6c8248c4"
+  integrity sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==
+  dependencies:
+    escalade "^3.1.1"
+    picocolors "^1.0.0"
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
@@ -13044,6 +13504,32 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
+webpack-bundle-analyzer@4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.6.1.tgz#bee2ee05f4ba4ed430e4831a319126bb4ed9f5a6"
+  integrity sha512-oKz9Oz9j3rUciLNfpGFjOb49/jEpXNmWdVH8Ls//zNcnLlQdTGXQQMsBbb/gR7Zl8WNLxVCq+0Hqbx3zv6twBw==
+  dependencies:
+    acorn "^8.0.4"
+    acorn-walk "^8.0.0"
+    chalk "^4.1.0"
+    commander "^7.2.0"
+    gzip-size "^6.0.0"
+    lodash "^4.17.20"
+    opener "^1.5.2"
+    sirv "^1.0.7"
+    ws "^7.3.1"
+
+webpack-dev-middleware@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-6.0.2.tgz#4aab69257378e01d6fe964a8b2d07e8a87623ebc"
+  integrity sha512-iOddiJzPcQC6lwOIu60vscbGWth8PCRcWRCwoQcTQf9RMoOWBHg5EyzpGdtSmGMrSPd5vHEfFXmVErQEmkRngQ==
+  dependencies:
+    colorette "^2.0.10"
+    memfs "^3.4.12"
+    mime-types "^2.1.31"
+    range-parser "^1.2.1"
+    schema-utils "^4.0.0"
+
 webpack-dev-middleware@^5.3.1:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz#efae67c2793908e7311f1d9b06f2a08dcc97e51f"
@@ -13054,6 +13540,42 @@ webpack-dev-middleware@^5.3.1:
     mime-types "^2.1.31"
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
+
+webpack-dev-server@4.13.1:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.13.1.tgz#6417a9b5d2f528e7644b68d6ed335e392dccffe8"
+  integrity sha512-5tWg00bnWbYgkN+pd5yISQKDejRBYGEw15RaEEslH+zdbNDxxaZvEAO2WulaSaFKb5n3YG8JXsGaDsut1D0xdA==
+  dependencies:
+    "@types/bonjour" "^3.5.9"
+    "@types/connect-history-api-fallback" "^1.3.5"
+    "@types/express" "^4.17.13"
+    "@types/serve-index" "^1.9.1"
+    "@types/serve-static" "^1.13.10"
+    "@types/sockjs" "^0.3.33"
+    "@types/ws" "^8.5.1"
+    ansi-html-community "^0.0.8"
+    bonjour-service "^1.0.11"
+    chokidar "^3.5.3"
+    colorette "^2.0.10"
+    compression "^1.7.4"
+    connect-history-api-fallback "^2.0.0"
+    default-gateway "^6.0.3"
+    express "^4.17.3"
+    graceful-fs "^4.2.6"
+    html-entities "^2.3.2"
+    http-proxy-middleware "^2.0.3"
+    ipaddr.js "^2.0.1"
+    launch-editor "^2.6.0"
+    open "^8.0.9"
+    p-retry "^4.5.0"
+    rimraf "^3.0.2"
+    schema-utils "^4.0.0"
+    selfsigned "^2.1.1"
+    serve-index "^1.9.1"
+    sockjs "^0.3.24"
+    spdy "^4.0.2"
+    webpack-dev-middleware "^5.3.1"
+    ws "^8.13.0"
 
 webpack-dev-server@^4.0.0:
   version "4.11.1"
@@ -13098,10 +13620,40 @@ webpack-merge@^5.7.3:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
-webpack-sources@^3.2.3:
+webpack-sources@3.2.3, webpack-sources@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
+
+webpack@5.76.0:
+  version "5.76.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.76.0.tgz#f9fb9fb8c4a7dbdcd0d56a98e56b8a942ee2692c"
+  integrity sha512-l5sOdYBDunyf72HW8dF23rFtWq/7Zgvt/9ftMof71E/yUb1YLOBmTgA2K4vQthB3kotMrSj609txVE0dnr2fjA==
+  dependencies:
+    "@types/eslint-scope" "^3.7.3"
+    "@types/estree" "^0.0.51"
+    "@webassemblyjs/ast" "1.11.1"
+    "@webassemblyjs/wasm-edit" "1.11.1"
+    "@webassemblyjs/wasm-parser" "1.11.1"
+    acorn "^8.7.1"
+    acorn-import-assertions "^1.7.6"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.10.0"
+    es-module-lexer "^0.9.0"
+    eslint-scope "5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.9"
+    json-parse-even-better-errors "^2.3.1"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.1.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.3"
+    watchpack "^2.4.0"
+    webpack-sources "^3.2.3"
 
 webpack@^5.69.1:
   version "5.89.0"
@@ -13325,10 +13877,25 @@ write-pkg@4.0.0:
     type-fest "^0.4.1"
     write-json-file "^3.2.0"
 
+ws@8.8.1:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
+  integrity sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==
+
+ws@^7.3.1:
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
+
 ws@^7.4.6:
   version "7.5.7"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.7.tgz#9e0ac77ee50af70d58326ecff7e85eb3fa375e67"
   integrity sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==
+
+ws@^8.13.0:
+  version "8.15.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.15.1.tgz#271ba33a45ca0cc477940f7f200cd7fba7ee1997"
+  integrity sha512-W5OZiCjXEmk0yZ66ZN82beM5Sz7l7coYxpRkzS+p9PP+ToQry8szKh+61eNktr7EA9DOwvFGhfC605jDHbP6QQ==
 
 ws@^8.4.2:
   version "8.10.0"
@@ -13449,6 +14016,19 @@ yargs@16.2.0, yargs@^16.0.0, yargs@^16.0.2, yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
+yargs@17.6.2, yargs@^17.6.2:
+  version "17.6.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
+  integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
 yargs@^17.0.1:
   version "17.3.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.3.1.tgz#da56b28f32e2fd45aefb402ed9c26f42be4c07b9"
@@ -13461,19 +14041,6 @@ yargs@^17.0.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.0.0"
-
-yargs@^17.6.2:
-  version "17.6.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.2.tgz#2e23f2944e976339a1ee00f18c77fedee8332541"
-  integrity sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==
-  dependencies:
-    cliui "^8.0.1"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
-    y18n "^5.0.5"
-    yargs-parser "^21.1.1"
 
 yarn-or-npm@^3.0.1:
   version "3.0.1"
@@ -13500,3 +14067,13 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod-validation-error@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-1.3.1.tgz#7134579d2ba3994495133b879a076786c8c270f5"
+  integrity sha512-cNEXpla+tREtNdAnNKY4xKY1SGOn2yzyuZMu4O0RQylX9apRpUjNcPkEc3uHIAr5Ct7LenjZt6RzjEH6+JsqVQ==
+
+zod@^3.21.4:
+  version "3.22.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
+  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

The idea of this PR is to bring a new plugin allowing us to use the [rspack](https://www.rspack.dev/) as a possible bundler for Electron with forge tooling. By the fact  that `rspack` has a similar API related for Webpack, it follows the same approach. As the example below:

```ts
    {
      name: '@electron-forge/plugin-rspack',
      config: {
        mainConfig: './rspack.main.config.js',
        renderer: {
          config: './rspack.renderer.config.js',
          entryPoints: [{
            name: 'main_window',
            html: './src/renderer/index.html',
            js: './src/renderer/index.js',
            preload: {
              js: './src/preload.js'
            }
          }]
        }
      }
    }
```
