### PR TITLE
fix: bump packager minimum dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@doyensec/electronegativity": "^1.9.1",
     "@electron/get": "^3.0.0",
     "@electron/osx-sign": "^1.0.5",
-    "@electron/packager": "^18.1.3",
+    "@electron/packager": "^18.3.1",
     "@electron/rebuild": "^3.2.10",
     "@google-cloud/storage": "^7.5.0",
     "@malept/cross-spawn-promise": "^2.0.0",

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -52,7 +52,7 @@
     "@electron-forge/template-webpack-typescript": "7.3.1",
     "@electron-forge/tracer": "7.3.1",
     "@electron/get": "^3.0.0",
-    "@electron/packager": "^18.1.3",
+    "@electron/packager": "^18.3.1",
     "@electron/rebuild": "^3.2.10",
     "@malept/cross-spawn-promise": "^2.0.0",
     "chalk": "^4.0.0",

--- a/packages/plugin/vite/package.json
+++ b/packages/plugin/vite/package.json
@@ -24,7 +24,7 @@
     "fs-extra": "^10.0.0"
   },
   "devDependencies": {
-    "@electron/packager": "^18.1.3",
+    "@electron/packager": "^18.3.1",
     "@malept/cross-spawn-promise": "^2.0.0",
     "@types/node": "^18.0.3",
     "chai": "^4.3.3",

--- a/packages/plugin/webpack/package.json
+++ b/packages/plugin/webpack/package.json
@@ -11,7 +11,7 @@
     "test": "xvfb-maybe mocha --config ../../../.mocharc.js test/**/*_spec.ts test/*_spec.ts"
   },
   "devDependencies": {
-    "@electron/packager": "^18.1.3",
+    "@electron/packager": "^18.3.1",
     "@malept/cross-spawn-promise": "^2.0.0",
     "@types/node": "^18.0.3",
     "chai": "^4.3.3",

--- a/packages/utils/types/package.json
+++ b/packages/utils/types/package.json
@@ -9,7 +9,7 @@
   "typings": "dist/index.d.ts",
   "dependencies": {
     "@electron-forge/tracer": "7.3.1",
-    "@electron/packager": "^18.1.3",
+    "@electron/packager": "^18.3.1",
     "@electron/rebuild": "^3.2.10",
     "listr2": "^5.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,10 +1043,10 @@
     minimist "^1.2.6"
     plist "^3.0.5"
 
-"@electron/packager@^18.1.3":
-  version "18.1.3"
-  resolved "https://registry.yarnpkg.com/@electron/packager/-/packager-18.1.3.tgz#53eba507e5dccaa4cbfae56bf6e2f58a7bc257a5"
-  integrity sha512-21T5MxUf7DwV07IIes3jO/571mXCjOGVPdmYJFPCVDTimFiHQSW0Oy+OIGQaKBiNIXfnP29KylsCQbmds6O6Iw==
+"@electron/packager@^18.3.1":
+  version "18.3.1"
+  resolved "https://registry.yarnpkg.com/@electron/packager/-/packager-18.3.1.tgz#5e18a0840302ec70911c88dbbbf01837aef559d6"
+  integrity sha512-KpbLQH/ZYwmMASthBLy8GFn/5JlLdEayYFtLfkOcMWjBayDDjbatpWfN5Px9jMJZKXKO9knVc9hOgrDYxJsFMw==
   dependencies:
     "@electron/asar" "^3.2.1"
     "@electron/get" "^3.0.0"
@@ -1054,7 +1054,6 @@
     "@electron/osx-sign" "^1.0.5"
     "@electron/universal" "^2.0.1"
     "@electron/windows-sign" "^1.0.0"
-    cross-spawn-windows-exe "^1.2.0"
     debug "^4.0.1"
     extract-zip "^2.0.0"
     filenamify "^4.1.0"
@@ -1064,7 +1063,7 @@
     junk "^3.1.0"
     parse-author "^2.0.0"
     plist "^3.0.0"
-    rcedit "^4.0.0"
+    resedit "^2.0.0"
     resolve "^1.1.6"
     semver "^7.1.3"
     yargs-parser "^21.1.1"
@@ -4953,7 +4952,7 @@ cross-env@^7.0.2:
   dependencies:
     cross-spawn "^7.0.1"
 
-cross-spawn-windows-exe@^1.1.0, cross-spawn-windows-exe@^1.2.0:
+cross-spawn-windows-exe@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/cross-spawn-windows-exe/-/cross-spawn-windows-exe-1.2.0.tgz#46253b0f497676e766faf4a7061004618b5ac5ec"
   integrity sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw==
@@ -10785,6 +10784,11 @@ pathval@^1.1.1:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
+pe-library@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pe-library/-/pe-library-1.0.0.tgz#360934ccdc25f19ac24d61c9a347caf23a9dc27a"
+  integrity sha512-yZ+4d3YHKUjO0BX03oXFfHRKLdYKDO2HmCt1RcApPxme/P5ASPbbKnuQkzFrmT482wi2kfO+sPgqasrz5QeU1w==
+
 pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
@@ -11110,7 +11114,7 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rcedit@^4.0.0, rcedit@^4.0.1:
+rcedit@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/rcedit/-/rcedit-4.0.1.tgz#892ac47a19204a380f49e00ea38ce070443343c2"
   integrity sha512-bZdaQi34krFWhrDn+O53ccBDw0MkAT2Vhu75SqhtvhQu4OPyFM4RoVheyYiVQYdjhUi6EJMVWQ0tR6bCIYVkUg==
@@ -11394,6 +11398,13 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
+
+resedit@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resedit/-/resedit-2.0.0.tgz#cd615f294c38e4b806cf031ede128d5e0c17d1d7"
+  integrity sha512-vrrJCabKxAW4MT1QivtAAb0poGp8KT2qhnSzfN9tFIxb2rQu1hRHNn1VgGSZR7nmxGaW5Yz0YeW1bjgvRfNoKA==
+  dependencies:
+    pe-library "^1.0.0"
 
 resolve-alpn@^1.0.0:
   version "1.2.1"


### PR DESCRIPTION
This isn't really required because transitive deps can be updated without having to update them in forge, but I'm writing a doc that says "this works in packager X and forge Y" and the only way to be sure that sentence is correct is to make a version of forge that forces packager X 😆 