### PR TITLE
chore: remove `source-map-support`

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "rechoir": "^0.8.0",
     "resolve-package": "^1.0.1",
     "semver": "^7.2.1",
-    "source-map-support": "^0.5.13",
     "sudo-prompt": "^9.1.1",
     "username": "^5.1.0",
     "vite": "^5.0.12",

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -71,7 +71,6 @@
     "rechoir": "^0.8.0",
     "resolve-package": "^1.0.1",
     "semver": "^7.2.1",
-    "source-map-support": "^0.5.13",
     "sudo-prompt": "^9.1.1",
     "username": "^5.1.0",
     "yarn-or-npm": "^3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11736,7 +11736,7 @@ source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
-source-map-support@^0.5.13, source-map-support@~0.5.20:
+source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==


### PR DESCRIPTION
We added this package in https://github.com/electron/forge/pull/488, and I don't think it's used anywhere.

It's also not advised to be used past Node 12:

> This package is no longer required as [Node 12.12.0 introduced the --enable-source-maps flag.](https://nodejs.org/docs/latest-v16.x/api/cli.html#--enable-source-maps) (unless you're using the [vm](https://nodejs.org/api/vm.html) module, as --enable-source-maps does not work with vm.runInThisContext).