### PR TITLE
chore(plugins/electronegativity): correct some config types 

### DIFF
--- a/packages/plugin/electronegativity/src/ElectronegativityPlugin.ts
+++ b/packages/plugin/electronegativity/src/ElectronegativityPlugin.ts
@@ -38,7 +38,7 @@ export type ElectronegativityConfig = {
    *
    * Defaults to `false`.
    */
-  isRelative?: false;
+  isRelative?: boolean;
   /**
    * Specify a range to run Electron upgrade checks. For example, `'7..8'` checks an upgrade
    * from Electron 7 to Electron 8.
@@ -49,7 +49,7 @@ export type ElectronegativityConfig = {
    *
    * Defaults to empty array (`[]`)
    */
-  parserPlugins: Array<string>;
+  parserPlugins?: Array<string>;
 };
 
 export default class ElectronegativityPlugin extends PluginBase<ElectronegativityConfig> {
@@ -65,6 +65,7 @@ export default class ElectronegativityPlugin extends PluginBase<Electronegativit
     await runElectronegativity(
       {
         ...this.config,
+        isRelative: this.config.isRelative ?? false,
         parserPlugins: this.config.parserPlugins ?? [],
         input: options.outputPaths[0],
       },


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

- `isRelative` should be `boolean` and defaults to `false`.
- `parserPlugins` should be optional.