### PR TITLE
test: avoid `proxyquire` in `api_spec_slow`

### DIFF
--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -77,8 +77,8 @@ for (const nodeInstaller of ['npm', 'yarn']) {
         expect(await fs.pathExists(path.resolve(dir, 'node_modules/@electron-forge/cli')), '@electron-forge/cli should exist').to.equal(true);
       });
 
-      it('should create a api.config.js', async () => {
-        await expectProjectPathExists(dir, 'api.config.js', 'file');
+      it('should create a forge.config.js', async () => {
+        await expectProjectPathExists(dir, 'forge.config.js', 'file');
       });
 
       describe('lint', () => {

--- a/packages/api/core/test/slow/api_spec_slow.ts
+++ b/packages/api/core/test/slow/api_spec_slow.ts
@@ -197,7 +197,7 @@ for (const nodeInstaller of ['npm', 'yarn']) {
         });
       });
 
-      it('creates api.config.js and is packageable', async () => {
+      it('creates forge.config.js and is packageable', async () => {
         await updatePackageJSON(dir, async (packageJSON) => {
           packageJSON.name = 'Name';
           packageJSON.productName = 'ProductName';
@@ -205,7 +205,7 @@ for (const nodeInstaller of ['npm', 'yarn']) {
 
         await api.import({ dir });
 
-        expect(fs.existsSync(path.join(dir, 'api.config.js'))).to.equal(true);
+        expect(fs.existsSync(path.join(dir, 'forge.config.js'))).to.equal(true);
 
         execSync(`${nodeInstaller} install`, {
           cwd: dir,


### PR DESCRIPTION
Small improvement for tests. We removed the `forge install` command in a v6 beta, but this test fixture still used `proxyquire` to stub that module.

Eliminating `proxyquire` here also improves type safety as `forge` was previously an `any` type.