### PR TITLE
fix: .vscode settings.json changes on open

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,14 +3,14 @@
   "[typescript]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "explicit"
     },
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[javascript]": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "explicit"
     },
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },


### PR DESCRIPTION
- [X] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [X] The changes are appropriately documented (if applicable).
- [X] The changes have sufficient test coverage (if applicable).
- [X] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Visual Studio Code 1.85 automatically changes `settings.json` on open as `true` is no longer a valid setting.

See [vscode-workspace-settings-change-on-its-own](https://stackoverflow.com/questions/77637621/vscode-workspace-settings-change-on-its-own) and microsoft/vscode-eslint#1750 @dbaeumer

#3456