### PR TITLE
build(plugin-vite): allow renderer name to contain dashes

### DIFF
--- a/packages/plugin/vite/src/config/vite.base.config.ts
+++ b/packages/plugin/vite/src/config/vite.base.config.ts
@@ -33,7 +33,7 @@ export function getDefineKeys(names: string[]) {
   const define: { [name: string]: VitePluginRuntimeKeys } = {};
 
   // change name from kebab case to upper snake case to agree with vite:define plugin
-  //  this allows the VitePluginRendererConfig entries to contain names with dashes
+  // this allows the VitePluginRendererConfig entries to contain names with dashes
 
   return names.reduce((acc, name) => {
     const NAME = name.toUpperCase().replaceAll('-', '_');

--- a/packages/plugin/vite/src/config/vite.base.config.ts
+++ b/packages/plugin/vite/src/config/vite.base.config.ts
@@ -32,8 +32,11 @@ export function getBuildConfig(env: ConfigEnv<'build'>): UserConfig {
 export function getDefineKeys(names: string[]) {
   const define: { [name: string]: VitePluginRuntimeKeys } = {};
 
+  // change name from kebab case to upper snake case to agree with vite:define plugin
+  //  this allows the VitePluginRendererConfig entries to contain names with dashes
+
   return names.reduce((acc, name) => {
-    const NAME = name.toUpperCase();
+    const NAME = name.toUpperCase().replaceAll('-', '_');
     const keys: VitePluginRuntimeKeys = {
       VITE_DEV_SERVER_URL: `${NAME}_VITE_DEV_SERVER_URL`,
       VITE_NAME: `${NAME}_VITE_NAME`,


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Small edit to vite plugin to allow VitePluginRendererConfig entries to have hyphens in their name.

Motivation is we have a large forge repo with multiple applications / frontends. We have them organized as follows:

.
└── src/
    ├── app-1-frontend-1
    ├── app-2-frontend-1
    ├── app-2-frontend-2
    └── app-3-frontend-1
    
In forge v7.4.0, vite.base.config.ts was a part of the vite-typescript template. Ran into the issue while trying to update our dependencies as a result of #3583. This shouldn't break any existing users as if they already had "-" in their name, the build would've already been failing