### PR TITLE
fix(deps): add missing peer dependencies

### DIFF
--- a/packages/template/webpack-typescript/package.json
+++ b/packages/template/webpack-typescript/package.json
@@ -29,7 +29,9 @@
     "chai": "^4.3.3",
     "fast-glob": "^3.2.7",
     "fork-ts-checker-webpack-plugin": "^7.2.13",
-    "listr2": "^7.0.2"
+    "listr2": "^7.0.2",
+    "typescript": "^4.6.3",
+    "webpack": "^5.69.1"
   },
   "files": [
     "dist",

--- a/packages/template/webpack-typescript/tmpl/package.json
+++ b/packages/template/webpack-typescript/tmpl/package.json
@@ -14,6 +14,7 @@
     "style-loader": "^3.0.0",
     "ts-loader": "^9.2.2",
     "ts-node": "^10.0.0",
-    "typescript": "~4.5.4"
+    "typescript": "^4.6.3",
+    "webpack": "^5.69.1"
   }
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fix warnings:
```console
➤ YN0002: │ @electron-forge/template-webpack-typescript@workspace:packages/template/webpack-typescript doesn't provide typescript (pd370b), requested by fork-ts-checker-webpack-plugin.
➤ YN0002: │ @electron-forge/template-webpack-typescript@workspace:packages/template/webpack-typescript doesn't provide webpack (p738c5), requested by fork-ts-checker-webpack-plugin.
➤ YN0002: │ electron-forge@workspace:. doesn't provide eslint-plugin-ava (pa3622), requested by @malept/eslint-config.
```

### Changes
- `@electron-forge/template-webpack-typescript` dependency --> add `typescript` and `webpack` to _dev dependencies_ of [/packages/template/webpack-typescript/package.json](https://github.com/electron/forge/blob/main/packages/template/webpack-typescript/package.json)
- ~~`electron-forge` dependency --> add `eslint-plugin-ava` to _dev dependencies_ of [/package.json](https://github.com/electron/forge/blob/main/package.json)~~ --> waiting https://github.com/malept/eslint-config/issues/107