### PR TITLE
fix: move electron-installer-dmg to dependencies

### DIFF
--- a/packages/maker/dmg/package.json
+++ b/packages/maker/dmg/package.json
@@ -24,10 +24,8 @@
   "dependencies": {
     "@electron-forge/maker-base": "7.4.0",
     "@electron-forge/shared-types": "7.4.0",
+    "electron-installer-dmg": "^4.0.0",
     "fs-extra": "^10.0.0"
-  },
-  "optionalDependencies": {
-    "electron-installer-dmg": "^4.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

`electron-installer-dmg` is directly used in `MakerDMG.ts`. If a user needs to use `@electron-forge/maker-dmg` to generate a dmg file, they must also install `electron-installer-dmg`. Therefore, `electron-installer-dmg` should be a direct dependency of `@electron-forge/maker-dmg`.

