### PR TITLE
feat: Adding optional metadata config to gcs publisher

### DIFF
--- a/packages/publisher/gcs/src/Config.ts
+++ b/packages/publisher/gcs/src/Config.ts
@@ -1,6 +1,8 @@
 import { PredefinedAcl, StorageOptions } from '@google-cloud/storage';
 import { ConfigMetadata } from '@google-cloud/storage/build/cjs/src/resumable-upload';
 
+import { GCSArtifact } from './PublisherGCS';
+
 export interface PublisherGCSConfig {
   /**
    * Options passed into the `Storage` client constructor.
@@ -36,8 +38,9 @@ export interface PublisherGCSConfig {
    */
   keyResolver?: (fileName: string, platform: string, arch: string) => string;
   /**
-   * Optional Metadata for GCS Objects
+   * Generate optional Metadata for GCS Objects
    * See https://cloud.google.com/storage/docs/metadata for more info.
+   * Expects a function that takes a GCSArtifact object and returns a `ConfigMetadata` object.
    */
-  metadata?: ConfigMetadata;
+  metadataGenerator?: (artifact: GCSArtifact) => ConfigMetadata;
 }

--- a/packages/publisher/gcs/src/Config.ts
+++ b/packages/publisher/gcs/src/Config.ts
@@ -1,5 +1,5 @@
 import { PredefinedAcl, StorageOptions } from '@google-cloud/storage';
-import { ConfigMetadata } from "@google-cloud/storage/build/cjs/src/resumable-upload";
+import { ConfigMetadata } from '@google-cloud/storage/build/cjs/src/resumable-upload';
 
 export interface PublisherGCSConfig {
   /**

--- a/packages/publisher/gcs/src/Config.ts
+++ b/packages/publisher/gcs/src/Config.ts
@@ -1,4 +1,5 @@
 import { PredefinedAcl, StorageOptions } from '@google-cloud/storage';
+import { ConfigMetadata } from "@google-cloud/storage/build/cjs/src/resumable-upload";
 
 export interface PublisherGCSConfig {
   /**
@@ -34,4 +35,9 @@ export interface PublisherGCSConfig {
    * Custom function to provide the key to upload a given file to
    */
   keyResolver?: (fileName: string, platform: string, arch: string) => string;
+  /**
+   * Optional Metadata for GCS Objects
+   * See https://cloud.google.com/storage/docs/metadata for more info.
+   */
+  metadata?: ConfigMetadata;
 }

--- a/packages/publisher/gcs/src/PublisherGCS.ts
+++ b/packages/publisher/gcs/src/PublisherGCS.ts
@@ -6,7 +6,7 @@ import { PublisherGCSConfig } from './Config';
 
 const d = debug('electron-forge:publish:gcs');
 
-type GCSArtifact = {
+export type GCSArtifact = {
   path: string;
   keyPrefix: string;
   platform: string;
@@ -53,7 +53,7 @@ export default class PublisherGCS extends PublisherStatic<PublisherGCSConfig> {
         d('uploading:', artifact.path);
 
         await bucket.upload(artifact.path, {
-          metadata: this.config.metadata || {},
+          metadata: this.config.metadataGenerator ? this.config.metadataGenerator(artifact) : {},
           gzip: true,
           destination: this.keyForArtifact(artifact),
           predefinedAcl: this.config.predefinedAcl,

--- a/packages/publisher/gcs/src/PublisherGCS.ts
+++ b/packages/publisher/gcs/src/PublisherGCS.ts
@@ -53,6 +53,7 @@ export default class PublisherGCS extends PublisherStatic<PublisherGCSConfig> {
         d('uploading:', artifact.path);
 
         await bucket.upload(artifact.path, {
+          metadata: this.config.metadata || {},
           gzip: true,
           destination: this.keyForArtifact(artifact),
           predefinedAcl: this.config.predefinedAcl,


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [X] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [X] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [X] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Optionally pass metadata to GCS objects
Useful for setting cacheControl on files such as RELEASE.json