### PR TITLE
docs: mark plugin-vite as experimental

### DIFF
--- a/packages/plugin/vite/README.md
+++ b/packages/plugin/vite/README.md
@@ -1,5 +1,7 @@
 ## plugin-vite
 
+_Note: This plugin is considered experimental and is under active development; we do not offer API stability guarantees as development continues. Minor versions may include breaking changes - see release notes for details on migration._
+
 This plugin makes it easy to set up standard vite tooling to compile both your main process code and your renderer process code, with built-in support for Hot Module Replacement (HMR) in the renderer process and support for multiple renderers.
 
 ```javascript


### PR DESCRIPTION
Following a discussion among maintainers, this PR adds documentation to flag the Vite plug-in as experimental, as it is under active development and may introduce unplanned breaking changes.

While we will strive to keep breaking changes to a minimum, this marking allows users to make a more informed decision on risk before using the Vite plug-in for their projects.

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).