### PR TITLE
build: fix keyv type resolution warning during dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "@types/fetch-mock": "^7.3.1",
     "@types/fs-extra": "^9.0.6",
     "@types/interpret": "^1.1.1",
+    "@types/keyv": "^3.1.4",
     "@types/listr": "^0.14.2",
     "@types/lodash": "^4.14.166",
     "@types/mime-types": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3053,6 +3053,13 @@
   dependencies:
     keyv "*"
 
+"@types/keyv@^3.1.4":
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.4.tgz#3ccdb1c6751b0c7e52300bcdacd5bcbf8faa75b6"
+  integrity sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/listr@^0.14.2":
   version "0.14.4"
   resolved "https://registry.yarnpkg.com/@types/listr/-/listr-0.14.4.tgz#6ba2a4206615cf80d79d10f9ba9701c303cd57b6"
@@ -8524,9 +8531,9 @@ jws@^4.0.0:
     safe-buffer "^5.0.1"
 
 keyv@*, keyv@^4.0.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.0.tgz#dbce9ade79610b6e641a9a65f2f6499ba06b9bc6"
-  integrity sha512-2YvuMsA+jnFGtBareKqgANOEKe1mk3HKiXu2fRmAfyxG0MJAywNhi5ttWA3PMjl4NmpyjZNbFifR2vNjW1znfA==
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
+  integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
   dependencies:
     json-buffer "3.0.1"
 


### PR DESCRIPTION
Not sure why this happens, but easy enough to fix with no impact to published modules by adding this types package to our root package json.

<img width="545" alt="image" src="https://github.com/electron/forge/assets/6634592/71ac6681-9824-4ddb-b94b-62c85fb4f86a">
