### PR TITLE
fix(core): packageJSON won't be found when programmatic usage instead of CLI

### DIFF
--- a/packages/api/core/src/util/resolve-dir.ts
+++ b/packages/api/core/src/util/resolve-dir.ts
@@ -39,7 +39,7 @@ export default async (dir: string): Promise<string | null> => {
         return mDir;
       }
 
-      if (packageJSON.devDependencies?.['@electron-forge/cli']) {
+      if (packageJSON.devDependencies?.['@electron-forge/cli'] || packageJSON.devDependencies?.['@electron-forge/core']) {
         d('package.json with forge dependency found in', testPath);
         return mDir;
       }


### PR DESCRIPTION
If use programmatic usage instead of CLI, the 'package.json' wont be found in this function

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
