### PR TITLE
ci: use larger Linux resource class for slow tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,12 @@ version: 2.1
 orbs:
   node: electronjs/node@2.3.0
 
+executors:
+  linux-medium-plus:
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium+
+
 commands:
   install:
     steps:
@@ -126,7 +132,7 @@ jobs:
                   npm install node-gyp@9.4.0
       - when:
           condition:
-            equal: [node/linux, << parameters.executor >>]
+            equal: [linux-medium-plus, << parameters.executor >>]
           steps:
             - run:
                 name: Linux specific setup
@@ -174,10 +180,10 @@ workflows:
             - lint-and-build
           matrix:
             parameters:
-              executor: [node/windows, node/linux, node/macos]
+              executor: [node/windows, linux-medium-plus, node/macos]
               arch: [x64, arm64]
             exclude:
               - executor: node/windows
                 arch: arm64
-              - executor: node/linux
+              - executor: linux-medium-plus
                 arch: arm64


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

The CI job for slow tests on Linux has started consistently failing, and it looks to be due to OOM. Bumping the resource class size to work around it.