### PR TITLE
feat(core): support ESM Forge module loading

### DIFF
--- a/packages/api/core/helper/dynamic-import.d.ts
+++ b/packages/api/core/helper/dynamic-import.d.ts
@@ -1,1 +1,3 @@
 export declare function dynamicImport(path: string): Promise<any>;
+/** Like {@linkcode dynamicImport()}, but falls back to require on failure. */
+export declare function dynamicImportMaybe(path: string): Promise<any>;

--- a/packages/api/core/helper/dynamic-import.d.ts
+++ b/packages/api/core/helper/dynamic-import.d.ts
@@ -1,3 +1,3 @@
 export declare function dynamicImport(path: string): Promise<any>;
-/** Like {@linkcode dynamicImport()}, but falls back to require on failure. */
+/** Like {@link dynamicImport()}, except it tries out {@link require()} first. */
 export declare function dynamicImportMaybe(path: string): Promise<any>;

--- a/packages/api/core/helper/dynamic-import.js
+++ b/packages/api/core/helper/dynamic-import.js
@@ -1,8 +1,9 @@
 const url = require('url');
+const fs = require('fs');
 
 exports.dynamicImport = function dynamicImport(path) {
   try {
-    return import(url.pathToFileURL(path));
+    return import(fs.existsSync(path) ? url.pathToFileURL(path) : path);
   } catch (error) {
     return Promise.reject(error);
   }

--- a/packages/api/core/helper/dynamic-import.js
+++ b/packages/api/core/helper/dynamic-import.js
@@ -7,3 +7,7 @@ exports.dynamicImport = function dynamicImport(path) {
     return Promise.reject(error);
   }
 };
+
+exports.dynamicImportMaybe = function dynamicImportMaybe(path) {
+  return exports.dynamicImport(path).catch(() => require(path));
+};

--- a/packages/api/core/helper/dynamic-import.js
+++ b/packages/api/core/helper/dynamic-import.js
@@ -1,5 +1,9 @@
 const url = require('url');
 
 exports.dynamicImport = function dynamicImport(path) {
-  return import(url.pathToFileURL(path));
+  try {
+    return import(url.pathToFileURL(path));
+  } catch (error) {
+    return Promise.reject(error);
+  }
 };

--- a/packages/api/core/helper/dynamic-import.js
+++ b/packages/api/core/helper/dynamic-import.js
@@ -15,7 +15,8 @@ exports.dynamicImportMaybe = async function dynamicImportMaybe(path) {
   } catch (e1) {
     try {
       return await exports.dynamicImport(path);
-    } catch {
+    } catch (e2) {
+      e1.message = '\n1. ' + e1.message + '\n2. ' + e2.message;
       throw e1;
     }
   }

--- a/packages/api/core/helper/dynamic-import.js
+++ b/packages/api/core/helper/dynamic-import.js
@@ -9,6 +9,14 @@ exports.dynamicImport = function dynamicImport(path) {
   }
 };
 
-exports.dynamicImportMaybe = function dynamicImportMaybe(path) {
-  return exports.dynamicImport(path).catch(() => require(path));
+exports.dynamicImportMaybe = async function dynamicImportMaybe(path) {
+  try {
+    return require(path);
+  } catch (e1) {
+    try {
+      return await exports.dynamicImport(path);
+    } catch {
+      throw e1;
+    }
+  }
 };

--- a/packages/api/core/helper/dynamic-import.js
+++ b/packages/api/core/helper/dynamic-import.js
@@ -1,9 +1,9 @@
 const url = require('url');
 const fs = require('fs');
 
-exports.dynamicImport = function dynamicImport(path) {
+exports.dynamicImport = async function dynamicImport(path) {
   try {
-    return import(fs.existsSync(path) ? url.pathToFileURL(path) : path);
+    return await import(fs.existsSync(path) ? url.pathToFileURL(path) : path);
   } catch (error) {
     return Promise.reject(error);
   }

--- a/packages/api/core/src/api/init-scripts/find-template.ts
+++ b/packages/api/core/src/api/init-scripts/find-template.ts
@@ -2,7 +2,7 @@ import { ForgeTemplate } from '@electron-forge/shared-types';
 import debug from 'debug';
 import resolvePackage from 'resolve-package';
 
-import { PossibleModule } from '../../util/require-search';
+import { PossibleModule } from '../../util/import-search';
 
 const d = debug('electron-forge:init:find-template');
 

--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -22,10 +22,10 @@ import logSymbols from 'log-symbols';
 
 import getForgeConfig from '../util/forge-config';
 import { getHookListrTasks, runMutatingHook } from '../util/hook';
+import importSearch from '../util/import-search';
 import getCurrentOutDir from '../util/out-dir';
 import parseArchs from '../util/parse-archs';
 import { readMutatedPackageJson } from '../util/read-package-json';
-import requireSearch from '../util/require-search';
 import resolveDir from '../util/resolve-dir';
 
 import { listrPackage } from './package';
@@ -168,7 +168,7 @@ export const listrMake = (
                   throw new Error(`The following maker config has a maker name that is not a string: ${JSON.stringify(resolvableTarget)}`);
                 }
 
-                const MakerClass = requireSearch<typeof MakerImpl>(dir, [resolvableTarget.name]);
+                const MakerClass = await importSearch<typeof MakerImpl>(dir, [resolvableTarget.name]);
                 if (!MakerClass) {
                   throw new Error(
                     `Could not find module with name '${resolvableTarget.name}'. If this is a package from NPM, make sure it's listed in the devDependencies of your package.json. If this is a local module, make sure you have the correct path to its entry point. Try using the DEBUG="electron-forge:require-search" environment variable for more information.`

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -25,9 +25,9 @@ const d = debug('electron-forge:packager');
 /**
  * Resolves hooks if they are a path to a file (instead of a `Function`).
  */
-function resolveHooks<F = HookFunction>(hooks: (string | F)[] | undefined, dir: string) {
+async function resolveHooks<F = HookFunction>(hooks: (string | F)[] | undefined, dir: string) {
   if (hooks) {
-    return Promise.all(hooks.map(async (hook) => (typeof hook === 'string' ? ((await importSearch<F>(dir, [hook])) as F) : hook)));
+    return await Promise.all(hooks.map(async (hook) => (typeof hook === 'string' ? ((await importSearch<F>(dir, [hook])) as F) : hook)));
   }
 
   return [];

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -14,10 +14,10 @@ import { Listr, PRESET_TIMER } from 'listr2';
 
 import getForgeConfig from '../util/forge-config';
 import { getHookListrTasks, runHook } from '../util/hook';
+import importSearch from '../util/import-search';
 import { warn } from '../util/messages';
 import getCurrentOutDir from '../util/out-dir';
 import { readMutatedPackageJson } from '../util/read-package-json';
-import requireSearch from '../util/require-search';
 import resolveDir from '../util/resolve-dir';
 
 const d = debug('electron-forge:packager');
@@ -27,7 +27,7 @@ const d = debug('electron-forge:packager');
  */
 function resolveHooks<F = HookFunction>(hooks: (string | F)[] | undefined, dir: string) {
   if (hooks) {
-    return hooks.map((hook) => (typeof hook === 'string' ? (requireSearch<F>(dir, [hook]) as F) : hook));
+    return Promise.all(hooks.map(async (hook) => (typeof hook === 'string' ? ((await importSearch<F>(dir, [hook])) as F) : hook)));
   }
 
   return [];
@@ -216,13 +216,12 @@ export const listrPackage = (
 
             const rebuildTasks = new Map<string, Promise<ForgeListrTask<never>>[]>();
             const signalRebuildStart = new Map<string, ((task: ForgeListrTask<never>) => void)[]>();
-
             const afterFinalizePackageTargetsHooks: FinalizePackageTargetsHookFunction[] = [
               (targets, done) => {
                 provideTargets(targets);
                 done();
               },
-              ...resolveHooks(forgeConfig.packagerConfig.afterFinalizePackageTargets, ctx.dir),
+              ...(await resolveHooks(forgeConfig.packagerConfig.afterFinalizePackageTargets, ctx.dir)),
             ];
 
             const pruneEnabled = !('prune' in forgeConfig.packagerConfig) || forgeConfig.packagerConfig.prune;
@@ -265,7 +264,7 @@ export const listrPackage = (
                 await fs.writeJson(path.resolve(buildPath, 'package.json'), copiedPackageJSON, { spaces: 2 });
                 done();
               },
-              ...resolveHooks(forgeConfig.packagerConfig.afterCopy, ctx.dir),
+              ...(await resolveHooks(forgeConfig.packagerConfig.afterCopy, ctx.dir)),
             ];
 
             const afterCompleteHooks: HookFunction[] = [
@@ -273,13 +272,13 @@ export const listrPackage = (
                 signalPackageDone.get(getTargetKey({ platform: pPlatform, arch: pArch }))?.pop()?.();
                 done();
               },
-              ...resolveHooks(forgeConfig.packagerConfig.afterComplete, ctx.dir),
+              ...(await resolveHooks(forgeConfig.packagerConfig.afterComplete, ctx.dir)),
             ];
 
             const afterPruneHooks = [];
 
             if (pruneEnabled) {
-              afterPruneHooks.push(...resolveHooks(forgeConfig.packagerConfig.afterPrune, ctx.dir));
+              afterPruneHooks.push(...(await resolveHooks(forgeConfig.packagerConfig.afterPrune, ctx.dir)));
             }
 
             afterPruneHooks.push((async (buildPath, electronVersion, pPlatform, pArch, done) => {
@@ -293,7 +292,7 @@ export const listrPackage = (
                 done();
               }) as HookFunction,
             ];
-            afterExtractHooks.push(...resolveHooks(forgeConfig.packagerConfig.afterExtract, ctx.dir));
+            afterExtractHooks.push(...(await resolveHooks(forgeConfig.packagerConfig.afterExtract, ctx.dir)));
 
             type PackagerArch = Exclude<ForgeArch, 'arm'>;
 

--- a/packages/api/core/src/api/publish.ts
+++ b/packages/api/core/src/api/publish.ts
@@ -19,9 +19,9 @@ import fs from 'fs-extra';
 import { Listr } from 'listr2';
 
 import getForgeConfig from '../util/forge-config';
+import importSearch from '../util/import-search';
 import getCurrentOutDir from '../util/out-dir';
 import PublishState from '../util/publish-state';
-import requireSearch from '../util/require-search';
 import resolveDir from '../util/resolve-dir';
 
 import { listrMake, MakeOptions } from './make';
@@ -198,7 +198,7 @@ export default autoTrace(
                 } else {
                   const resolvablePublishTarget = publishTarget as IForgeResolvablePublisher;
                   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  const PublisherClass: any = requireSearch(dir, [resolvablePublishTarget.name]);
+                  const PublisherClass: any = await importSearch(dir, [resolvablePublishTarget.name]);
                   if (!PublisherClass) {
                     throw new Error(
                       `Could not find a publish target with the name: ${resolvablePublishTarget.name}. Make sure it's listed in the devDependencies of your package.json`

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -6,7 +6,7 @@ import * as interpret from 'interpret';
 import { template } from 'lodash';
 import * as rechoir from 'rechoir';
 
-import { dynamicImport } from '../../helper/dynamic-import.js';
+import { dynamicImportMaybe } from '../../helper/dynamic-import.js';
 
 import { runMutatingHook } from './hook';
 import PluginInterface from './plugin-interface';
@@ -128,13 +128,7 @@ export default async (dir: string): Promise<ResolvedForgeConfig> => {
     const forgeConfigPath = path.resolve(dir, forgeConfig as string);
     try {
       // The loaded "config" could potentially be a static forge config, ESM module or async function
-      let loaded;
-      try {
-        loaded = (await dynamicImport(forgeConfigPath)) as MaybeESM<ForgeConfig | AsyncForgeConfigGenerator>;
-      } catch (err) {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        loaded = require(forgeConfigPath) as MaybeESM<ForgeConfig | AsyncForgeConfigGenerator>;
-      }
+      const loaded = (await dynamicImportMaybe(forgeConfigPath)) as MaybeESM<ForgeConfig | AsyncForgeConfigGenerator>;
       const maybeForgeConfig = 'default' in loaded ? loaded.default : loaded;
       forgeConfig = typeof maybeForgeConfig === 'function' ? await maybeForgeConfig() : maybeForgeConfig;
     } catch (err) {

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -155,7 +155,7 @@ export default async (dir: string): Promise<ResolvedForgeConfig> => {
   const templateObj = { ...packageJSON, year: new Date().getFullYear() };
   renderConfigTemplate(dir, templateObj, resolvedForgeConfig);
 
-  resolvedForgeConfig.pluginInterface = new PluginInterface(dir, resolvedForgeConfig);
+  resolvedForgeConfig.pluginInterface = await PluginInterface.create(dir, resolvedForgeConfig);
 
   resolvedForgeConfig = await runMutatingHook(resolvedForgeConfig, 'resolveForgeConfig', resolvedForgeConfig);
 

--- a/packages/api/core/src/util/import-search.ts
+++ b/packages/api/core/src/util/import-search.ts
@@ -2,7 +2,9 @@ import path from 'path';
 
 import debug from 'debug';
 
-const d = debug('electron-forge:require-search');
+import { dynamicImportMaybe } from '../../helper/dynamic-import.js';
+
+const d = debug('electron-forge:import-search');
 
 // https://github.com/nodejs/node/blob/da0ede1ad55a502a25b4139f58aab3fb1ee3bf3f/lib/internal/modules/cjs/loader.js#L353-L359
 type RequireError = Error & {
@@ -11,14 +13,14 @@ type RequireError = Error & {
   requestPath: string | undefined;
 };
 
-export function requireSearchRaw<T>(relativeTo: string, paths: string[]): T | null {
+export async function importSearchRaw<T>(relativeTo: string, paths: string[]): Promise<T | null> {
   // Attempt to locally short-circuit if we're running from a checkout of forge
   if (__dirname.includes('forge/packages/api/core/') && paths.length === 1 && paths[0].startsWith('@electron-forge/')) {
     const [moduleType, moduleName] = paths[0].split('/')[1].split('-');
     try {
       const localPath = path.resolve(__dirname, '..', '..', '..', '..', moduleType, moduleName);
       d('testing local forge build', { moduleType, moduleName, localPath });
-      return require(localPath);
+      return await dynamicImportMaybe(localPath);
     } catch {
       // Ignore
     }
@@ -32,7 +34,7 @@ export function requireSearchRaw<T>(relativeTo: string, paths: string[]): T | nu
   for (const testPath of testPaths) {
     try {
       d('testing', testPath);
-      return require(testPath);
+      return await dynamicImportMaybe(testPath);
     } catch (err) {
       if (err instanceof Error) {
         const requireErr = err as RequireError;
@@ -51,7 +53,7 @@ export type PossibleModule<T> = {
   default?: T;
 } & T;
 
-export default <T>(relativeTo: string, paths: string[]): T | null => {
-  const result = requireSearchRaw<PossibleModule<T>>(relativeTo, paths);
+export default async <T>(relativeTo: string, paths: string[]): Promise<T | null> => {
+  const result = await importSearchRaw<PossibleModule<T>>(relativeTo, paths);
   return typeof result === 'object' && result && result.default ? result.default : (result as T | null);
 };

--- a/packages/api/core/src/util/plugin-interface.ts
+++ b/packages/api/core/src/util/plugin-interface.ts
@@ -60,6 +60,9 @@ export default class PluginInterface implements IForgePluginInterface {
       })
     ).then((plugins) => {
       this.plugins = plugins;
+      for (const plugin of this.plugins) {
+        plugin.init(dir, forgeConfig);
+      }
       return;
     });
     // TODO: fix hack
@@ -71,11 +74,6 @@ export default class PluginInterface implements IForgePluginInterface {
       configurable: false,
       writable: false,
     });
-
-    for (const plugin of this.plugins) {
-      plugin.init(dir, forgeConfig);
-    }
-
     this.triggerHook = this.triggerHook.bind(this);
     this.overrideStartLogic = this.overrideStartLogic.bind(this);
   }

--- a/packages/api/core/test/fast/import-search_spec.ts
+++ b/packages/api/core/test/fast/import-search_spec.ts
@@ -15,15 +15,7 @@ describe('import-search', () => {
   });
 
   it('should throw if file exists but fails to load', async () => {
-    let test: () => unknown;
-    try {
-      const ret = await importSearch(__dirname, ['../fixture/require-search/throw-error']);
-      test = () => ret;
-    } catch (error) {
-      test = () => {
-        throw error;
-      };
-    }
-    expect(test).to.throw('test');
+    const promise = importSearch(__dirname, ['../fixture/require-search/throw-error']);
+    await expect(promise).to.be.rejectedWith('test');
   });
 });

--- a/packages/api/core/test/fast/publish_spec.ts
+++ b/packages/api/core/test/fast/publish_spec.ts
@@ -60,7 +60,7 @@ describe('publish', () => {
         config.publishers = publishers;
         return config;
       },
-      '../util/require-search': (_: string, [name]: [string]) => {
+      '../util/import-search': async (_: string, [name]: [string]) => {
         if (name === 'void') {
           return fakePublisher(voidStub);
         }

--- a/packages/api/core/test/fast/require-search_spec.ts
+++ b/packages/api/core/test/fast/require-search_spec.ts
@@ -1,22 +1,29 @@
 import { expect } from 'chai';
 
 import findConfig from '../../src/util/forge-config';
-import requireSearch from '../../src/util/require-search';
+import importSearch from '../../src/util/import-search';
 
-describe('require-search', () => {
-  it('should resolve null if no file exists', () => {
-    const resolved = requireSearch(__dirname, ['../../src/util/wizard-secrets']);
+describe('import-search', () => {
+  it('should resolve null if no file exists', async () => {
+    const resolved = await importSearch(__dirname, ['../../src/util/wizard-secrets']);
     expect(resolved).to.equal(null);
   });
 
-  it('should resolve a file if it exists', () => {
-    const resolved = requireSearch(__dirname, ['../../src/util/forge-config']);
+  it('should resolve a file if it exists', async () => {
+    const resolved = await importSearch(__dirname, ['../../src/util/forge-config']);
     expect(resolved).to.equal(findConfig);
   });
 
-  it('should throw if file exists but fails to load', () => {
-    expect(() => {
-      requireSearch(__dirname, ['../fixture/require-search/throw-error']);
-    }).to.throw('test');
+  it('should throw if file exists but fails to load', async () => {
+    let test: () => unknown;
+    try {
+      const ret = await importSearch(__dirname, ['../fixture/require-search/throw-error']);
+      test = () => ret;
+    } catch (error) {
+      test = () => {
+        throw error;
+      };
+    }
+    expect(test).to.throw('test');
   });
 });


### PR DESCRIPTION
- [X] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [X] The testsuite passes successfully on my local machine (if applicable).

### Summary

This PR focuses on bringing the initial support loading Forge modules (plugins, makers, publishers etc.) that use ESM for their module format. It should also contain some cosmetic changes like rename of `require-search` to `import-search` (to reflect it isn't around the `require` API only anymore), improvements around the helper so it won't resolve path for modules passed by their names and introduces new function, `dynamicImportMaybe`, that will also try doing `require` first and falling back to ESM when it fails (I chose to `require` first so I won't have to resolve `default` in CJS import).

The main motivation on that is to allow third-parties as well as official Forge modules to be able to effortlessly utilise the ESM syntax entirely. While this is possible for now with the Forge as well, it requires of already importing the class to the config on your own.

There are currently a few things that could be considered to be worked on in the future, but are not really necessary from what I've been testing:

- Resolving directory paths for `import` in order to load them properly. This could be useful when makers are installed in unusual paths that even make Node not to be able to find modules when they are placed that way. Plus, there could be some issue with actually finding what to import given how complex it became in Node to resolve imports, plus resolving internal imports (starting in `#`) would probably also have to be supported as well. It might not be worth of the efforts for now.

- (Maybe) dropping `dynamicImport` or making it private, since it doesn't seem to be used outside of its own module scope anymore.

- ~~Improving some tests, so they have simpler logic. Currently, I focused more on preserving on the logic that tests actually uses and only changing them by making them async or use some wrapped stuff. This should make them work essentially similar way while fixing *false negatives* introduced by some *drastic* changes, like making some synchronous functions async or renaming a module.~~ **Done in 9229bff.**

I should also mention, the changes in this repo were tested by me (locally) [with my own implementation of ESM maker](https://github.com/SpacingBat3/ReForged/tree/master/makers/appimage).

### Changes around the tests

Of course, I had to modify tests for `require-search` and `publish-spec`, due to changes in module names and switching some previously synchronous code to be async. For now, testing only the workspace `@electron-forge/core`, I've seen similar number of tests failing on both official implementation and this fork, and I think they were caused because Forge expected to run tests from a root project than a workspace, as I saw those were mostly caused due to missing scripts in workspace package (so it's nothing serious). I guess it's out of the scope to fix that tho.

### Additional notes

I hope my commit messages as well as their classification and even this PR name fits well the policy of this project. This is my first time to contribute to Forge, so I'm definitely learning how to do stuff right while trying to avoid mistakes as much as I could 😄️.