### PR TITLE
feat(maker-wix): Expose the property associateExtensions

### DIFF
--- a/packages/maker/wix/src/Config.ts
+++ b/packages/maker/wix/src/Config.ts
@@ -8,6 +8,10 @@ export interface MakerWixConfig {
    */
   appUserModelId?: string;
   /**
+   * A comma separated string of extensions with each to be associated the app icon.
+   */
+  associateExtensions?: string;
+  /**
    * The app's description
    */
   description?: string;


### PR DESCRIPTION
See here for documentation https://js.electronforge.io/classes/_electron_forge_maker_wix.InternalOptions.MSICreator.html#associateExtensions

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Adding to the `MakerWixConfig` interface property `associateExtensions` that allows one to specify exts to be associated with the app icon.