### PR TITLE
fix(maker-squirrel): only push `delta` artifacts if they exist on disk

### DIFF
--- a/packages/maker/squirrel/src/MakerSquirrel.ts
+++ b/packages/maker/squirrel/src/MakerSquirrel.ts
@@ -41,7 +41,7 @@ export default class MakerSquirrel extends MakerBase<MakerSquirrelConfig> {
       path.resolve(outPath, `${winstallerConfig.name}-${nupkgVersion}-full.nupkg`),
     ];
     const deltaPath = path.resolve(outPath, `${winstallerConfig.name}-${nupkgVersion}-delta.nupkg`);
-    if ((winstallerConfig.remoteReleases && !winstallerConfig.noDelta) || (await fs.pathExists(deltaPath))) {
+    if (winstallerConfig.remoteReleases && !winstallerConfig.noDelta && (await fs.pathExists(deltaPath))) {
       artifacts.push(deltaPath);
     }
     const msiPath = path.resolve(outPath, winstallerConfig.setupMsi || `${appName}Setup.msi`);


### PR DESCRIPTION
The logic here I think is wrong. It adds the `-delta` file to `artifacts` even if it doesn't exist. This will cause `--from-dry-run` to fail. I think electron installer might not always produce a delta file.

Given the logic below for the `msi` that check the file exists before adding it, that made sense to do here to.

