### PR TITLE
chore: add ts-node checks and optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,13 @@
     "macos-alias": "^0.2.11"
   },
   "peerDependencies": {
-    "@electron/fuses": ">=1.0.0"
+    "@electron/fuses": ">=1.0.0",
+    "ts-node": "^10"
+  },
+  "peerDependenciesMeta": {
+    "ts-node": {
+      "optional": true
+    }
   },
   "lint-staged": {
     "*.{html,json,md,yml}": "prettier --write",

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -76,6 +76,14 @@
     "username": "^5.1.0",
     "yarn-or-npm": "^3.0.1"
   },
+  "peerDependencies": {
+    "ts-node": "^10"
+  },
+  "peerDependenciesMeta": {
+    "ts-node": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">= 16.4.0"
   },

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -126,6 +126,13 @@ export default async (dir: string): Promise<ResolvedForgeConfig> => {
 
   if (!forgeConfig || typeof forgeConfig === 'string') {
     for (const extension of ['.js', ...Object.keys(interpret.extensions)]) {
+      if (extension === '.ts') {
+        try {
+          require.resolve('ts-node');
+        } catch {
+          throw new Error('forge.config.ts is a TypeScript file, please install ts-node dependency');
+        }
+      }
       const pathToConfig = path.resolve(dir, `forge.config${extension}`);
       if (await fs.pathExists(pathToConfig)) {
         rechoir.prepare(interpret.extensions, pathToConfig, dir);


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
`rechoir` dependency use `ts-node` if `forge.config` file is a TypeScript file (`forge.config.ts`) so `ts-node` needs to be installed as dependency.
Add an error message is `ts-node` dependency is missing.

Fix #3609