### PR TITLE
feat(core): adding register/unregisterForgeConfigForDirectory to utils

### DIFF
--- a/packages/api/core/src/util/index.ts
+++ b/packages/api/core/src/util/index.ts
@@ -1,6 +1,14 @@
 import { getElectronVersion, hasYarn, yarnOrNpmSpawn } from '@electron-forge/core-utils';
 
-import { BuildIdentifierConfig, BuildIdentifierMap, fromBuildIdentifier } from './forge-config';
+import {
+  BuildIdentifierConfig,
+  BuildIdentifierMap,
+  fromBuildIdentifier,
+  registerForgeConfigForDirectory,
+  unregisterForgeConfigForDirectory,
+} from './forge-config';
+
+import type { ForgeConfig } from '@electron-forge/shared-types';
 
 export default class ForgeUtils {
   /**
@@ -19,4 +27,20 @@ export default class ForgeUtils {
   hasYarn = hasYarn;
 
   yarnOrNpmSpawn = yarnOrNpmSpawn;
+
+  /**
+   * Register a virtual config file for forge to find.
+   * Takes precedence over other configuration options like a forge.config.js file.
+   * Dir should point to the folder containing the app.
+   */
+  registerForgeConfigForDirectory(dir: string, config: ForgeConfig): void {
+    return registerForgeConfigForDirectory(dir, config);
+  }
+
+  /**
+   * Unregister a forge config previously registered with registerForgeConfigForDirectory.
+   */
+  unregisterForgeConfigForDirectory(dir: string): void {
+    return unregisterForgeConfigForDirectory(dir);
+  }
 }

--- a/packages/api/core/src/util/resolve-dir.ts
+++ b/packages/api/core/src/util/resolve-dir.ts
@@ -4,6 +4,7 @@ import { getElectronVersion } from '@electron-forge/core-utils';
 import debug from 'debug';
 import fs from 'fs-extra';
 
+import { registeredForgeConfigs } from './forge-config';
 import { readRawPackageJson } from './read-package-json';
 
 const d = debug('electron-forge:project-resolver');
@@ -12,15 +13,19 @@ const d = debug('electron-forge:project-resolver');
 //        and / or forge config then we need to be able to resolve
 //        the dir without calling getElectronVersion
 export default async (dir: string): Promise<string | null> => {
-  let mDir = dir;
+  let mDir = path.resolve(dir);
   let bestGuessDir: string | null = null;
   let lastError: string | null = null;
 
   let prevDir;
   while (prevDir !== mDir) {
     prevDir = mDir;
-    const testPath = path.resolve(mDir, 'package.json');
     d('searching for project in:', mDir);
+    if (registeredForgeConfigs.has(mDir)) {
+      d('virtual config found in:', mDir);
+      return mDir;
+    }
+    const testPath = path.resolve(mDir, 'package.json');
     if (await fs.pathExists(testPath)) {
       const packageJSON = await readRawPackageJson(mDir);
 

--- a/packages/api/core/test/fast/resolve-dir_spec.ts
+++ b/packages/api/core/test/fast/resolve-dir_spec.ts
@@ -2,6 +2,7 @@ import path from 'path';
 
 import { expect } from 'chai';
 
+import { registerForgeConfigForDirectory, unregisterForgeConfigForDirectory } from '../../src/util/forge-config';
 import resolveDir from '../../src/util/resolve-dir';
 
 describe('resolve-dir', () => {
@@ -19,5 +20,15 @@ describe('resolve-dir', () => {
   it('should return a directory if it finds a node module', async () => {
     expect(await resolveDir(path.resolve(__dirname, '../fixture/dummy_app/foo'))).to.not.be.equal(null);
     expect(await resolveDir(path.resolve(__dirname, '../fixture/dummy_app/foo'))).to.be.equal(path.resolve(__dirname, '../fixture/dummy_app'));
+  });
+
+  it('should return a directory if it finds a virtual config', async () => {
+    try {
+      registerForgeConfigForDirectory('/foo/var/virtual', {});
+      expect(await resolveDir('/foo/var/virtual')).to.not.be.equal(null);
+      expect(await resolveDir(path.resolve(__dirname, '/foo/var/virtual'))).to.be.equal(path.resolve(__dirname, '/foo/var/virtual'));
+    } finally {
+      unregisterForgeConfigForDirectory('/foo/var/virtual');
+    }
   });
 });


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

### Summary:
Fixes: https://github.com/electron/forge/issues/3510

Currently it is not possible to provide a forge config through the API of @electron-forge/core.
This makes integrating electron forge in to other build systems difficult, if these build systems want to provide the configuration for electron forge (for example by using metadata from previous build steps).

This pull request implements two functions ```utils.registerForgeConfigForDirectory(dir: string, config: ForgeConfig): void``` and ```unregisterForgeConfigForDirectory(dir: string): void``` to make this easier.
A "virtual" config registered through the first method behaves as if a forge.config.js file where present at that location exporting the object provided by the config parameter.
This takes precedence over any existing config options in an existing forge-config.js or package.json file in that directory.

This is my first contribution to this Project and i do not have a lot of experience in Open Source Development.
So If i forgot anything or i should have done something differently, please let me know.
Thank You!!