### PR TITLE
ci: don't use versionDocs option in API Documentation workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -47,7 +47,6 @@ jobs:
           defaultBranch: main
           noCommit: true
           showUnderscoreFiles: true
-          versionDocs: true
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

This got flipped on in #3520 because I thought it would be nice, but [the workflow is now hitting GitHub server errors](https://github.com/electron/forge/actions/runs/8759922305/attempts/2) and I suspect it has to do with the number of files changed. Removing `versionDocs: true` should cut down on the number of files changed and hopefully let the workflow succeed.