### PR TITLE
feat(publisher-s3): allow ACL omission

### DIFF
--- a/packages/publisher/s3/src/Config.ts
+++ b/packages/publisher/s3/src/Config.ts
@@ -39,7 +39,7 @@ export interface PublisherS3Config {
    */
   public?: boolean;
   /**
-   * Whether to omit the ACL when creating the S3 object
+   * Whether to omit the ACL when creating the S3 object. If set, `public` will have no effect.
    *
    * Default: false
    */

--- a/packages/publisher/s3/src/Config.ts
+++ b/packages/publisher/s3/src/Config.ts
@@ -39,6 +39,12 @@ export interface PublisherS3Config {
    */
   public?: boolean;
   /**
+   * Whether to omit the ACL when creating the S3 object
+   *
+   * Default: false
+   */
+  omitAcl?: boolean;
+  /**
    * The endpoint URI to send requests to.
    *
    * E.g. `https://s3.example.com`

--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 
-import { S3Client } from '@aws-sdk/client-s3';
+import { PutObjectCommandInput, S3Client } from '@aws-sdk/client-s3';
 import { Progress, Upload } from '@aws-sdk/lib-storage';
 import { Credentials } from '@aws-sdk/types';
 import { PublisherOptions, PublisherStatic } from '@electron-forge/publisher-static';
@@ -59,15 +59,18 @@ export default class PublisherS3 extends PublisherStatic<PublisherS3Config> {
     await Promise.all(
       artifacts.map(async (artifact) => {
         d('uploading:', artifact.path);
+        const params: PutObjectCommandInput = {
+          Body: fs.createReadStream(artifact.path),
+          Bucket: this.config.bucket,
+          Key: this.keyForArtifact(artifact),
+        };
+        if (!this.config.omitAcl) {
+          params.ACL = this.config.public ? 'public-read' : 'private';
+        }
         const uploader = new Upload({
           client: s3Client,
           leavePartsOnError: true,
-          params: {
-            Body: fs.createReadStream(artifact.path),
-            Bucket: this.config.bucket,
-            Key: this.keyForArtifact(artifact),
-            ACL: this.config.public ? 'public-read' : 'private',
-          },
+          params,
         });
 
         uploader.on('httpUploadProgress', (progress: Progress) => {


### PR DESCRIPTION
This allows the caller to omit the ACL from the upload request, per Amazon's recommendation of using bucket owner-enforced permissions.

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

AWS recommends disabling the use of ACLs and instead using bucket owner-enforced permissions (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/ensure-object-ownership.html). The current configuration and implementation of the S3 publisher always applies an ACL, which simply doesn't work with buckets configured this way. This PR adds an `omitAcl` option to the config that simply omits the ACL from the upload command.

I considered making this config look more like the Google Cloud Storage publisher (which uses essentially applies some of its options, such as `predefinedAcl`, `public`, and `private`, directly to its upload object); however, that would be a breaking change, and I opted for keeping this non-breaking. I'm happy to refactor if you think that is preferred.