### PR TITLE
Fix/cloudflare r2 skip checksum

### DIFF
--- a/packages/publisher/s3/package.json
+++ b/packages/publisher/s3/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/electron/forge",
   "author": "Samuel Attard",
   "license": "MIT",
-  "main": "src/PublisherS3.ts",
+  "main": "dist/PublisherS3.ts",
   "devDependencies": {
     "chai": "^4.3.3",
     "mocha": "^9.0.1"

--- a/packages/publisher/s3/package.json
+++ b/packages/publisher/s3/package.json
@@ -5,8 +5,7 @@
   "repository": "https://github.com/electron/forge",
   "author": "Samuel Attard",
   "license": "MIT",
-  "main": "dist/PublisherS3.js",
-  "typings": "dist/PublisherS3.d.ts",
+  "main": "src/PublisherS3.ts",
   "devDependencies": {
     "chai": "^4.3.3",
     "mocha": "^9.0.1"

--- a/packages/publisher/s3/src/Config.ts
+++ b/packages/publisher/s3/src/Config.ts
@@ -62,6 +62,13 @@ export interface PublisherS3Config {
    * Default: false
    */
   s3ForcePathStyle?: boolean;
+
+  /**
+   * Whether to calculate checksums for uploaded files (Fix for Cloudflare R2)
+   *
+   * Default: false
+   */
+  s3RequestChecksumCalculation?: 'WHEN_SUPPORTED' | 'WHEN_REQUIRED';
   /**
    * Custom function to provide the key to upload a given file to
    */

--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -48,6 +48,7 @@ export default class PublisherS3 extends PublisherStatic<PublisherS3Config> {
       region: this.config.region,
       endpoint: this.config.endpoint,
       forcePathStyle: !!this.config.s3ForcePathStyle,
+      requestChecksumCalculation: this.config.s3RequestChecksumCalculation,
     });
 
     d('creating s3 client with options:', this.config);


### PR DESCRIPTION
Enables pass through for `s3RequestChecksumCalculation` S3Client option

```
  publishers: [
    {
      name: '@electron-forge/publisher-s3',
      config: {
        s3RequestChecksumCalculation: 'WHEN_REQUIRED', // cloudflare fix
```

Can be used to get around Cloudflare R2's lack of checksum support.

```
An unhandled rejection has occurred inside Forge:
NotImplemented: Header 'x-amz-checksum-algorithm' with value 'CRC32' not implemented
at throwDefaultError (/Users/seb/dev/Streem/slyce-studio-mono/node_modules/.pnpm/@smithy+smithy-client@4.1.2/node_modules/@smithy/smithy-client/dist-cjs/index.js:867:20)
    at /Users/seb/dev/Streem/slyce-studio-mono/node_modules/.pnpm/@smithy+smithy-client@4.1.2/node_modules/@smithy/smithy-client/dist-cjs/index.js:876:5
    at de_CommandError (/Users/seb/dev/Streem/slyce-studio-mono/node_modules/.pnpm/@aws-sdk+client-s3@3.731.1/node_modules/@aws-sdk/client-s3/dist-cjs/index.js:4965:14)
```

<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [ ] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
