### PR TITLE
feat: adds default fuses to templates

### DIFF
--- a/packages/template/base/tmpl/forge.config.js
+++ b/packages/template/base/tmpl/forge.config.js
@@ -29,9 +29,16 @@ module.exports = {
       name: '@electron-forge/plugin-auto-unpack-natives',
       config: {},
     },
+    // Fuses are used to enable/disable various Electron functionality
+    // at package time, before code signing the application
     new FusesPlugin({
       version: FuseVersion.V1,
       [FuseV1Options.RunAsNode]: false,
+      [FuseV1Options.EnableCookieEncryption]: true,
+      [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+      [FuseV1Options.EnableNodeCliInspectArguments]: false,
+      [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+      [FuseV1Options.OnlyLoadAppFromAsar]: true,
     }),
   ],
 };

--- a/packages/template/base/tmpl/forge.config.js
+++ b/packages/template/base/tmpl/forge.config.js
@@ -1,3 +1,6 @@
+const { FusesPlugin } = require('@electron-forge/plugin-fuses');
+const { FuseV1Options, FuseVersion } = require('@electron/fuses');
+
 module.exports = {
   packagerConfig: {
     asar: true,
@@ -26,5 +29,9 @@ module.exports = {
       name: '@electron-forge/plugin-auto-unpack-natives',
       config: {},
     },
+    new FusesPlugin({
+      version: FuseVersion.V1,
+      [FuseV1Options.RunAsNode]: false,
+    }),
   ],
 };

--- a/packages/template/base/tmpl/package.json
+++ b/packages/template/base/tmpl/package.json
@@ -10,6 +10,10 @@
     "make": "electron-forge make",
     "publish": "electron-forge publish"
   },
+  "devDependencies": {
+    "@electron/fuses": "^1.7.0",
+    "@electron-forge/plugin-fuses": "^7.2.0"
+  },
   "keywords": [],
   "author": "",
   "license": "MIT"

--- a/packages/template/vite-typescript/tmpl/forge.config.ts
+++ b/packages/template/vite-typescript/tmpl/forge.config.ts
@@ -4,6 +4,8 @@ import { MakerZIP } from '@electron-forge/maker-zip';
 import { MakerDeb } from '@electron-forge/maker-deb';
 import { MakerRpm } from '@electron-forge/maker-rpm';
 import { VitePlugin } from '@electron-forge/plugin-vite';
+import { FusesPlugin } from '@electron-forge/plugin-fuses';
+import { FuseV1Options, FuseVersion } from '@electron/fuses';
 
 const config: ForgeConfig = {
   packagerConfig: {},
@@ -30,6 +32,10 @@ const config: ForgeConfig = {
           config: 'vite.renderer.config.ts',
         },
       ],
+    }),
+    new FusesPlugin({
+      version: FuseVersion.V1,
+      [FuseV1Options.RunAsNode]: false,
     }),
   ],
 };

--- a/packages/template/vite-typescript/tmpl/forge.config.ts
+++ b/packages/template/vite-typescript/tmpl/forge.config.ts
@@ -8,7 +8,9 @@ import { FusesPlugin } from '@electron-forge/plugin-fuses';
 import { FuseV1Options, FuseVersion } from '@electron/fuses';
 
 const config: ForgeConfig = {
-  packagerConfig: {},
+  packagerConfig: {
+    asar: true,
+  },
   rebuildConfig: {},
   makers: [new MakerSquirrel({}), new MakerZIP({}, ['darwin']), new MakerRpm({}), new MakerDeb({})],
   plugins: [
@@ -33,9 +35,16 @@ const config: ForgeConfig = {
         },
       ],
     }),
+    // Fuses are used to enable/disable various Electron functionality
+    // at package time, before code signing the application
     new FusesPlugin({
       version: FuseVersion.V1,
       [FuseV1Options.RunAsNode]: false,
+      [FuseV1Options.EnableCookieEncryption]: true,
+      [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+      [FuseV1Options.EnableNodeCliInspectArguments]: false,
+      [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+      [FuseV1Options.OnlyLoadAppFromAsar]: true,
     }),
   ],
 };

--- a/packages/template/vite-typescript/tmpl/package.json
+++ b/packages/template/vite-typescript/tmpl/package.json
@@ -1,5 +1,7 @@
 {
   "devDependencies": {
+    "@electron/fuses": "^1.7.0",
+    "@electron-forge/plugin-fuses": "^7.2.0",
     "@electron-forge/plugin-vite": "ELECTRON_FORGE/VERSION",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",

--- a/packages/template/vite/tmpl/forge.config.js
+++ b/packages/template/vite/tmpl/forge.config.js
@@ -1,3 +1,6 @@
+const { FusesPlugin } = require('@electron-forge/plugin-fuses');
+const { FuseV1Options, FuseVersion } = require('@electron/fuses');
+
 module.exports = {
   packagerConfig: {},
   rebuildConfig: {},
@@ -44,5 +47,9 @@ module.exports = {
         ],
       },
     },
+    new FusesPlugin({
+      version: FuseVersion.V1,
+      [FuseV1Options.RunAsNode]: false,
+    }),
   ],
 };

--- a/packages/template/vite/tmpl/forge.config.js
+++ b/packages/template/vite/tmpl/forge.config.js
@@ -2,7 +2,9 @@ const { FusesPlugin } = require('@electron-forge/plugin-fuses');
 const { FuseV1Options, FuseVersion } = require('@electron/fuses');
 
 module.exports = {
-  packagerConfig: {},
+  packagerConfig: {
+    asar: true,
+  },
   rebuildConfig: {},
   makers: [
     {
@@ -47,9 +49,16 @@ module.exports = {
         ],
       },
     },
+    // Fuses are used to enable/disable various Electron functionality
+    // at package time, before code signing the application
     new FusesPlugin({
       version: FuseVersion.V1,
       [FuseV1Options.RunAsNode]: false,
+      [FuseV1Options.EnableCookieEncryption]: true,
+      [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+      [FuseV1Options.EnableNodeCliInspectArguments]: false,
+      [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+      [FuseV1Options.OnlyLoadAppFromAsar]: true,
     }),
   ],
 };

--- a/packages/template/vite/tmpl/package.json
+++ b/packages/template/vite/tmpl/package.json
@@ -1,5 +1,7 @@
 {
   "devDependencies": {
+    "@electron/fuses": "^1.7.0",
+    "@electron-forge/plugin-fuses": "^7.2.0",
     "@electron-forge/plugin-vite": "ELECTRON_FORGE/VERSION"
   }
 }

--- a/packages/template/webpack-typescript/tmpl/forge.config.ts
+++ b/packages/template/webpack-typescript/tmpl/forge.config.ts
@@ -5,6 +5,8 @@ import { MakerDeb } from '@electron-forge/maker-deb';
 import { MakerRpm } from '@electron-forge/maker-rpm';
 import { AutoUnpackNativesPlugin } from '@electron-forge/plugin-auto-unpack-natives';
 import { WebpackPlugin } from '@electron-forge/plugin-webpack';
+import { FusesPlugin } from '@electron-forge/plugin-fuses';
+import { FuseV1Options, FuseVersion } from '@electron/fuses';
 
 import { mainConfig } from './webpack.main.config';
 import { rendererConfig } from './webpack.renderer.config';
@@ -32,6 +34,10 @@ const config: ForgeConfig = {
           },
         ],
       },
+    }),
+    new FusesPlugin({
+      version: FuseVersion.V1,
+      [FuseV1Options.RunAsNode]: false,
     }),
   ],
 };

--- a/packages/template/webpack-typescript/tmpl/forge.config.ts
+++ b/packages/template/webpack-typescript/tmpl/forge.config.ts
@@ -35,9 +35,16 @@ const config: ForgeConfig = {
         ],
       },
     }),
+    // Fuses are used to enable/disable various Electron functionality
+    // at package time, before code signing the application
     new FusesPlugin({
       version: FuseVersion.V1,
       [FuseV1Options.RunAsNode]: false,
+      [FuseV1Options.EnableCookieEncryption]: true,
+      [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+      [FuseV1Options.EnableNodeCliInspectArguments]: false,
+      [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+      [FuseV1Options.OnlyLoadAppFromAsar]: true,
     }),
   ],
 };

--- a/packages/template/webpack-typescript/tmpl/package.json
+++ b/packages/template/webpack-typescript/tmpl/package.json
@@ -1,5 +1,7 @@
 {
   "devDependencies": {
+    "@electron/fuses": "^1.7.0",
+    "@electron-forge/plugin-fuses": "^7.2.0",
     "@electron-forge/plugin-webpack": "ELECTRON_FORGE/VERSION",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",

--- a/packages/template/webpack/tmpl/forge.config.js
+++ b/packages/template/webpack/tmpl/forge.config.js
@@ -1,3 +1,6 @@
+const { FusesPlugin } = require('@electron-forge/plugin-fuses');
+const { FuseV1Options, FuseVersion } = require('@electron/fuses');
+
 module.exports = {
   packagerConfig: {
     asar: true,
@@ -45,5 +48,9 @@ module.exports = {
         },
       },
     },
+    new FusesPlugin({
+      version: FuseVersion.V1,
+      [FuseV1Options.RunAsNode]: false,
+    }),
   ],
 };

--- a/packages/template/webpack/tmpl/forge.config.js
+++ b/packages/template/webpack/tmpl/forge.config.js
@@ -48,9 +48,16 @@ module.exports = {
         },
       },
     },
+    // Fuses are used to enable/disable various Electron functionality
+    // at package time, before code signing the application
     new FusesPlugin({
       version: FuseVersion.V1,
       [FuseV1Options.RunAsNode]: false,
+      [FuseV1Options.EnableCookieEncryption]: true,
+      [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+      [FuseV1Options.EnableNodeCliInspectArguments]: false,
+      [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+      [FuseV1Options.OnlyLoadAppFromAsar]: true,
     }),
   ],
 };


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [X] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [X] The changes are appropriately documented (if applicable).
- [X] The changes have sufficient test coverage (if applicable).
- [X] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
In order to make fuses more discoverable and add safe defaults for new electron applications, we are introducing a default fuses configuration in each of the existing templates used in electron forge init

To test this change, I created a new project using our 5 existing templates: base, vite, vite-typescript, webpack, webpack-typescript. For each of these projects, I ran `yarn package` and checked that the resulting .app ran as expected. I also verified that the fuses were actually set by running `npx @electron/fuses read` and verifying that the output matches the forge.config configurations:

```
  Fuse Version: v1
  RunAsNode is Disabled
  EnableCookieEncryption is Enabled
  EnableNodeOptionsEnvironmentVariable is Disabled
  EnableNodeCliInspectArguments is Disabled
  EnableEmbeddedAsarIntegrityValidation is Enabled
  OnlyLoadAppFromAsar is Enabled
  LoadBrowserProcessSpecificV8Snapshot is Disabled
```