### PR TITLE
chore: upgrade yarn@1.22.22 in corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
   "prettier": {
     "singleQuote": true
   },
-  "packageManager": "yarn@1.22.19+sha1.4ba7fc5c6e704fce2066ecbfb0b0d8976fe62447",
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "workspaces": {
     "packages": [
       "packages/api/*",


### PR DESCRIPTION
SHA fetched using new `corepack up` command.

ref https://github.com/electron/forge/pull/3359