### PR TITLE
refactor(all): use `node:` prefixes

### DIFF
--- a/packages/api/cli/src/electron-forge-import.ts
+++ b/packages/api/cli/src/electron-forge-import.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { api } from '@electron-forge/core';
 import program from 'commander';

--- a/packages/api/cli/src/electron-forge-init.ts
+++ b/packages/api/cli/src/electron-forge-init.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { api, InitOptions } from '@electron-forge/core';
 import program from 'commander';

--- a/packages/api/cli/src/electron-forge-make.ts
+++ b/packages/api/cli/src/electron-forge-make.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { api, MakeOptions } from '@electron-forge/core';
 import { initializeProxy } from '@electron/get';

--- a/packages/api/cli/src/electron-forge-package.ts
+++ b/packages/api/cli/src/electron-forge-package.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { api, PackageOptions } from '@electron-forge/core';
 import { initializeProxy } from '@electron/get';

--- a/packages/api/cli/src/electron-forge-publish.ts
+++ b/packages/api/cli/src/electron-forge-publish.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { api, PublishOptions } from '@electron-forge/core';
 import { initializeProxy } from '@electron/get';

--- a/packages/api/cli/src/electron-forge-start.ts
+++ b/packages/api/cli/src/electron-forge-start.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { api, StartOptions } from '@electron-forge/core';
 import { ElectronProcess } from '@electron-forge/shared-types';

--- a/packages/api/cli/src/util/check-system.ts
+++ b/packages/api/cli/src/util/check-system.ts
@@ -1,6 +1,6 @@
-import { exec } from 'child_process';
-import os from 'os';
-import path from 'path';
+import { exec } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
 
 import { utils as forgeUtils } from '@electron-forge/core';
 import { ForgeListrTask } from '@electron-forge/shared-types';

--- a/packages/api/cli/src/util/working-dir.ts
+++ b/packages/api/cli/src/util/working-dir.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import fs from 'fs-extra';
 

--- a/packages/api/cli/test/cli_spec.ts
+++ b/packages/api/cli/test/cli_spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { spawn } from '@malept/cross-spawn-promise';
 import chai, { expect } from 'chai';

--- a/packages/api/core/src/api/import.ts
+++ b/packages/api/core/src/api/import.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { safeYarnOrNpm, updateElectronDependency } from '@electron-forge/core-utils';
 import { ForgeListrOptions, ForgeListrTaskFn } from '@electron-forge/shared-types';

--- a/packages/api/core/src/api/init-scripts/init-git.ts
+++ b/packages/api/core/src/api/init-scripts/init-git.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { exec } from 'node:child_process';
 
 import debug from 'debug';
 

--- a/packages/api/core/src/api/init-scripts/init-link.ts
+++ b/packages/api/core/src/api/init-scripts/init-link.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { safeYarnOrNpm, yarnOrNpmSpawn } from '@electron-forge/core-utils';
 import { ForgeListrTask } from '@electron-forge/shared-types';

--- a/packages/api/core/src/api/init-scripts/init-npm.ts
+++ b/packages/api/core/src/api/init-scripts/init-npm.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { safeYarnOrNpm } from '@electron-forge/core-utils';
 import { ForgeListrTask } from '@electron-forge/shared-types';

--- a/packages/api/core/src/api/init.ts
+++ b/packages/api/core/src/api/init.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { safeYarnOrNpm } from '@electron-forge/core-utils';
 import { ForgeTemplate } from '@electron-forge/shared-types';

--- a/packages/api/core/src/api/make.ts
+++ b/packages/api/core/src/api/make.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { getElectronVersion } from '@electron-forge/core-utils';
 import { MakerBase } from '@electron-forge/maker-base';

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { promisify } from 'util';
+import path from 'node:path';
+import { promisify } from 'node:util';
 
 import { getElectronVersion, listrCompatibleRebuildHook } from '@electron-forge/core-utils';
 import { ForgeArch, ForgeListrTask, ForgeListrTaskDefinition, ForgeListrTaskFn, ForgePlatform, ResolvedForgeConfig } from '@electron-forge/shared-types';

--- a/packages/api/core/src/api/publish.ts
+++ b/packages/api/core/src/api/publish.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { PublisherBase } from '@electron-forge/publisher-base';
 import {

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -1,4 +1,4 @@
-import { spawn, SpawnOptions } from 'child_process';
+import { spawn, SpawnOptions } from 'node:child_process';
 
 import { getElectronVersion, listrCompatibleRebuildHook } from '@electron-forge/core-utils';
 import {

--- a/packages/api/core/src/util/electron-executable.ts
+++ b/packages/api/core/src/util/electron-executable.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { getElectronModulePath } from '@electron-forge/core-utils';
 import logSymbols from 'log-symbols';

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { ForgeConfig, ResolvedForgeConfig } from '@electron-forge/shared-types';
 import fs from 'fs-extra';

--- a/packages/api/core/src/util/import-search.ts
+++ b/packages/api/core/src/util/import-search.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import debug from 'debug';
 

--- a/packages/api/core/src/util/linux-installer.ts
+++ b/packages/api/core/src/util/linux-installer.ts
@@ -1,5 +1,5 @@
-import { spawnSync } from 'child_process';
-import { promisify } from 'util';
+import { spawnSync } from 'node:child_process';
+import { promisify } from 'node:util';
 
 import sudoPrompt from 'sudo-prompt';
 

--- a/packages/api/core/src/util/out-dir.ts
+++ b/packages/api/core/src/util/out-dir.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { ResolvedForgeConfig } from '@electron-forge/shared-types';
 

--- a/packages/api/core/src/util/publish-state.ts
+++ b/packages/api/core/src/util/publish-state.ts
@@ -1,5 +1,5 @@
-import crypto from 'crypto';
-import path from 'path';
+import crypto from 'node:crypto';
+import path from 'node:path';
 
 import { ForgeMakeResult } from '@electron-forge/shared-types';
 import fs from 'fs-extra';

--- a/packages/api/core/src/util/read-package-json.ts
+++ b/packages/api/core/src/util/read-package-json.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { ResolvedForgeConfig } from '@electron-forge/shared-types';
 import fs from 'fs-extra';

--- a/packages/api/core/src/util/resolve-dir.ts
+++ b/packages/api/core/src/util/resolve-dir.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { getElectronVersion } from '@electron-forge/core-utils';
 import debug from 'debug';

--- a/packages/api/core/src/util/upgrade-forge-config.ts
+++ b/packages/api/core/src/util/upgrade-forge-config.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { ForgeConfig, ForgePlatform, IForgeResolvableMaker, IForgeResolvablePublisher } from '@electron-forge/shared-types';
 

--- a/packages/api/core/test/fast/electron-executable_spec.ts
+++ b/packages/api/core/test/fast/electron-executable_spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import chai, { expect } from 'chai';
 import { createSandbox } from 'sinon';

--- a/packages/api/core/test/fast/forge-config_spec.ts
+++ b/packages/api/core/test/fast/forge-config_spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { ResolvedForgeConfig } from '@electron-forge/shared-types';
 import { expect } from 'chai';

--- a/packages/api/core/test/fast/make_spec.ts
+++ b/packages/api/core/test/fast/make_spec.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { ForgeMakeResult } from '@electron-forge/shared-types';
 import { expect } from 'chai';

--- a/packages/api/core/test/fast/out-dir_spec.ts
+++ b/packages/api/core/test/fast/out-dir_spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { ResolvedForgeConfig } from '@electron-forge/shared-types';
 import { expect } from 'chai';

--- a/packages/api/core/test/fast/publish_spec.ts
+++ b/packages/api/core/test/fast/publish_spec.ts
@@ -1,5 +1,5 @@
-import os from 'os';
-import path from 'path';
+import os from 'node:os';
+import path from 'node:path';
 
 import { ForgeConfigPublisher, IForgePublisher } from '@electron-forge/shared-types';
 import { expect } from 'chai';

--- a/packages/api/core/test/fast/read-package-json_spec.ts
+++ b/packages/api/core/test/fast/read-package-json_spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { ResolvedForgeConfig } from '@electron-forge/shared-types';
 import { expect } from 'chai';

--- a/packages/api/core/test/fast/resolve-dir_spec.ts
+++ b/packages/api/core/test/fast/resolve-dir_spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { expect } from 'chai';
 

--- a/packages/api/core/test/fast/start_spec.ts
+++ b/packages/api/core/test/fast/start_spec.ts
@@ -36,7 +36,7 @@ describe('start', () => {
       '../util/read-package-json': {
         readMutatedPackageJson: () => Promise.resolve(packageJSON),
       },
-      child_process: {
+      'node:child_process': {
         spawn: spawnStub,
       },
     }).default;

--- a/packages/api/core/test/fast/upgrade-forge-config_spec.ts
+++ b/packages/api/core/test/fast/upgrade-forge-config_spec.ts
@@ -1,4 +1,4 @@
-import assert from 'assert';
+import assert from 'node:assert';
 
 import { ForgeConfig, IForgeResolvableMaker, IForgeResolvablePublisher } from '@electron-forge/shared-types';
 import { expect } from 'chai';

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -1,6 +1,6 @@
-import assert from 'assert';
-import { execSync } from 'child_process';
-import path from 'path';
+import assert from 'node:assert';
+import { execSync } from 'node:child_process';
+import path from 'node:path';
 
 import { yarnOrNpmSpawn } from '@electron-forge/core-utils';
 import { createDefaultCertificate } from '@electron-forge/maker-appx';

--- a/packages/api/core/test/slow/init_git_spec_slow.ts
+++ b/packages/api/core/test/slow/init_git_spec_slow.ts
@@ -1,6 +1,6 @@
-import { execSync } from 'child_process';
-import os from 'os';
-import path from 'path';
+import { execSync } from 'node:child_process';
+import os from 'node:os';
+import path from 'node:path';
 
 import { expect } from 'chai';
 import fs from 'fs-extra';

--- a/packages/api/core/test/slow/install-dependencies_spec_slow.ts
+++ b/packages/api/core/test/slow/install-dependencies_spec_slow.ts
@@ -1,5 +1,5 @@
-import os from 'os';
-import path from 'path';
+import os from 'node:os';
+import path from 'node:path';
 
 import { expect } from 'chai';
 import fs from 'fs-extra';

--- a/packages/maker/appx/src/MakerAppX.ts
+++ b/packages/maker/appx/src/MakerAppX.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';

--- a/packages/maker/appx/test/MakerAppX_spec.ts
+++ b/packages/maker/appx/test/MakerAppX_spec.ts
@@ -1,5 +1,5 @@
-import { tmpdir } from 'os';
-import { join } from 'path';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import { expect } from 'chai';
 import fs from 'fs-extra';

--- a/packages/maker/base/src/Maker.ts
+++ b/packages/maker/base/src/Maker.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { ForgeArch, ForgePlatform, IForgeMaker, ResolvedForgeConfig } from '@electron-forge/shared-types';
 import fs from 'fs-extra';

--- a/packages/maker/base/test/ensure-output_spec.ts
+++ b/packages/maker/base/test/ensure-output_spec.ts
@@ -1,5 +1,5 @@
-import os from 'os';
-import path from 'path';
+import os from 'node:os';
+import path from 'node:path';
 
 import { expect } from 'chai';
 import fs from 'fs-extra';

--- a/packages/maker/deb/src/MakerDeb.ts
+++ b/packages/maker/deb/src/MakerDeb.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';

--- a/packages/maker/deb/test/MakerDeb_spec.ts
+++ b/packages/maker/deb/test/MakerDeb_spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch } from '@electron-forge/shared-types';

--- a/packages/maker/dmg/src/MakerDMG.ts
+++ b/packages/maker/dmg/src/MakerDMG.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';

--- a/packages/maker/dmg/test/MakerDMG_spec.ts
+++ b/packages/maker/dmg/test/MakerDMG_spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { expect } from 'chai';

--- a/packages/maker/flatpak/src/MakerFlatpak.ts
+++ b/packages/maker/flatpak/src/MakerFlatpak.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';

--- a/packages/maker/flatpak/test/MakerFlatpak_spec.ts
+++ b/packages/maker/flatpak/test/MakerFlatpak_spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch } from '@electron-forge/shared-types';

--- a/packages/maker/pkg/src/MakerPKG.ts
+++ b/packages/maker/pkg/src/MakerPKG.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';

--- a/packages/maker/pkg/test/MakerPKG_spec.ts
+++ b/packages/maker/pkg/test/MakerPKG_spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { expect } from 'chai';

--- a/packages/maker/rpm/src/MakerRpm.ts
+++ b/packages/maker/rpm/src/MakerRpm.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';

--- a/packages/maker/rpm/test/MakerRpm_spec.ts
+++ b/packages/maker/rpm/test/MakerRpm_spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgeArch } from '@electron-forge/shared-types';

--- a/packages/maker/snap/src/MakerSnap.ts
+++ b/packages/maker/snap/src/MakerSnap.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';

--- a/packages/maker/snap/test/MakerSnap_spec.ts
+++ b/packages/maker/snap/test/MakerSnap_spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { expect } from 'chai';

--- a/packages/maker/squirrel/src/MakerSquirrel.ts
+++ b/packages/maker/squirrel/src/MakerSquirrel.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';

--- a/packages/maker/wix/src/MakerWix.ts
+++ b/packages/maker/wix/src/MakerWix.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';

--- a/packages/maker/zip/src/MakerZIP.ts
+++ b/packages/maker/zip/src/MakerZIP.ts
@@ -1,5 +1,5 @@
-import path from 'path';
-import { promisify } from 'util';
+import path from 'node:path';
+import { promisify } from 'node:util';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';

--- a/packages/maker/zip/test/MakerZip_spec.ts
+++ b/packages/maker/zip/test/MakerZip_spec.ts
@@ -1,5 +1,5 @@
-import os from 'os';
-import path from 'path';
+import os from 'node:os';
+import path from 'node:path';
 
 import { expect } from 'chai';
 import fs from 'fs-extra';

--- a/packages/plugin/fuses/src/FusesPlugin.ts
+++ b/packages/plugin/fuses/src/FusesPlugin.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { namedHookWithTaskFn, PluginBase } from '@electron-forge/plugin-base';
 import { ForgeMultiHookMap, ForgePlatform } from '@electron-forge/shared-types';

--- a/packages/plugin/fuses/src/util/getElectronExecutablePath.ts
+++ b/packages/plugin/fuses/src/util/getElectronExecutablePath.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { ForgePlatform } from '@electron-forge/shared-types';
 

--- a/packages/plugin/fuses/test/FusesPlugin_spec_slow.ts
+++ b/packages/plugin/fuses/test/FusesPlugin_spec_slow.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { CrossSpawnOptions, spawn } from '@malept/cross-spawn-promise';
 import { expect } from 'chai';

--- a/packages/plugin/local-electron/test/LocalElectronPlugin_spec.ts
+++ b/packages/plugin/local-electron/test/LocalElectronPlugin_spec.ts
@@ -1,5 +1,5 @@
-import os from 'os';
-import path from 'path';
+import os from 'node:os';
+import path from 'node:path';
 
 import { ResolvedForgeConfig } from '@electron-forge/shared-types';
 import { expect } from 'chai';

--- a/packages/plugin/vite/test/VitePlugin_spec.ts
+++ b/packages/plugin/vite/test/VitePlugin_spec.ts
@@ -1,5 +1,5 @@
-import * as os from 'os';
-import * as path from 'path';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 import { ResolvedForgeConfig } from '@electron-forge/shared-types';
 import { IgnoreFunction } from '@electron/packager';

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import debug from 'debug';
 import HtmlWebpackPlugin from 'html-webpack-plugin';

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -1,6 +1,6 @@
-import crypto from 'crypto';
-import http from 'http';
-import path from 'path';
+import crypto from 'node:crypto';
+import http from 'node:http';
+import path from 'node:path';
 import { pipeline } from 'stream/promises';
 
 import { getElectronVersion, listrCompatibleRebuildHook } from '@electron-forge/core-utils';

--- a/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
+++ b/packages/plugin/webpack/test/AssetRelocatorPatch_spec.ts
@@ -1,5 +1,5 @@
-import http from 'http';
-import path from 'path';
+import http from 'node:http';
+import path from 'node:path';
 
 import { spawn } from '@malept/cross-spawn-promise';
 import { expect } from 'chai';

--- a/packages/plugin/webpack/test/WebpackConfig_spec.ts
+++ b/packages/plugin/webpack/test/WebpackConfig_spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { expect } from 'chai';
 import { Configuration, Entry } from 'webpack';

--- a/packages/plugin/webpack/test/WebpackPlugin_spec.ts
+++ b/packages/plugin/webpack/test/WebpackPlugin_spec.ts
@@ -1,5 +1,5 @@
-import * as os from 'os';
-import * as path from 'path';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 import { ResolvedForgeConfig } from '@electron-forge/shared-types';
 import { IgnoreFunction } from '@electron/packager';

--- a/packages/publisher/base-static/src/PublisherStatic.ts
+++ b/packages/publisher/base-static/src/PublisherStatic.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { PublisherBase, PublisherOptions } from '@electron-forge/publisher-base';
 import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';

--- a/packages/publisher/bitbucket/src/PublisherBitbucket.ts
+++ b/packages/publisher/bitbucket/src/PublisherBitbucket.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { PublisherBase, PublisherOptions } from '@electron-forge/publisher-base';
 import FormData from 'form-data';

--- a/packages/publisher/electron-release-server/src/PublisherERS.ts
+++ b/packages/publisher/electron-release-server/src/PublisherERS.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { PublisherBase, PublisherOptions } from '@electron-forge/publisher-base';
 import { ForgeArch, ForgePlatform } from '@electron-forge/shared-types';

--- a/packages/publisher/github/src/util/github.ts
+++ b/packages/publisher/github/src/util/github.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { OctokitOptions } from '@octokit/core/dist-types/types.d';
 import { retry } from '@octokit/plugin-retry';

--- a/packages/publisher/nucleus/src/PublisherNucleus.ts
+++ b/packages/publisher/nucleus/src/PublisherNucleus.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { PublisherBase, PublisherOptions } from '@electron-forge/publisher-base';
 import debug from 'debug';

--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { PutObjectCommandInput, S3Client } from '@aws-sdk/client-s3';
 import { Progress, Upload } from '@aws-sdk/lib-storage';

--- a/packages/publisher/snapcraft/src/PublisherSnapcraft.ts
+++ b/packages/publisher/snapcraft/src/PublisherSnapcraft.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { PublisherBase, PublisherOptions } from '@electron-forge/publisher-base';
 import fs from 'fs-extra';

--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { ForgeListrTaskDefinition, ForgeTemplate, InitTemplateOptions } from '@electron-forge/shared-types';
 import debug from 'debug';

--- a/packages/template/vite-typescript/src/ViteTypeScriptTemplate.ts
+++ b/packages/template/vite-typescript/src/ViteTypeScriptTemplate.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { ForgeListrTaskDefinition, InitTemplateOptions } from '@electron-forge/shared-types';
 import { BaseTemplate } from '@electron-forge/template-base';

--- a/packages/template/vite-typescript/tmpl/main.ts
+++ b/packages/template/vite-typescript/tmpl/main.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow } from 'electron';
-import path from 'path';
+import path from 'node:path';
 import started from 'electron-squirrel-startup';
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.

--- a/packages/template/vite/src/ViteTemplate.ts
+++ b/packages/template/vite/src/ViteTemplate.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { ForgeListrTaskDefinition, InitTemplateOptions } from '@electron-forge/shared-types';
 import { BaseTemplate } from '@electron-forge/template-base';

--- a/packages/template/vite/test/ViteTemplate_spec.ts
+++ b/packages/template/vite/test/ViteTemplate_spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import * as testUtils from '@electron-forge/test-utils';
 import { expect } from 'chai';

--- a/packages/template/webpack-typescript/src/WebpackTypeScriptTemplate.ts
+++ b/packages/template/webpack-typescript/src/WebpackTypeScriptTemplate.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { ForgeListrTaskDefinition, InitTemplateOptions } from '@electron-forge/shared-types';
 import { BaseTemplate } from '@electron-forge/template-base';

--- a/packages/template/webpack-typescript/test/WebpackTypeScript_spec_slow.ts
+++ b/packages/template/webpack-typescript/test/WebpackTypeScript_spec_slow.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { yarnOrNpmSpawn } from '@electron-forge/core-utils';
 import * as testUtils from '@electron-forge/test-utils';

--- a/packages/template/webpack/src/WebpackTemplate.ts
+++ b/packages/template/webpack/src/WebpackTemplate.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import { ForgeListrTaskDefinition, InitTemplateOptions } from '@electron-forge/shared-types';
 import { BaseTemplate } from '@electron-forge/template-base';

--- a/packages/template/webpack/test/WebpackTemplate_spec.ts
+++ b/packages/template/webpack/test/WebpackTemplate_spec.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import * as testUtils from '@electron-forge/test-utils';
 import { expect } from 'chai';

--- a/packages/utils/core-utils/src/electron-version.ts
+++ b/packages/utils/core-utils/src/electron-version.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import path from 'node:path';
 
 import debug from 'debug';
 import findUp from 'find-up';

--- a/packages/utils/core-utils/src/rebuild.ts
+++ b/packages/utils/core-utils/src/rebuild.ts
@@ -1,5 +1,5 @@
-import * as cp from 'child_process';
-import * as path from 'path';
+import * as cp from 'node:child_process';
+import * as path from 'node:path';
 
 import { ForgeArch, ForgeListrTask, ForgePlatform } from '@electron-forge/shared-types';
 import { RebuildOptions } from '@electron/rebuild';

--- a/packages/utils/core-utils/test/electron-version_spec.ts
+++ b/packages/utils/core-utils/test/electron-version_spec.ts
@@ -1,5 +1,5 @@
-import os from 'os';
-import path from 'path';
+import os from 'node:os';
+import path from 'node:path';
 
 import { expect } from 'chai';
 import fs from 'fs-extra';

--- a/packages/utils/test-utils/src/index.ts
+++ b/packages/utils/test-utils/src/index.ts
@@ -1,5 +1,5 @@
-import os from 'os';
-import path from 'path';
+import os from 'node:os';
+import path from 'node:path';
 
 import { ExitError, spawn } from '@malept/cross-spawn-promise';
 import { expect } from 'chai';

--- a/packages/utils/tracer/src/index.ts
+++ b/packages/utils/tracer/src/index.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import * as fs from 'node:fs';
 
 import { Fields, Tracer } from 'chrome-trace-event';
 

--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -1,4 +1,4 @@
-import { ChildProcess } from 'child_process';
+import { ChildProcess } from 'node:child_process';
 
 import { autoTrace } from '@electron-forge/tracer';
 import { ArchOption, Options as ElectronPackagerOptions, TargetPlatform } from '@electron/packager';

--- a/packages/utils/web-multi-logger/src/Logger.ts
+++ b/packages/utils/web-multi-logger/src/Logger.ts
@@ -1,5 +1,5 @@
-import http from 'http';
-import path from 'path';
+import http from 'node:http';
+import path from 'node:path';
 
 import express from 'express';
 import ews from 'express-ws';

--- a/tools/fix-deps.ts
+++ b/tools/fix-deps.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import * as fs from 'fs-extra';
 

--- a/tools/gen-ts-glue.ts
+++ b/tools/gen-ts-glue.ts
@@ -12,8 +12,8 @@
  * file (like index.ts) to redirect to the right file.
  */
 
-import { promises as fs } from 'fs';
-import path from 'path';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
 
 import { getPackageInfo } from './utils';
 

--- a/tools/gen-tsconfigs.ts
+++ b/tools/gen-tsconfigs.ts
@@ -1,5 +1,5 @@
-import { promises as fs } from 'fs';
-import * as path from 'path';
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
 
 import { getPackageInfo } from './utils';
 

--- a/tools/position-docs.ts
+++ b/tools/position-docs.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import glob from 'fast-glob';
 import * as fs from 'fs-extra';

--- a/tools/sync-readmes.ts
+++ b/tools/sync-readmes.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import * as fs from 'fs-extra';
 import { Listr } from 'listr2';

--- a/tools/test-dist.ts
+++ b/tools/test-dist.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import chalk from 'chalk';
 import * as fs from 'fs-extra';

--- a/tools/update-node-version.ts
+++ b/tools/update-node-version.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env ts-node
 
-import path from 'path';
+import path from 'node:path';
 
 import { readJsonSync, writeJsonSync } from 'fs-extra';
 

--- a/tools/utils.ts
+++ b/tools/utils.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'node:path';
 
 import * as fs from 'fs-extra';
 

--- a/typings/sudo-prompt/index.d.ts
+++ b/typings/sudo-prompt/index.d.ts
@@ -1,4 +1,4 @@
-import { PromiseWithChild } from 'child_process';
+import { PromiseWithChild } from 'node:child_process';
 
 // Copied from https://github.com/jorangreef/sudo-prompt/pull/124
 // TODO: Remove this if/when that PR gets merged/released


### PR DESCRIPTION
Tearing the bandaid off here so that we can use these going forward. They're cleaner and I think a few of the newer modules require you to have prefixed namespaces going forward (e.g. `node:test`).

We can pull in https://github.com/import-js/eslint-plugin-import/pull/3024 when a new minor release of that package goes out.