### PR TITLE
fix(vite-template): fix vite template start failed after package

### DIFF
--- a/packages/template/base/tmpl/index.js
+++ b/packages/template/base/tmpl/index.js
@@ -1,8 +1,9 @@
-const { app, BrowserWindow } = require('electron');
-const path = require('node:path');
+import { app, BrowserWindow } from 'electron';
+import path from 'node:path';
+import started from 'electron-squirrel-startup';
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
-if (require('electron-squirrel-startup')) {
+if (started) {
   app.quit();
 }
 

--- a/packages/template/vite-typescript/tmpl/forge.env.d.ts
+++ b/packages/template/vite-typescript/tmpl/forge.env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="@electron-forge/plugin-vite/forge-vite-env" />
+
+declare module 'electron-squirrel-startup' {
+  const started: boolean;
+  export = started;
+}

--- a/packages/template/vite-typescript/tmpl/forge.env.d.ts
+++ b/packages/template/vite-typescript/tmpl/forge.env.d.ts
@@ -1,6 +1,1 @@
 /// <reference types="@electron-forge/plugin-vite/forge-vite-env" />
-
-declare module 'electron-squirrel-startup' {
-  const started: boolean;
-  export = started;
-}

--- a/packages/template/vite-typescript/tmpl/main.ts
+++ b/packages/template/vite-typescript/tmpl/main.ts
@@ -1,8 +1,9 @@
 import { app, BrowserWindow } from 'electron';
 import path from 'path';
+import started from 'electron-squirrel-startup';
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
-if (require('electron-squirrel-startup')) {
+if (started) {
   app.quit();
 }
 

--- a/packages/template/vite/src/ViteTemplate.ts
+++ b/packages/template/vite/src/ViteTemplate.ts
@@ -15,7 +15,6 @@ class ViteTemplate extends BaseTemplate {
         title: 'Setting up Forge configuration',
         task: async () => {
           await this.copyTemplateFile(directory, 'forge.config.js');
-          await this.copyTemplateFile(directory, 'forge.env.d.ts');
         },
       },
       {

--- a/packages/template/vite/test/ViteTemplate_spec.ts
+++ b/packages/template/vite/test/ViteTemplate_spec.ts
@@ -28,7 +28,6 @@ describe('ViteTemplate', () => {
   context('template files are copied to project', () => {
     const expectedFiles = [
       'package.json',
-      'forge.env.d.ts',
       'forge.config.js',
       'vite.main.config.mjs',
       'vite.preload.config.mjs',

--- a/packages/template/vite/tmpl/forge.env.d.ts
+++ b/packages/template/vite/tmpl/forge.env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="@electron-forge/plugin-vite/forge-vite-env" />


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Closes #3714

Since we removed the copy `dependencies` logic in vite-plugin of `v7.5.0`, this will cause `if (require('electron-squirrel-startup'))` to fail to load.
This is because Vite's built-in `@rollup/plugin-commonjs` cannot handle CommonJS's `require()` function like Webpack in many cases. We need to make some compromises in code writing and try to use ESModule's `import` statement to avoid this problem.

> If anyone wants to know more about this issue, I wrote an article introducing the problem of Vite building CommonJS format code. 👉🏻 https://github.com/vite-plugin/vite-plugin-commonjs/blob/main/commonjs.zh-CN.md
