### PR TITLE
fix(maker-dmg): remove unnecessary `appPath` config value

### DIFF
--- a/packages/maker/dmg/src/Config.ts
+++ b/packages/maker/dmg/src/Config.ts
@@ -35,4 +35,4 @@ export interface AdditionalDMGOptions {
   'code-sign'?: CodeSignOptions;
 }
 
-export type MakerDMGConfig = Omit<ElectronInstallerDMGOptions, 'name'> & { name?: string };
+export type MakerDMGConfig = Omit<ElectronInstallerDMGOptions, 'name' | 'appPath'> & { name?: string };

--- a/packages/maker/dmg/test/MakerDMG_spec.ts
+++ b/packages/maker/dmg/test/MakerDMG_spec.ts
@@ -34,9 +34,7 @@ describe('MakerDMG', () => {
     ensureFileStub = stub().returns(Promise.resolve());
     eidStub = stub().returns(Promise.resolve());
     renameStub = stub().returns(Promise.resolve());
-    config = {
-      appPath: 'fake',
-    };
+    config = {};
 
     MakerDMG = proxyquire
       .noPreserveCache()


### PR DESCRIPTION
Fixes https://github.com/electron/forge/issues/3712