### PR TITLE
ci(windows): pin version of wix toolset to v3.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,8 +108,8 @@ jobs:
                 name: Windows Setup
                 shell: bash
                 command: |
-                  choco install --no-progress -y wixtoolset
-                  echo 'export PATH=$PATH:"/C/Program Files (x86)/WiX Toolset v3.11/bin"' >> "$BASH_ENV"
+                  choco install --no-progress -y wixtoolset  --version=3.14.0
+                  echo 'export PATH=$PATH:"/C/Program Files (x86)/WiX Toolset v3.14/bin"' >> "$BASH_ENV"
                   cd 'C:\Program Files\nodejs\node_modules\npm\node_modules\@npmcli\run-script'
                   npm install node-gyp@9.4.0
       - when:


### PR DESCRIPTION
Fixes our current CI issues.

Looks like WiX3 just got its first package release in 5 years, which fixes a bunch of security problems.

See https://github.com/wixtoolset/wix3/releases/tag/wix314rtm

> WiX v3.14 is the latest recommended maintenance release of WiX v3; it contains mitigations in all versions of WiX v3 for a vulnerability affecting all bundles. We recommend upgrading to WiX v3.14--or WiX v4.0--as soon as possible.
> For more information about the vulnerability, see [WiX Security Releases Available](https://www.firegiant.com/blog/2024/2/6/wix-security-releases-available/).