### PR TITLE
fix(plugin-webpack): protocol recognizes webpack's `devServer` setting

### DIFF
--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -114,7 +114,8 @@ export default class WebpackConfigGenerator {
     if (this.isProd) {
       return `\`file://$\{require('path').resolve(__dirname, '..', 'renderer', '${entryPoint.name}', '${basename}')}\``;
     }
-    const baseUrl = `http://localhost:${this.port}/${entryPoint.name}`;
+    const protocol = this.pluginConfig.devServer?.server === 'https' ? 'https' : 'http';
+    const baseUrl = `${protocol}://localhost:${this.port}/${entryPoint.name}`;
     if (basename !== 'index.html') {
       return `'${baseUrl}/${basename}'`;
     }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

If you have opened your dev server with https via the `devServer.server` setting, make it aware of it.