### PR TITLE
build: remove x64 macOS jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,6 +157,8 @@ workflows:
                 arch: arm64
               - executor: node/linux
                 arch: arm64
+              - executor: node/macos
+                arch: x64
       - slow-tests:
           requires:
             - lint-and-build
@@ -169,3 +171,5 @@ workflows:
                 arch: arm64
               - executor: node/linux
                 arch: arm64
+              - executor: node/macos
+                arch: x64


### PR DESCRIPTION
Ref https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718

At this point, we might want to just use a list of 3 jobs instead of having half the jobs in the matrix in an exception list haha.