### PR TITLE
feat(publisher-github): option to automatically generate release notes

### DIFF
--- a/packages/publisher/github/src/Config.ts
+++ b/packages/publisher/github/src/Config.ts
@@ -47,4 +47,8 @@ export interface PublisherGitHubConfig {
    * Re-upload the new asset if you upload an asset with the same filename as existing asset
    */
   force?: boolean;
+  /**
+   * Whether to automatically generate release notes for the release
+   */
+  generateReleaseNotes?: boolean;
 }

--- a/packages/publisher/github/src/PublisherGithub.ts
+++ b/packages/publisher/github/src/PublisherGithub.ts
@@ -74,6 +74,7 @@ export default class PublisherGithub extends PublisherBase<PublisherGitHubConfig
               name: releaseName,
               draft: config.draft !== false,
               prerelease: config.prerelease === true,
+              generate_release_notes: config.generateReleaseNotes === true,
             })
           ).data;
         } else {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Exposes a config option to automatically generate the release notes when creating the GitHub release.