### PR TITLE
fix(api-core): find forgeConfig file

### DIFF
--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -127,7 +127,7 @@ export default async (dir: string): Promise<ResolvedForgeConfig> => {
   if (forgeConfig && typeof forgeConfig === 'string') {
     const pathToConfig = path.resolve(dir, forgeConfig);
     if (!rechoir.prepare(interpret.extensions, pathToConfig, dir)) {
-      throw new Error(`Not found interpret for config file[${pathToConfig}]`);
+      throw new Error(`Not found interpret for config file: ${pathToConfig}`);
     }
   }
 

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -124,7 +124,14 @@ export default async (dir: string): Promise<ResolvedForgeConfig> => {
     forgeConfig = packageJSON.config && packageJSON.config.forge ? packageJSON.config.forge : null;
   }
 
-  if (!forgeConfig || typeof forgeConfig === 'string') {
+  if (forgeConfig && typeof forgeConfig === 'string') {
+    const pathToConfig = path.resolve(dir, forgeConfig);
+    if (!rechoir.prepare(interpret.extensions, pathToConfig, dir)) {
+      throw new Error(`Not found interpret for config file[${pathToConfig}]`);
+    }
+  }
+
+  if (!forgeConfig) {
     for (const extension of ['.js', ...Object.keys(interpret.extensions)]) {
       const pathToConfig = path.resolve(dir, `forge.config${extension}`);
       if (await fs.pathExists(pathToConfig)) {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
    `package.json->config->forge`提供相对路径时，并不能准确寻找文件。除非提供`object`类型，否则都要遍历所有扩展名，启动时略耗时。