### PR TITLE
build: bump memory limit for docs:generate script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:watch": "yarn build --watch",
     "postbuild": "ts-node tools/test-dist",
     "docs": "yarn build && yarn docs:generate",
-    "docs:generate": "yarn docs:plugin && node --max-old-space-size=8192 -r ts-node/register ./tools/gen-docs.ts",
+    "docs:generate": "yarn docs:plugin && node --max-old-space-size=16384 -r ts-node/register ./tools/gen-docs.ts",
     "docs:plugin": "cd ./tools/doc-plugin && yarn build",
     "lerna:publish": "lerna publish --force-publish --conventional-commits --no-changelog --exact",
     "lint:js": "prettier --check . && eslint .",


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

The push API documentation workflow is [running out of memory](https://github.com/electron/forge/actions/runs/7993414416/job/21829876738) on new releases (both v7.2.0 and v7.3.0 failed).

@erickzhao will try to look into improving the overall process in the future, but in the meantime the quickest way to mitigate the issue is to bump the memory limit.