### PR TITLE
build: upgrade `electron-installer-dmg@5`

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
   "optionalDependencies": {
     "@malept/electron-installer-flatpak": "^0.11.4",
     "electron-installer-debian": "^3.2.0",
-    "electron-installer-dmg": "^4.0.0",
+    "electron-installer-dmg": "^5.0.0",
     "electron-installer-redhat": "^3.2.0",
     "electron-installer-snap": "^5.2.0",
     "electron-windows-store": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
   "optionalDependencies": {
     "@malept/electron-installer-flatpak": "^0.11.4",
     "electron-installer-debian": "^3.2.0",
-    "electron-installer-dmg": "^5.0.0",
+    "electron-installer-dmg": "^5.0.1",
     "electron-installer-redhat": "^3.2.0",
     "electron-installer-snap": "^5.2.0",
     "electron-windows-store": "^2.1.0",

--- a/packages/maker/dmg/package.json
+++ b/packages/maker/dmg/package.json
@@ -27,7 +27,7 @@
     "fs-extra": "^10.0.0"
   },
   "optionalDependencies": {
-    "electron-installer-dmg": "^5.0.0"
+    "electron-installer-dmg": "^5.0.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/maker/dmg/package.json
+++ b/packages/maker/dmg/package.json
@@ -27,7 +27,7 @@
     "fs-extra": "^10.0.0"
   },
   "optionalDependencies": {
-    "electron-installer-dmg": "^4.0.0"
+    "electron-installer-dmg": "^5.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/maker/dmg/src/Config.ts
+++ b/packages/maker/dmg/src/Config.ts
@@ -1,3 +1,5 @@
+import type { ElectronInstallerDMGOptions } from 'electron-installer-dmg';
+
 export interface CodeSignOptions {
   'signing-identity': string;
   identifier?: string;
@@ -33,45 +35,4 @@ export interface AdditionalDMGOptions {
   'code-sign'?: CodeSignOptions;
 }
 
-export interface MakerDMGConfig {
-  /**
-   * The application name
-   */
-  name?: string;
-  /**
-   * Path to the background for the DMG window
-   */
-  background?: string;
-  /**
-   * Path to the icon to use for the app in the DMG window
-   */
-  icon?: string;
-  /**
-   * Overwrite an existing DMG file if if already exists
-   */
-  overwrite?: boolean;
-  /**
-   * Enable debug message output
-   */
-  debug?: boolean;
-  /**
-   * How big to make the icon for the app in the DMG
-   */
-  iconSize?: number;
-  /**
-   * Disk image format
-   *
-   * Default: UDZO
-   */
-  format?: 'UDRW' | 'UDRO' | 'UDCO' | 'UDZO' | 'UDBZ' | 'ULFO';
-  /**
-   * Override the contents of the DMG, has a reasonable default
-   */
-  contents?: DMGContents[] | ((opts: MakerDMGConfig & AdditionalDMGOptions) => DMGContents[]);
-  /**
-   * Additional options to pass through to node-appdmg
-   *
-   * All available options are available in the [`appdmg` docs](https://github.com/LinusU/node-appdmg)
-   */
-  additionalDMGOptions?: AdditionalDMGOptions;
-}
+export type MakerDMGConfig = Omit<ElectronInstallerDMGOptions, 'name'> & { name?: string };

--- a/packages/maker/dmg/src/MakerDMG.ts
+++ b/packages/maker/dmg/src/MakerDMG.ts
@@ -16,7 +16,7 @@ export default class MakerDMG extends MakerBase<MakerDMGConfig> {
   }
 
   async make({ dir, makeDir, appName, packageJSON, targetArch }: MakerOptions): Promise<string[]> {
-    const { electronDMG } = require('electron-installer-dmg');
+    const { createDMG } = require('electron-installer-dmg');
 
     const outPath = path.resolve(makeDir, `${this.config.name || appName}.dmg`);
     const forgeDefaultOutPath = path.resolve(makeDir, `${appName}-${packageJSON.version}-${targetArch}.dmg`);
@@ -29,14 +29,14 @@ export default class MakerDMG extends MakerBase<MakerDMGConfig> {
       appPath: path.resolve(dir, `${appName}.app`),
       out: path.dirname(outPath),
     };
-    const opts = await electronDMG(dmgConfig);
+    await createDMG(dmgConfig);
     if (!this.config.name) {
       await this.ensureFile(forgeDefaultOutPath);
       await fs.rename(outPath, forgeDefaultOutPath);
       return [forgeDefaultOutPath];
     }
 
-    return [opts.dmgPath];
+    return [outPath];
   }
 }
 

--- a/packages/maker/dmg/src/MakerDMG.ts
+++ b/packages/maker/dmg/src/MakerDMG.ts
@@ -16,7 +16,7 @@ export default class MakerDMG extends MakerBase<MakerDMGConfig> {
   }
 
   async make({ dir, makeDir, appName, packageJSON, targetArch }: MakerOptions): Promise<string[]> {
-    const electronDMG = require('electron-installer-dmg');
+    const { electronDMG } = require('electron-installer-dmg');
 
     const outPath = path.resolve(makeDir, `${this.config.name || appName}.dmg`);
     const forgeDefaultOutPath = path.resolve(makeDir, `${appName}-${packageJSON.version}-${targetArch}.dmg`);

--- a/packages/maker/dmg/test/MakerDMG_spec.ts
+++ b/packages/maker/dmg/test/MakerDMG_spec.ts
@@ -32,16 +32,18 @@ describe('MakerDMG', () => {
 
   beforeEach(async () => {
     ensureFileStub = stub().returns(Promise.resolve());
-    eidStub = stub().returns(Promise.resolve({ dmgPath: '/path/to/dmg' }));
+    eidStub = stub().returns(Promise.resolve());
     renameStub = stub().returns(Promise.resolve());
-    config = {};
+    config = {
+      appPath: 'fake',
+    };
 
     MakerDMG = proxyquire
       .noPreserveCache()
       .noCallThru()
       .load('../src/MakerDMG', {
         '../../util/ensure-output': { ensureFile: ensureFileStub },
-        'electron-installer-dmg': eidStub,
+        'electron-installer-dmg': { createDMG: eidStub },
         'fs-extra': {
           rename: renameStub,
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2814,6 +2814,13 @@
     "@tufjs/canonical-json" "1.0.0"
     minimatch "^9.0.0"
 
+"@types/appdmg@^0.5.5":
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/@types/appdmg/-/appdmg-0.5.5.tgz#141a4f565395acf587c3f35642a021aea97deea2"
+  integrity sha512-G+n6DgZTZFOteITE30LnWj+HRVIGr7wMlAiLWOO02uJFWVEitaPU9JVXm9wJokkgshBawb2O1OykdcsmkkZfgg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/body-parser@*":
   version "1.19.2"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
@@ -5449,11 +5456,12 @@ electron-installer-debian@^3.2.0:
     word-wrap "^1.2.3"
     yargs "^16.0.2"
 
-electron-installer-dmg@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/electron-installer-dmg/-/electron-installer-dmg-5.0.0.tgz#21e805bc92bbb04b672c214aa431c60809a57f5d"
-  integrity sha512-Z21l/z6HKGxiaIBB76i8YK1DqRggWCbIezvojbKW3zZE7wN9jXqupXByWD3szoGam+1k1/MjAUbkdlZcvI6PTQ==
+electron-installer-dmg@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/electron-installer-dmg/-/electron-installer-dmg-5.0.1.tgz#309662eccce4a8585a79fe4bce79c23976a950f0"
+  integrity sha512-qOa1aAQdX57C+vzhDk3549dd/PRlNL4F8y736MTD1a43qptD+PvHY97Bo9gSf+OZ8iUWE7BrYSpk/FgLUe40EA==
   dependencies:
+    "@types/appdmg" "^0.5.5"
     debug "^4.3.2"
     minimist "^1.2.7"
   optionalDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -5449,13 +5449,13 @@ electron-installer-debian@^3.2.0:
     word-wrap "^1.2.3"
     yargs "^16.0.2"
 
-electron-installer-dmg@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/electron-installer-dmg/-/electron-installer-dmg-4.0.0.tgz#0520bcc8a928e559b3f16fc5cbc12b182a66ea1c"
-  integrity sha512-g3W6XnyUa7QGrAF7ViewHdt6bXV2KYU1Pm1CY3pZpp+H6mOjCHHAhf/iZAxtaX1ERCb+SQHz7xSsAHuNH9I8ZQ==
+electron-installer-dmg@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/electron-installer-dmg/-/electron-installer-dmg-5.0.0.tgz#21e805bc92bbb04b672c214aa431c60809a57f5d"
+  integrity sha512-Z21l/z6HKGxiaIBB76i8YK1DqRggWCbIezvojbKW3zZE7wN9jXqupXByWD3szoGam+1k1/MjAUbkdlZcvI6PTQ==
   dependencies:
     debug "^4.3.2"
-    minimist "^1.1.1"
+    minimist "^1.2.7"
   optionalDependencies:
     appdmg "^0.6.4"
 
@@ -9532,12 +9532,12 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
   integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
 
-minimist@^1.2.8:
+minimist@^1.2.7, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==


### PR DESCRIPTION
Upgrades to the latest `electron-installer-dmg` release, which provides native TS types so we don't need to duplicate the configuration within Forge.