### PR TITLE
test(plugin-fuses): bump Electron version in fixture

### DIFF
--- a/packages/plugin/fuses/spec/fixture/app/package.json
+++ b/packages/plugin/fuses/spec/fixture/app/package.json
@@ -13,6 +13,6 @@
     "@electron-forge/cli": "6.4.0",
     "@electron-forge/plugin-fuses": "6.4.0",
     "@electron-forge/shared-types": "6.4.0",
-    "electron": "12.0.0"
+    "electron": "34.0.0"
   }
 }

--- a/packages/plugin/fuses/spec/fixture/app/package.json.tmpl
+++ b/packages/plugin/fuses/spec/fixture/app/package.json.tmpl
@@ -13,6 +13,6 @@
     "@electron-forge/cli": "6.4.0",
     "@electron-forge/plugin-fuses": "6.4.0",
     "@electron-forge/shared-types": "6.4.0",
-    "electron": "12.0.0"
+    "electron": "34.0.0"
   }
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.

**Summarize your changes:**

Dependabot decided to flag this `package.json` with past Electron security vulnerabilities due to the old Electron version, so bump this to clear them and it's good to update this to a modern version anyway.