### PR TITLE
chore: Bump @electron/windows-sign deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "electron-installer-snap": "^5.2.0",
     "electron-windows-store": "^2.1.0",
     "electron-winstaller": "^5.3.0",
-    "electron-wix-msi": "^5.1.2",
+    "electron-wix-msi": "^5.1.3",
     "macos-alias": "^0.2.11"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@doyensec/electronegativity": "^1.9.1",
     "@electron/get": "^3.0.0",
     "@electron/osx-sign": "^1.0.5",
-    "@electron/packager": "^18.1.2",
+    "@electron/packager": "^18.1.3",
     "@electron/rebuild": "^3.2.10",
     "@google-cloud/storage": "^7.5.0",
     "@malept/cross-spawn-promise": "^2.0.0",
@@ -159,8 +159,8 @@
     "electron-installer-redhat": "^3.2.0",
     "electron-installer-snap": "^5.2.0",
     "electron-windows-store": "^2.1.0",
-    "electron-winstaller": "^5.0.0",
-    "electron-wix-msi": "^5.0.0",
+    "electron-winstaller": "^5.3.0",
+    "electron-wix-msi": "^5.1.1",
     "macos-alias": "^0.2.11"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "electron-installer-snap": "^5.2.0",
     "electron-windows-store": "^2.1.0",
     "electron-winstaller": "^5.3.0",
-    "electron-wix-msi": "^5.1.1",
+    "electron-wix-msi": "^5.1.2",
     "macos-alias": "^0.2.11"
   },
   "peerDependencies": {

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -52,7 +52,7 @@
     "@electron-forge/template-webpack-typescript": "7.3.0",
     "@electron-forge/tracer": "7.3.0",
     "@electron/get": "^3.0.0",
-    "@electron/packager": "^18.1.2",
+    "@electron/packager": "^18.1.3",
     "@electron/rebuild": "^3.2.10",
     "@malept/cross-spawn-promise": "^2.0.0",
     "chalk": "^4.0.0",

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -395,7 +395,7 @@ describe('Electron Forge API', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ...options: any[]
       ) {
-        describe(`make (with target=${path.basename(path.dirname(target().name))})`, async () => {
+        describe(`make (with target=${target().name})`, async () => {
           before(async () => {
             await updatePackageJSON(dir, async (packageJSON) => {
               packageJSON.config.forge.makers = [target() as IForgeResolvableMaker];

--- a/packages/maker/squirrel/package.json
+++ b/packages/maker/squirrel/package.json
@@ -20,7 +20,7 @@
     "fs-extra": "^10.0.0"
   },
   "optionalDependencies": {
-    "electron-winstaller": "^5.0.0"
+    "electron-winstaller": "^5.3.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/maker/wix/package.json
+++ b/packages/maker/wix/package.json
@@ -18,7 +18,7 @@
     "@electron-forge/maker-base": "7.3.0",
     "@electron-forge/shared-types": "7.3.0",
     "chalk": "^4.0.0",
-    "electron-wix-msi": "^5.1.1",
+    "electron-wix-msi": "^5.1.2",
     "log-symbols": "^4.0.0",
     "parse-author": "^2.0.0"
   },

--- a/packages/maker/wix/package.json
+++ b/packages/maker/wix/package.json
@@ -18,7 +18,7 @@
     "@electron-forge/maker-base": "7.3.0",
     "@electron-forge/shared-types": "7.3.0",
     "chalk": "^4.0.0",
-    "electron-wix-msi": "^5.1.2",
+    "electron-wix-msi": "^5.1.3",
     "log-symbols": "^4.0.0",
     "parse-author": "^2.0.0"
   },

--- a/packages/maker/wix/package.json
+++ b/packages/maker/wix/package.json
@@ -18,7 +18,7 @@
     "@electron-forge/maker-base": "7.3.0",
     "@electron-forge/shared-types": "7.3.0",
     "chalk": "^4.0.0",
-    "electron-wix-msi": "^5.0.0",
+    "electron-wix-msi": "^5.1.1",
     "log-symbols": "^4.0.0",
     "parse-author": "^2.0.0"
   },

--- a/packages/plugin/vite/package.json
+++ b/packages/plugin/vite/package.json
@@ -24,7 +24,7 @@
     "fs-extra": "^10.0.0"
   },
   "devDependencies": {
-    "@electron/packager": "^18.1.2",
+    "@electron/packager": "^18.1.3",
     "@malept/cross-spawn-promise": "^2.0.0",
     "@types/node": "^18.0.3",
     "chai": "^4.3.3",

--- a/packages/plugin/webpack/package.json
+++ b/packages/plugin/webpack/package.json
@@ -11,7 +11,7 @@
     "test": "xvfb-maybe mocha --config ../../../.mocharc.js test/**/*_spec.ts test/*_spec.ts"
   },
   "devDependencies": {
-    "@electron/packager": "^18.1.2",
+    "@electron/packager": "^18.1.3",
     "@malept/cross-spawn-promise": "^2.0.0",
     "@types/node": "^18.0.3",
     "chai": "^4.3.3",

--- a/packages/utils/types/package.json
+++ b/packages/utils/types/package.json
@@ -9,7 +9,7 @@
   "typings": "dist/index.d.ts",
   "dependencies": {
     "@electron-forge/tracer": "7.3.0",
-    "@electron/packager": "^18.1.2",
+    "@electron/packager": "^18.1.3",
     "@electron/rebuild": "^3.2.10",
     "listr2": "^5.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5539,10 +5539,10 @@ electron-winstaller@^5.3.0:
   optionalDependencies:
     "@electron/windows-sign" "^1.1.2"
 
-electron-wix-msi@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/electron-wix-msi/-/electron-wix-msi-5.1.1.tgz#e41883a87c954d1d2bfd3b0658b1c06e571232b1"
-  integrity sha512-9IKCaMRj7eJBptLVnTuVioRwk97s4uxKAkIBzOZWte0FbkBCDgsXP4pd50GzE+zsbhk2HVenI3G1d114Xt2kIQ==
+electron-wix-msi@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/electron-wix-msi/-/electron-wix-msi-5.1.2.tgz#382d39ab9fcfe2cecdcc769bc7ef0ea88895b397"
+  integrity sha512-/hSyUXD/Kg8a82piMljjdQXlD8TW9PoMTUXqJd1j8Jn06fDAsJbbBtgWMiKE+OeJGWg3Rmg7UbfCaR8ykm9APA==
   dependencies:
     "@electron/windows-sign" "^1.1.2"
     debug "^4.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5539,10 +5539,10 @@ electron-winstaller@^5.3.0:
   optionalDependencies:
     "@electron/windows-sign" "^1.1.2"
 
-electron-wix-msi@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/electron-wix-msi/-/electron-wix-msi-5.1.2.tgz#382d39ab9fcfe2cecdcc769bc7ef0ea88895b397"
-  integrity sha512-/hSyUXD/Kg8a82piMljjdQXlD8TW9PoMTUXqJd1j8Jn06fDAsJbbBtgWMiKE+OeJGWg3Rmg7UbfCaR8ykm9APA==
+electron-wix-msi@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/electron-wix-msi/-/electron-wix-msi-5.1.3.tgz#ab85dc1145a7ce7ae7724ed3ca3f92c447988c9a"
+  integrity sha512-EYj1cm1nZoVHmIIx3o0aKt784lxdEpJnXbEnyypklUCnglqSb7ni+1xi1Vp/gtrGS/mzIxnWBT+x5fIfuDjhvA==
   dependencies:
     "@electron/windows-sign" "^1.1.2"
     debug "^4.3.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,10 +1043,10 @@
     minimist "^1.2.6"
     plist "^3.0.5"
 
-"@electron/packager@^18.1.2":
-  version "18.1.2"
-  resolved "https://registry.yarnpkg.com/@electron/packager/-/packager-18.1.2.tgz#8d7d4f8918deea2bda833a6b5ac1ecea283080be"
-  integrity sha512-2W5TBNnY+AAx1SMxcawNk1h3blCb8zCmOsatruBCaCYmU+HHzugZ6WgyKXdaaywnLE6OMRQN11Qp5xVpZCgppg==
+"@electron/packager@^18.1.3":
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/@electron/packager/-/packager-18.1.3.tgz#53eba507e5dccaa4cbfae56bf6e2f58a7bc257a5"
+  integrity sha512-21T5MxUf7DwV07IIes3jO/571mXCjOGVPdmYJFPCVDTimFiHQSW0Oy+OIGQaKBiNIXfnP29KylsCQbmds6O6Iw==
   dependencies:
     "@electron/asar" "^3.2.1"
     "@electron/get" "^3.0.0"
@@ -1110,6 +1110,17 @@
     debug "^4.3.4"
     fs-extra "^11.1.1"
     minimist "^1.2.8"
+
+"@electron/windows-sign@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@electron/windows-sign/-/windows-sign-1.1.2.tgz#5489861ca62348d2300407e85d949af95849955e"
+  integrity sha512-eXEiZjDtxW3QORCWfRUarANPRTlH9B6At4jqBZJ0NzokSGutXQUVLPA6WmGpIhDW6w2yCMdHW1EJd1HrXtU5sg==
+  dependencies:
+    cross-dirname "^0.1.0"
+    debug "^4.3.4"
+    fs-extra "^11.1.1"
+    minimist "^1.2.8"
+    postject "^1.0.0-alpha.6"
 
 "@esbuild/aix-ppc64@0.19.11":
   version "0.19.11"
@@ -3960,21 +3971,6 @@ asap@^2.0.0:
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==
 
-asar@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/asar/-/asar-2.1.0.tgz#97c6a570408c4e38a18d4a3fb748a621b5a7844e"
-  integrity sha512-d2Ovma+bfqNpvBzY/KU8oPY67ZworixTpkjSx0PCXnQi67c2cXmssaTxpFDUM0ttopXoGx/KRxNg/GDThYbXQA==
-  dependencies:
-    chromium-pickle-js "^0.2.0"
-    commander "^2.20.0"
-    cuint "^0.2.2"
-    glob "^7.1.3"
-    minimatch "^3.0.4"
-    mkdirp "^0.5.1"
-    tmp-promise "^1.0.5"
-  optionalDependencies:
-    "@types/glob" "^7.1.1"
-
 asar@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/asar/-/asar-3.1.0.tgz#70b0509449fe3daccc63beb4d3c7d2e24d3c6473"
@@ -4104,7 +4100,7 @@ bl@^4.0.3, bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bluebird@^3.0.6, bluebird@^3.1.1, bluebird@^3.5.0:
+bluebird@^3.0.6, bluebird@^3.1.1:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -4721,6 +4717,11 @@ commander@^8.3.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
+commander@^9.4.0:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
+  integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
+
 common-ancestor-path@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz#4f7d2d1394d91b7abdf51871c62f71eadb0182a7"
@@ -4940,6 +4941,11 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-dirname@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/cross-dirname/-/cross-dirname-0.1.0.tgz#b899599f30a5389f59e78c150e19f957ad16a37c"
+  integrity sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==
+
 cross-env@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
@@ -5022,11 +5028,6 @@ cssesc@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
-
-cuint@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
-  integrity sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=
 
 cycle@1.0.x:
   version "1.0.3"
@@ -5525,30 +5526,32 @@ electron-windows-store@^2.1.0:
     multiline "^2.0.0"
     path-exists "^3.0.0"
 
-electron-winstaller@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/electron-winstaller/-/electron-winstaller-5.0.0.tgz#0db968f34d498b16c69566a40848f562e70e7bcc"
-  integrity sha512-V+jFda7aVAm0htCG8Q95buPUpmXZW9ujh1HdhSlWY6y4QnJnw4TfrmxTlQWV4p2ioF/71JMI/1YF+/qbSICogA==
+electron-winstaller@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/electron-winstaller/-/electron-winstaller-5.3.0.tgz#852aa6d6daf48e22ec30cfd5c287fd8253f110bc"
+  integrity sha512-ml77/OmeeLFFc+dk3YCwPQrl8rthwYcAea6mMZPFq7cGXlpWyRmmT0LY73XdCukPnevguXJFs+4Xu+aGHJwFDA==
   dependencies:
-    asar "^2.0.1"
+    "@electron/asar" "^3.2.1"
     debug "^4.1.1"
     fs-extra "^7.0.1"
     lodash.template "^4.2.2"
     temp "^0.9.0"
+  optionalDependencies:
+    "@electron/windows-sign" "^1.1.2"
 
-electron-wix-msi@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/electron-wix-msi/-/electron-wix-msi-5.0.0.tgz#6899beabb59180fbe71dede79e9ae805779497a5"
-  integrity sha512-CfcakpocoGGtzXElHwiSqB5nSlscyZYPBDTj7s+kfw2jXby3Nzzso7vIA+6EiPebn704D4JyKaJ7O4GCY2h5KQ==
+electron-wix-msi@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/electron-wix-msi/-/electron-wix-msi-5.1.1.tgz#e41883a87c954d1d2bfd3b0658b1c06e571232b1"
+  integrity sha512-9IKCaMRj7eJBptLVnTuVioRwk97s4uxKAkIBzOZWte0FbkBCDgsXP4pd50GzE+zsbhk2HVenI3G1d114Xt2kIQ==
   dependencies:
+    "@electron/windows-sign" "^1.1.2"
     debug "^4.3.4"
-    fs-extra "^10.0.1"
-    klaw "^4.0.1"
+    fs-extra "^10.1.0"
+    klaw "^4.1.0"
     lodash "^4.17.21"
-    rcedit "^3.0.1"
+    rcedit "^4.0.1"
     rcinfo "^0.1.3"
-    semver "^7.3.5"
-    uuid "^8.3.2"
+    semver "^7.6.0"
   optionalDependencies:
     "@bitdisaster/exe-icon-extractor" "^1.0.10"
 
@@ -6815,7 +6818,7 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@10.1.0, fs-extra@^10.0.1, fs-extra@^10.1.0:
+fs-extra@10.1.0, fs-extra@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
   integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
@@ -8542,10 +8545,10 @@ kind-of@^6.0.2, kind-of@^6.0.3:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-klaw@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/klaw/-/klaw-4.0.1.tgz#8dc6f5723f05894e8e931b516a8ff15c2976d368"
-  integrity sha512-pgsE40/SvC7st04AHiISNewaIMUbY5V/K8b21ekiPiFoYs/EYSdsGa+FJArB1d441uq4Q8zZyIxvAzkGNlBdRw==
+klaw@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-4.1.0.tgz#5df608067d8cb62bbfb24374f8e5d956323338f3"
+  integrity sha512-1zGZ9MF9H22UnkpVeuaGKOjfA2t6WrfdrJmGjy16ykcjnKQDmHVX+KI477rpbGevz/5FD4MC3xf1oxylBgcaQw==
 
 kleur@^4.0.3:
   version "4.1.5"
@@ -10883,6 +10886,13 @@ postcss@^8.4.32:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+postject@^1.0.0-alpha.6:
+  version "1.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/postject/-/postject-1.0.0-alpha.6.tgz#9d022332272e2cfce8dea4cfce1ee6dd1b2ee135"
+  integrity sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==
+  dependencies:
+    commander "^9.4.0"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -11100,14 +11110,7 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rcedit@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/rcedit/-/rcedit-3.0.1.tgz#ae21b43e49c075f4d84df1929832a12c302f3c90"
-  integrity sha512-XM0Jv40/y4hVAqj/MO70o/IWs4uOsaSoo2mLyk3klFDW+SStLnCtzuQu+1OBTIMGlM8CvaK9ftlYCp6DJ+cMsw==
-  dependencies:
-    cross-spawn-windows-exe "^1.1.0"
-
-rcedit@^4.0.0:
+rcedit@^4.0.0, rcedit@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/rcedit/-/rcedit-4.0.1.tgz#892ac47a19204a380f49e00ea38ce070443343c2"
   integrity sha512-bZdaQi34krFWhrDn+O53ccBDw0MkAT2Vhu75SqhtvhQu4OPyFM4RoVheyYiVQYdjhUi6EJMVWQ0tR6bCIYVkUg==
@@ -11508,13 +11511,6 @@ rfdc@^1.3.0:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
   integrity sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==
 
-rimraf@^2.6.3:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
-  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
 rimraf@^3.0.0, rimraf@^3.0.1, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -11710,6 +11706,13 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
+  dependencies:
+    lru-cache "^6.0.0"
 
 send@0.18.0:
   version "0.18.0"
@@ -12528,27 +12531,12 @@ tiny-each-async@2.0.3:
   resolved "https://registry.yarnpkg.com/tiny-each-async/-/tiny-each-async-2.0.3.tgz#8ebbbfd6d6295f1370003fbb37162afe5a0a51d1"
   integrity sha1-jru/1tYpXxNwAD+7NxYq/loKUdE=
 
-tmp-promise@^1.0.5:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-1.1.0.tgz#bb924d239029157b9bc1d506a6aa341f8b13e64c"
-  integrity sha512-8+Ah9aB1IRXCnIOxXZ0uFozV1nMU5xiu7hhFVUSxZ3bYu+psD4TzagCzVbexUCgNNGJnsmNDQlS4nG3mTyoNkw==
-  dependencies:
-    bluebird "^3.5.0"
-    tmp "0.1.0"
-
 tmp-promise@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/tmp-promise/-/tmp-promise-3.0.3.tgz#60a1a1cc98c988674fcbfd23b6e3367bdeac4ce7"
   integrity sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==
   dependencies:
     tmp "^0.2.0"
-
-tmp@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
-  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
-  dependencies:
-    rimraf "^2.6.3"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Updating all dependencies which now use `@electron/windows-sign`. This is a non-breaking change.
