### PR TITLE
ci: disable parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
         type: enum
         enum: ['x64', 'arm64']
     executor: << parameters.executor >>
-    parallelism: 2
+    parallelism: 1 # disabled due to being on CircleCI's free plan
     steps:
       - install
       - when:


### PR DESCRIPTION
We're getting `Job failed due to excessive parallelism` errors in CI now due to this flag.

Closes #3536