### PR TITLE
fix(plugin-vite): stop the world

### DIFF
--- a/packages/plugin/vite/src/VitePlugin.ts
+++ b/packages/plugin/vite/src/VitePlugin.ts
@@ -164,7 +164,7 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}`);
             // Avoid recursive builds caused by users configuring @electron-forge/plugin-vite in Vite config file.
             configFile: false,
             ...userConfig,
-            plugins: [onBuildDone(resolve), ...(userConfig.plugins ?? [])],
+            plugins: [onBuildDone(resolve, reject), ...(userConfig.plugins ?? [])],
           })
           .then((result) => {
             if (isWatcher(result)) {

--- a/packages/plugin/vite/src/util/plugins.ts
+++ b/packages/plugin/vite/src/util/plugins.ts
@@ -1,10 +1,19 @@
 import type { Plugin } from 'vite';
 
-export function onBuildDone(callback: () => void) {
+export function onBuildDone(onfulfilled: () => void, onrejected: (error: Error) => void) {
   return {
     name: '@electron-forge/plugin-vite:build-done',
-    closeBundle() {
-      callback();
+    buildEnd(error) {
+      error && onrejected(error);
+    },
+    generateBundle(options, bundle, isWrite) {
+      isWrite || onfulfilled();
+    },
+    writeBundle() {
+      onfulfilled();
+    },
+    renderError(error) {
+      error && onrejected(error);
     },
   } as Plugin;
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
Run `yarn run start`. Under the default configuration, `vite.build` will call `rollup.watch`. If the first build fails, `Promise.all` will never be resolved.

https://github.com/electron/forge/blob/7574b364901ec429220dbe7076184585a99529a5/packages/plugin/vite/src/VitePlugin.ts#L155-L183