### PR TITLE
fix(core-utils): don't add --save flag for npm install

### DIFF
--- a/packages/api/core/src/util/install-dependencies.ts
+++ b/packages/api/core/src/util/install-dependencies.ts
@@ -26,9 +26,8 @@ export default async (dir: string, deps: string[], depType = DepType.PROD, versi
     if (depType === DepType.DEV) cmd.push('--dev');
     if (versionRestriction === DepVersionRestriction.EXACT) cmd.push('--exact');
   } else {
-    if (versionRestriction === DepVersionRestriction.EXACT) cmd.push('--save-exact');
     if (depType === DepType.DEV) cmd.push('--save-dev');
-    if (depType === DepType.PROD) cmd.push('--save');
+    if (versionRestriction === DepVersionRestriction.EXACT) cmd.push('--save-exact');
   }
   d('executing', JSON.stringify(cmd), 'in:', dir);
   try {

--- a/packages/api/core/test/fast/install-dependencies_spec.ts
+++ b/packages/api/core/test/fast/install-dependencies_spec.ts
@@ -78,7 +78,7 @@ describe('Install dependencies', () => {
 
     it('should install prod deps', () => {
       install('mydir', ['react']);
-      expect(spawnSpy.firstCall.args[0]).to.be.deep.equal(['install', 'react', '--save']);
+      expect(spawnSpy.firstCall.args[0]).to.be.deep.equal(['install', 'react']);
     });
 
     it('should install dev deps', () => {
@@ -88,12 +88,12 @@ describe('Install dependencies', () => {
 
     it('should install exact deps', () => {
       install('mydir', ['react-dom'], DepType.PROD, DepVersionRestriction.EXACT);
-      expect(spawnSpy.firstCall.args[0]).to.be.deep.equal(['install', 'react-dom', '--save-exact', '--save']);
+      expect(spawnSpy.firstCall.args[0]).to.be.deep.equal(['install', 'react-dom', '--save-exact']);
     });
 
     it('should install exact dev deps', () => {
       install('mydir', ['mocha'], DepType.DEV, DepVersionRestriction.EXACT);
-      expect(spawnSpy.firstCall.args[0]).to.be.deep.equal(['install', 'mocha', '--save-exact', '--save-dev']);
+      expect(spawnSpy.firstCall.args[0]).to.be.deep.equal(['install', 'mocha', '--save-dev', '--save-exact']);
     });
   });
 });


### PR DESCRIPTION
Small refactor fix. `--save` is the default behaviour for package manager install nowadays, so this PR removes the `--save` flag from `npm install` when installing dependencies. This aligns with behaviour with `yarn`.

