### PR TITLE
feat: add preStart hook and port existing startLogic impls

### DIFF
--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -112,6 +112,15 @@ export default autoTrace(
             }
           ),
         },
+        {
+          title: `Running ${chalk.yellow('preStart')} hook`,
+          task: childTrace<Parameters<ForgeListrTaskFn<StartContext>>>(
+            { name: 'run-preStart-hook', category: '@electron-forge/core' },
+            async (childTrace, { forgeConfig }, task) => {
+              return delayTraceTillSignal(childTrace, task.newListr(await getHookListrTasks(childTrace, forgeConfig, 'preStart')), 'run');
+            }
+          ),
+        },
       ],
       listrOptions
     );

--- a/packages/plugin/local-electron/src/LocalElectronPlugin.ts
+++ b/packages/plugin/local-electron/src/LocalElectronPlugin.ts
@@ -11,7 +11,6 @@ export default class LocalElectronPlugin extends PluginBase<LocalElectronPluginC
     super(c);
 
     this.getHooks = this.getHooks.bind(this);
-    this.startLogic = this.startLogic.bind(this);
   }
 
   get enabled(): boolean {
@@ -21,16 +20,9 @@ export default class LocalElectronPlugin extends PluginBase<LocalElectronPluginC
     return this.config.enabled;
   }
 
-  async startLogic(): Promise<false> {
-    if (this.enabled) {
-      this.checkPlatform(process.platform);
-      process.env.ELECTRON_OVERRIDE_DIST_PATH = this.config.electronPath;
-    }
-    return false;
-  }
-
   getHooks(): ForgeHookMap {
     return {
+      preStart: this.preStart,
       packageAfterExtract: this.afterExtract,
     };
   }
@@ -46,6 +38,13 @@ export default class LocalElectronPlugin extends PluginBase<LocalElectronPluginC
   private checkArch = (arch: string) => {
     if ((this.config.electronArch || process.arch) !== arch) {
       throw new Error(`Can not use local Electron version, required arch "${arch}" but local arch is "${this.config.electronArch || process.arch}"`);
+    }
+  };
+
+  private preStart: ForgeHookFn<'preStart'> = async () => {
+    if (this.enabled) {
+      this.checkPlatform(process.platform);
+      process.env.ELECTRON_OVERRIDE_DIST_PATH = this.config.electronPath;
     }
   };
 

--- a/packages/plugin/local-electron/test/LocalElectronPlugin_spec.ts
+++ b/packages/plugin/local-electron/test/LocalElectronPlugin_spec.ts
@@ -9,6 +9,8 @@ import { LocalElectronPlugin } from '../src/LocalElectronPlugin';
 
 describe('LocalElectronPlugin', () => {
   describe('start logic', () => {
+    const fakeForgeConfig = {} as ResolvedForgeConfig;
+
     before(() => {
       delete process.env.ELECTRON_OVERRIDE_DIST_PATH;
     });
@@ -20,30 +22,22 @@ describe('LocalElectronPlugin', () => {
     it('should set ELECTRON_OVERRIDE_DIST_PATH when enabled', async () => {
       expect(process.env.ELECTRON_OVERRIDE_DIST_PATH).to.equal(undefined);
       const p = new LocalElectronPlugin({ electronPath: 'test/foo' });
-      await p.startLogic();
+      await p.getHooks().preStart?.(fakeForgeConfig);
       expect(process.env.ELECTRON_OVERRIDE_DIST_PATH).to.equal('test/foo');
     });
 
     it('should not set ELECTRON_OVERRIDE_DIST_PATH when disabled', async () => {
       expect(process.env.ELECTRON_OVERRIDE_DIST_PATH).to.equal(undefined);
       const p = new LocalElectronPlugin({ enabled: false, electronPath: 'test/foo' });
-      await p.startLogic();
+      await p.getHooks().preStart?.(fakeForgeConfig);
       expect(process.env.ELECTRON_OVERRIDE_DIST_PATH).to.equal(undefined);
     });
 
     it("should throw an error if platforms don't match", async () => {
       const p = new LocalElectronPlugin({ electronPath: 'test/bar', electronPlatform: 'wut' });
-      await expect(p.startLogic()).to.eventually.be.rejectedWith(
+      await expect(p.getHooks().preStart?.(fakeForgeConfig)).to.eventually.be.rejectedWith(
         `Can not use local Electron version, required platform "${process.platform}" but local platform is "wut"`
       );
-    });
-
-    it('should always return false', async () => {
-      let p = new LocalElectronPlugin({ electronPath: 'test/bar' });
-      expect(await p.startLogic()).to.equal(false);
-
-      p = new LocalElectronPlugin({ enabled: false, electronPath: 'test/bar' });
-      expect(await p.startLogic()).to.equal(false);
     });
   });
 

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -5,7 +5,7 @@ import { pipeline } from 'stream/promises';
 
 import { getElectronVersion, listrCompatibleRebuildHook } from '@electron-forge/core-utils';
 import { namedHookWithTaskFn, PluginBase } from '@electron-forge/plugin-base';
-import { ForgeMultiHookMap, ListrTask, ResolvedForgeConfig, StartResult } from '@electron-forge/shared-types';
+import { ForgeMultiHookMap, ListrTask, ResolvedForgeConfig } from '@electron-forge/shared-types';
 import Logger, { Tab } from '@electron-forge/web-multi-logger';
 import chalk from 'chalk';
 import debug from 'debug';
@@ -70,7 +70,6 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
       }
     }
 
-    this.startLogic = this.startLogic.bind(this);
     this.getHooks = this.getHooks.bind(this);
   }
 
@@ -158,6 +157,41 @@ export default class WebpackPlugin extends PluginBase<WebpackPluginConfig> {
 
   getHooks(): ForgeMultiHookMap {
     return {
+      preStart: [
+        namedHookWithTaskFn<'preStart'>(async (task) => {
+          if (this.alreadyStarted) return false;
+          this.alreadyStarted = true;
+
+          await fs.remove(this.baseDir);
+
+          const logger = new Logger(this.loggerPort);
+          this.loggers.push(logger);
+          await logger.start();
+
+          return task?.newListr([
+            {
+              title: 'Compiling main process code',
+              task: async () => {
+                await this.compileMain(true, logger);
+              },
+              rendererOptions: {
+                timer: { ...PRESET_TIMER },
+              },
+            },
+            {
+              title: 'Launching dev servers for renderer process code',
+              task: async (_, task) => {
+                await this.launchRendererDevServers(logger);
+                task.output = `Output Available: ${chalk.cyan(`http://localhost:${this.loggerPort}`)}\n`;
+              },
+              rendererOptions: {
+                persistentOutput: true,
+                timer: { ...PRESET_TIMER },
+              },
+            },
+          ]) as any;
+        }, 'Preparing webpack bundles'),
+      ],
       prePackage: [
         namedHookWithTaskFn<'prePackage'>(async (task, config, platform, arch) => {
           if (!task) {
@@ -563,43 +597,6 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}`);
   }
 
   private alreadyStarted = false;
-
-  async startLogic(): Promise<StartResult> {
-    if (this.alreadyStarted) return false;
-    this.alreadyStarted = true;
-
-    await fs.remove(this.baseDir);
-
-    const logger = new Logger(this.loggerPort);
-    this.loggers.push(logger);
-    await logger.start();
-
-    return {
-      tasks: [
-        {
-          title: 'Compiling main process code',
-          task: async () => {
-            await this.compileMain(true, logger);
-          },
-          rendererOptions: {
-            timer: { ...PRESET_TIMER },
-          },
-        },
-        {
-          title: 'Launching dev servers for renderer process code',
-          task: async (_, task) => {
-            await this.launchRendererDevServers(logger);
-            task.output = `Output Available: ${chalk.cyan(`http://localhost:${this.loggerPort}`)}\n`;
-          },
-          rendererOptions: {
-            persistentOutput: true,
-            timer: { ...PRESET_TIMER },
-          },
-        },
-      ],
-      result: false,
-    };
-  }
 }
 
 export { WebpackPlugin, WebpackPluginConfig };

--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -26,6 +26,7 @@ export type ForgeConfigPlugin = IForgeResolvablePlugin | IForgePlugin;
 
 export interface ForgeSimpleHookSignatures {
   generateAssets: [platform: ForgePlatform, version: ForgeArch];
+  preStart: [];
   postStart: [appProcess: ElectronProcess];
   prePackage: [platform: ForgePlatform, version: ForgeArch];
   packageAfterCopy: [buildPath: string, electronVersion: string, platform: ForgePlatform, arch: ForgeArch];


### PR DESCRIPTION
We already had `postStart` so this is pretty chill 🤷 Removes the "only one thing can mess with start logic" restriction for our own plugins.