### PR TITLE
fix: Electron dependency path for PnP

### DIFF
--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -154,7 +154,7 @@ export default autoTrace(
       }
 
       if (!electronExecPath) {
-        electronExecPath = await locateElectronExecutable(dir, packageJSON);
+        electronExecPath = locateElectronExecutable(dir, packageJSON);
       }
 
       d('Electron binary path:', electronExecPath);

--- a/packages/api/core/src/util/electron-executable.ts
+++ b/packages/api/core/src/util/electron-executable.ts
@@ -5,8 +5,8 @@ import logSymbols from 'log-symbols';
 
 type PackageJSON = Record<string, unknown>;
 
-export default async function locateElectronExecutable(dir: string, packageJSON: PackageJSON): Promise<string> {
-  const electronModulePath: string | undefined = await getElectronModulePath(dir, packageJSON);
+export default function locateElectronExecutable(dir: string, packageJSON: PackageJSON): string {
+  const electronModulePath: string | undefined = getElectronModulePath(dir, packageJSON);
 
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   let electronExecPath = require(electronModulePath || path.resolve(dir, 'node_modules/electron'));

--- a/packages/api/core/test/fast/make_spec.ts
+++ b/packages/api/core/test/fast/make_spec.ts
@@ -33,7 +33,7 @@ describe('make', () => {
       const electronPath = path.resolve(__dirname, 'node_modules/electron');
       stubbedMake = proxyquire.noCallThru().load('../../src/api/make', {
         '@electron-forge/core-utils': {
-          getElectronModulePath: () => Promise.resolve(electronPath),
+          getElectronModulePath: () => electronPath,
           getElectronVersion: () => Promise.resolve('1.0.0'),
         },
       }).default;

--- a/packages/utils/core-utils/src/electron-version.ts
+++ b/packages/utils/core-utils/src/electron-version.ts
@@ -41,12 +41,15 @@ function getElectronModuleName(packageJSON: PackageJSONWithDeps): string {
 }
 
 function getElectronPackageJSONPath(dir: string, packageName: string): string {
-  try {
-    // eslint-disable-next-line node/no-missing-require
-    return require.resolve(`${packageName}/package.json`, { paths: [dir] });
-  } catch {
-    throw new PackageNotFoundError(packageName, dir);
+  if (packageName) {
+    try {
+      // eslint-disable-next-line node/no-missing-require
+      return require.resolve(`${packageName}/package.json`, { paths: [dir] });
+    } catch {
+      // Ignore
+    }
   }
+  throw new PackageNotFoundError(packageName, dir);
 }
 
 export function getElectronModulePath(dir: string, packageJSON: PackageJSONWithDeps): string | undefined {

--- a/packages/utils/core-utils/test/electron-version_spec.ts
+++ b/packages/utils/core-utils/test/electron-version_spec.ts
@@ -130,7 +130,7 @@ describe('getElectronModulePath', () => {
         devDependencies: { electron: '^4.0.4' },
       };
 
-      expect(await getElectronModulePath(fixtureDir, packageJSON)).to.be.equal(path.join(workspaceDir, 'node_modules', 'electron'));
+      expect(getElectronModulePath(fixtureDir, packageJSON)).to.be.equal(path.join(workspaceDir, 'node_modules', 'electron'));
     });
 
     after(() => {
@@ -150,7 +150,7 @@ describe('getElectronModulePath', () => {
         devDependencies: { electron: '^4.0.4' },
       };
 
-      expect(await getElectronModulePath(fixtureDir, packageJSON)).to.be.equal(path.join(workspaceDir, 'node_modules', 'electron'));
+      expect(getElectronModulePath(fixtureDir, packageJSON)).to.be.equal(path.join(workspaceDir, 'node_modules', 'electron'));
     });
 
     it('finds the top-level electron module despite the additional node_modules folder inside the package', async () => {
@@ -160,7 +160,7 @@ describe('getElectronModulePath', () => {
         devDependencies: { electron: '^4.0.4' },
       };
 
-      expect(await getElectronModulePath(fixtureDir, packageJSON)).to.be.equal(path.join(workspaceDir, 'node_modules', 'electron'));
+      expect(getElectronModulePath(fixtureDir, packageJSON)).to.be.equal(path.join(workspaceDir, 'node_modules', 'electron'));
     });
 
     it('finds the correct electron module in nohoist mode', async () => {
@@ -170,8 +170,8 @@ describe('getElectronModulePath', () => {
         devDependencies: { electron: '^13.0.0' },
       };
 
-      expect(await getElectronModulePath(fixtureDir, packageJSON)).to.be.equal(path.join(fixtureDir, 'node_modules', 'electron'));
-      expect(await getElectronModulePath(fixtureDir, packageJSON)).not.to.be.equal(path.join(workspaceDir, 'node_modules', 'electron'));
+      expect(getElectronModulePath(fixtureDir, packageJSON)).to.be.equal(path.join(fixtureDir, 'node_modules', 'electron'));
+      expect(getElectronModulePath(fixtureDir, packageJSON)).not.to.be.equal(path.join(workspaceDir, 'node_modules', 'electron'));
     });
 
     after(() => {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
- use [require.resolve](https://nodejs.org/docs/latest-v22.x/api/modules.html#requireresolverequest-options)
- ~~remove PnP loader arguments from _process.env.NODE_OPTIONS_ with [utils.parseArgs](https://nodejs.org/api/util.html#utilparseargsconfig) (introduced with Node.js v18.3.0)~~

Related #3209

Fix #3611