### PR TITLE
fix: normalize windows version with build part correctly

### DIFF
--- a/packages/maker/appx/src/MakerAppX.ts
+++ b/packages/maker/appx/src/MakerAppX.ts
@@ -110,7 +110,7 @@ export default class MakerAppX extends MakerBase<MakerAppXConfig> {
       opts.devCert = await createDefaultCertificate(opts.publisher, { certFilePath: outPath, program: opts });
     }
 
-    if (opts.packageVersion.includes('-')) {
+    if (/[-+]/.test(opts.packageVersion)) {
       if (opts.makeVersionWinStoreCompatible) {
         opts.packageVersion = this.normalizeWindowsVersion(opts.packageVersion);
       } else {

--- a/packages/maker/base/src/Maker.ts
+++ b/packages/maker/base/src/Maker.ts
@@ -174,7 +174,7 @@ export default abstract class Maker<C> implements IForgeMaker {
    * prerelease information for use in Windows apps.
    */
   normalizeWindowsVersion(version: string): string {
-    const noPrerelease = version.replace(/-.*/, '');
+    const noPrerelease = version.replace(/[-+].*/, '');
     return `${noPrerelease}.0`;
   }
 }

--- a/packages/maker/base/test/version_spec.ts
+++ b/packages/maker/base/test/version_spec.ts
@@ -16,6 +16,11 @@ describe('normalizeWindowsVersion', () => {
       expect(maker.normalizeWindowsVersion(version)).to.equal('1.0.0.0');
     }
   });
+  it('removes everything after the plus sign', () => {
+    for (const version of ['1.0.0-alpha+001', '1.0.0+20130313144700', '1.0.0-beta+exp.sha.5114f85', '1.0.0+21AF26D3----117B344092BD']) {
+      expect(maker.normalizeWindowsVersion(version)).to.equal('1.0.0.0');
+    }
+  });
   it('does not truncate the version when there is no dash', () => {
     expect(maker.normalizeWindowsVersion('2.0.0')).to.equal('2.0.0.0');
   });


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

According to [semver2](https://semver.org/), a version can consist of a build part denoted by a `+` sign. The current implementation of `normalizeWindowsVersion` does not take that into account. Although the `+` sign usually comes after a `-` sign, it is not always the case. `normalizeWindowsVersion` should also handle the case where only `+` but not `-` exists.
