### PR TITLE
feat(plugin-vite): add derefSymlinks option to config

### DIFF
--- a/packages/plugin/vite/src/Config.ts
+++ b/packages/plugin/vite/src/Config.ts
@@ -36,4 +36,8 @@ export interface VitePluginConfig {
    * Renderer process Vite configs.
    */
   renderer: VitePluginRendererConfig[];
+  /**
+   * Whether symlinked dependencies should be dereferenced during the copying of node_modules. Defaults to false.
+   */
+  derefSymlinks?: boolean;
 }

--- a/packages/plugin/vite/src/ViteConfig.ts
+++ b/packages/plugin/vite/src/ViteConfig.ts
@@ -37,6 +37,10 @@ export default class ViteConfigGenerator {
     return this.isProd ? 'production' : 'development';
   }
 
+  get derefSymlinks(): boolean {
+    return this.pluginConfig.derefSymlinks ?? false;
+  }
+
   async getBuildConfig(): Promise<UserConfig[]> {
     if (!Array.isArray(this.pluginConfig.build)) {
       throw new Error('"config.build" must be an Array');

--- a/packages/plugin/vite/src/VitePlugin.ts
+++ b/packages/plugin/vite/src/VitePlugin.ts
@@ -120,9 +120,11 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}`);
       spaces: 2,
     });
 
+    const dereference = this.configGenerator.derefSymlinks;
+
     // Copy the dependencies in package.json
     for (const dep of flatDependencies) {
-      await fs.copy(dep.src, path.resolve(buildPath, dep.dest));
+      await fs.copy(dep.src, path.resolve(buildPath, dep.dest), { dereference });
     }
   };
 

--- a/packages/plugin/vite/test/ViteConfig_spec.ts
+++ b/packages/plugin/vite/test/ViteConfig_spec.ts
@@ -61,4 +61,23 @@ describe('ViteConfigGenerator', () => {
 
     expect(buildConfig1).deep.equal(buildConfig2);
   });
+
+  it('derefSymlinks', () => {
+    const createGeneratorWithConfig = (config: Partial<VitePluginConfig>) => {
+      const _config: VitePluginConfig = { build: [], renderer: [], ...config };
+      return new ViteConfigGenerator(_config, configRoot, true);
+    };
+
+    const testCases = new Map<boolean, Partial<VitePluginConfig>>([
+      [false, {}],
+      [false, { derefSymlinks: false }],
+      [true, { derefSymlinks: true }],
+    ]);
+
+    for (const [expectedResult, config] of testCases) {
+      const generator = createGeneratorWithConfig(config);
+
+      expect(generator.derefSymlinks).to.eq(expectedResult);
+    }
+  });
 });


### PR DESCRIPTION
- [ x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x ] The changes are appropriately documented (if applicable).
- [x ] The changes have sufficient test coverage (if applicable).
- [ x] The testsuite passes successfully on my local machine (if applicable).

To ensure a non-breaking change, I propose to add the **derefSymlinks** boolean option in a manner similar to the `ForgePackagerOptions` interface. If this option is set to true, all copied dependency symlinks will be dereferenced.

Closes #3632
