### PR TITLE
ci: make signed commits when publishing docs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -17,13 +17,16 @@ jobs:
         id: generate-token
         with:
           creds: ${{ secrets.GH_APP_CREDS }}
-          export-git-user: true
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: true
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Get short SHA for HEAD
+        id: get-short-sha
+        run: echo "sha=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
 
       - name: Use Node.js LTS
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
@@ -37,11 +40,20 @@ jobs:
           yarn
           yarn docs
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
+      - name: Prepare docs
+        uses: malept/github-action-gh-pages@e151760357583e2f9152f8e8c8658ceb3ccf3d64 # tag: v1.3.1
         with:
-          github_token: ${{ steps.generate-token.outputs.token }}
-          publish_dir: ./docs
           cname: js.electronforge.io
-          user_name: ${{ env.GIT_COMMITTER_NAME }}
-          user_email: ${{ env.GIT_COMMITTER_EMAIL }}
+          defaultBranch: main
+          noCommit: true
+          showUnderscoreFiles: true
+          versionDocs: true
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+      - name: Commit docs
+        uses: dsanders11/github-app-commit-action@56f54b482f8019a16d8f8b0bfbbc9fa3ee9802e8 # v1.3.0
+        with:
+          fail-on-no-changes: false
+          message: 'deploy: ${{ steps.get-short-sha.outputs.sha }}'
+          token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -41,7 +41,7 @@ jobs:
           yarn docs
 
       - name: Prepare docs
-        uses: malept/github-action-gh-pages@e151760357583e2f9152f8e8c8658ceb3ccf3d64 # tag: v1.3.1
+        uses: malept/github-action-gh-pages@f7952a65c4b763dc84b824a530dc38bd375ac91e # tag: v1.4.0
         with:
           cname: js.electronforge.io
           defaultBranch: main


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Switches the docs publishing workflow to using `malept/github-action-gh-pages` to align across the org (with `electron/get` and `electron/packager`), and uses `dsanders11/github-app-commit-action` to sign the commit.