### PR TITLE
fix(hooks): allow mutating hooks to have a `void` return

### DIFF
--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -56,7 +56,7 @@ export type ForgeSimpleHookFn<Hook extends keyof ForgeSimpleHookSignatures> = (
 export type ForgeMutatingHookFn<Hook extends keyof ForgeMutatingHookSignatures> = (
   forgeConfig: ResolvedForgeConfig,
   ...args: ForgeMutatingHookSignatures[Hook]
-) => Promise<ForgeMutatingHookSignatures[Hook][0] | undefined>;
+) => Promise<ForgeMutatingHookSignatures[Hook][0] | void>;
 export type ForgeHookFn<Hook extends ForgeHookName> = Hook extends keyof ForgeSimpleHookSignatures
   ? ForgeSimpleHookFn<Hook>
   : Hook extends keyof ForgeMutatingHookSignatures


### PR DESCRIPTION
The previous type here wouldn't work unless you explicitly returned `undefined` within your hook.