### PR TITLE
test: Vitest 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "ts-node": "^10.0.0",
     "typedoc": "0.25.13",
     "typescript": "~5.4.5",
-    "vitest": "^2.1.6",
+    "vitest": "^3.0.3",
     "xvfb-maybe": "^0.2.1",
     "yaml-hook": "^1.0.0"
   },

--- a/packages/api/cli/package.json
+++ b/packages/api/cli/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@malept/cross-spawn-promise": "^2.0.0",
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "dependencies": {
     "@electron-forge/core": "7.6.0",

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -23,7 +23,7 @@
     "@types/rechoir": "^0.6.1",
     "cross-env": "^7.0.2",
     "electron-installer-common": "^0.10.2",
-    "vitest": "^2.1.6",
+    "vitest": "^3.0.3",
     "yaml-hook": "^1.0.0"
   },
   "dependencies": {

--- a/packages/maker/appx/package.json
+++ b/packages/maker/appx/package.json
@@ -8,7 +8,7 @@
   "main": "dist/MakerAppX.js",
   "typings": "dist/MakerAppX.d.ts",
   "devDependencies": {
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "engines": {
     "node": ">= 16.4.0"

--- a/packages/maker/base/package.json
+++ b/packages/maker/base/package.json
@@ -8,7 +8,7 @@
   "main": "dist/Maker.js",
   "typings": "dist/Maker.d.ts",
   "devDependencies": {
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "engines": {
     "node": ">= 16.4.0"

--- a/packages/maker/deb/package.json
+++ b/packages/maker/deb/package.json
@@ -9,7 +9,7 @@
   "typings": "dist/MakerDeb.d.ts",
   "devDependencies": {
     "@electron-forge/test-utils": "7.6.0",
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "engines": {
     "node": ">= 16.4.0"

--- a/packages/maker/dmg/package.json
+++ b/packages/maker/dmg/package.json
@@ -9,7 +9,7 @@
   "typings": "dist/MakerDMG.d.ts",
   "devDependencies": {
     "@electron-forge/test-utils": "7.6.0",
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "engines": {
     "node": ">= 16.4.0"

--- a/packages/maker/flatpak/package.json
+++ b/packages/maker/flatpak/package.json
@@ -9,7 +9,7 @@
   "typings": "dist/MakerFlatpak.d.ts",
   "devDependencies": {
     "@electron-forge/test-utils": "7.6.0",
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "engines": {
     "node": ">= 16.4.0"

--- a/packages/maker/pkg/package.json
+++ b/packages/maker/pkg/package.json
@@ -8,7 +8,7 @@
   "typings": "dist/MakerPKG.d.ts",
   "devDependencies": {
     "@electron-forge/test-utils": "7.6.0",
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "engines": {
     "node": ">= 16.4.0"

--- a/packages/maker/rpm/package.json
+++ b/packages/maker/rpm/package.json
@@ -9,7 +9,7 @@
   "typings": "dist/MakerRpm.d.ts",
   "devDependencies": {
     "@electron-forge/test-utils": "7.6.0",
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "engines": {
     "node": ">= 16.4.0"

--- a/packages/maker/snap/package.json
+++ b/packages/maker/snap/package.json
@@ -8,7 +8,7 @@
   "typings": "dist/MakerSnap.d.ts",
   "devDependencies": {
     "@electron-forge/test-utils": "7.6.0",
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "engines": {
     "node": ">= 16.4.0"

--- a/packages/maker/wix/package.json
+++ b/packages/maker/wix/package.json
@@ -8,7 +8,7 @@
   "main": "dist/MakerWix.js",
   "typings": "dist/MakerWix.d.ts",
   "devDependencies": {
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "engines": {
     "node": ">= 16.4.0"

--- a/packages/maker/zip/package.json
+++ b/packages/maker/zip/package.json
@@ -9,7 +9,7 @@
   "typings": "dist/MakerZIP.d.ts",
   "devDependencies": {
     "@electron-forge/test-utils": "7.6.0",
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "engines": {
     "node": ">= 16.4.0"

--- a/packages/plugin/local-electron/package.json
+++ b/packages/plugin/local-electron/package.json
@@ -16,7 +16,7 @@
     "fs-extra": "^10.0.0"
   },
   "devDependencies": {
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/plugin/vite/package.json
+++ b/packages/plugin/vite/package.json
@@ -26,7 +26,7 @@
     "@malept/cross-spawn-promise": "^2.0.0",
     "@types/node": "^18.0.3",
     "vite": "^5.0.12",
-    "vitest": "^2.1.6",
+    "vitest": "^3.0.3",
     "which": "^2.0.2",
     "xvfb-maybe": "^0.2.1"
   },

--- a/packages/plugin/webpack/package.json
+++ b/packages/plugin/webpack/package.json
@@ -11,7 +11,7 @@
     "@electron/packager": "^18.3.5",
     "@malept/cross-spawn-promise": "^2.0.0",
     "@types/node": "^18.0.3",
-    "vitest": "^2.1.6",
+    "vitest": "^3.0.3",
     "which": "^2.0.2",
     "xvfb-maybe": "^0.2.1"
   },

--- a/packages/publisher/base-static/package.json
+++ b/packages/publisher/base-static/package.json
@@ -12,7 +12,7 @@
     "@electron-forge/shared-types": "7.6.0"
   },
   "devDependencies": {
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "engines": {
     "node": ">= 16.4.0"

--- a/packages/publisher/base/package.json
+++ b/packages/publisher/base/package.json
@@ -11,7 +11,7 @@
     "@electron-forge/shared-types": "7.6.0"
   },
   "devDependencies": {
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "engines": {
     "node": ">= 16.4.0"

--- a/packages/publisher/electron-release-server/package.json
+++ b/packages/publisher/electron-release-server/package.json
@@ -9,7 +9,7 @@
   "typings": "dist/PublisherERS.d.ts",
   "devDependencies": {
     "msw": "^2.7.0",
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "engines": {
     "node": ">= 16.4.0"

--- a/packages/publisher/github/package.json
+++ b/packages/publisher/github/package.json
@@ -8,7 +8,7 @@
   "main": "dist/PublisherGithub.js",
   "typings": "dist/PublisherGithub.d.ts",
   "devDependencies": {
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "engines": {
     "node": ">= 16.4.0"

--- a/packages/template/base/package.json
+++ b/packages/template/base/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@electron-forge/test-utils": "7.6.0",
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/template/vite-typescript/package.json
+++ b/packages/template/vite-typescript/package.json
@@ -23,7 +23,7 @@
     "@electron-forge/core-utils": "7.6.0",
     "@electron-forge/test-utils": "7.6.0",
     "fast-glob": "^3.2.7",
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "files": [
     "dist",

--- a/packages/template/vite/package.json
+++ b/packages/template/vite/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "@electron-forge/test-utils": "7.6.0",
     "listr2": "^7.0.2",
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/template/webpack-typescript/package.json
+++ b/packages/template/webpack-typescript/package.json
@@ -26,7 +26,7 @@
     "fast-glob": "^3.2.7",
     "fork-ts-checker-webpack-plugin": "^7.2.13",
     "listr2": "^7.0.2",
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "files": [
     "dist",

--- a/packages/template/webpack/package.json
+++ b/packages/template/webpack/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@electron-forge/test-utils": "7.6.0",
     "listr2": "^7.0.2",
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/utils/core-utils/package.json
+++ b/packages/utils/core-utils/package.json
@@ -23,7 +23,7 @@
     "node": ">= 16.4.0"
   },
   "devDependencies": {
-    "vitest": "^2.1.6"
+    "vitest": "^3.0.3"
   },
   "files": [
     "dist",

--- a/packages/utils/core-utils/spec/yarn-or-npm.spec.ts
+++ b/packages/utils/core-utils/spec/yarn-or-npm.spec.ts
@@ -21,17 +21,17 @@ describe('yarn-or-npm', () => {
 
   it('should by default equal the system yarn-or-npm value', async () => {
     const pm = await detect();
-    expect(safeYarnOrNpm()).resolves.toEqual(pm);
+    await expect(safeYarnOrNpm()).resolves.toEqual(pm);
   });
 
-  it('should return yarn if NODE_INSTALLER=yarn', () => {
+  it('should return yarn if NODE_INSTALLER=yarn', async () => {
     process.env.NODE_INSTALLER = 'yarn';
-    expect(safeYarnOrNpm()).resolves.toEqual('yarn');
+    await expect(safeYarnOrNpm()).resolves.toEqual('yarn');
   });
 
-  it('should return npm if NODE_INSTALLER=npm', () => {
+  it('should return npm if NODE_INSTALLER=npm', async () => {
     process.env.NODE_INSTALLER = 'npm';
-    expect(safeYarnOrNpm()).resolves.toEqual('npm');
+    await expect(safeYarnOrNpm()).resolves.toEqual('npm');
   });
 
   it('should return system value if NODE_INSTALLER is an unrecognized installer', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3382,6 +3382,16 @@
     chai "^5.1.2"
     tinyrainbow "^1.2.0"
 
+"@vitest/expect@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.0.3.tgz#a83af04a68e70a9af8aa6f68442a696b4bc599c5"
+  integrity sha512-SbRCHU4qr91xguu+dH3RUdI5dC86zm8aZWydbp961aIR7G8OYNN6ZiayFuf9WAngRbFOfdrLHCGgXTj3GtoMRQ==
+  dependencies:
+    "@vitest/spy" "3.0.3"
+    "@vitest/utils" "3.0.3"
+    chai "^5.1.2"
+    tinyrainbow "^2.0.0"
+
 "@vitest/mocker@2.1.6":
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-2.1.6.tgz#d13c5a7bd0abf432e1030f68acb43f51c4b3692e"
@@ -3391,12 +3401,28 @@
     estree-walker "^3.0.3"
     magic-string "^0.30.12"
 
+"@vitest/mocker@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.0.3.tgz#f63a7e2e93fecaab1046038f3a9f60ea6b369173"
+  integrity sha512-XT2XBc4AN9UdaxJAeIlcSZ0ILi/GzmG5G8XSly4gaiqIvPV3HMTSIDZWJVX6QRJ0PX1m+W8Cy0K9ByXNb/bPIA==
+  dependencies:
+    "@vitest/spy" "3.0.3"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.17"
+
 "@vitest/pretty-format@2.1.6", "@vitest/pretty-format@^2.1.6":
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-2.1.6.tgz#9bc642047a3efc637b41492b1f222c43be3822e4"
   integrity sha512-exZyLcEnHgDMKc54TtHca4McV4sKT+NKAe9ix/yhd/qkYb/TP8HTyXRFDijV19qKqTZM0hPL4753zU/U8L/gAA==
   dependencies:
     tinyrainbow "^1.2.0"
+
+"@vitest/pretty-format@3.0.3", "@vitest/pretty-format@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.0.3.tgz#4bd59463d1c944c22287c3da2060785269098183"
+  integrity sha512-gCrM9F7STYdsDoNjGgYXKPq4SkSxwwIU5nkaQvdUxiQ0EcNlez+PdKOVIsUJvh9P9IeIFmjn4IIREWblOBpP2Q==
+  dependencies:
+    tinyrainbow "^2.0.0"
 
 "@vitest/runner@2.1.6":
   version "2.1.6"
@@ -3405,6 +3431,14 @@
   dependencies:
     "@vitest/utils" "2.1.6"
     pathe "^1.1.2"
+
+"@vitest/runner@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.0.3.tgz#c123e3225ccdd52c5a8e45edb59340ec8dcb6df2"
+  integrity sha512-Rgi2kOAk5ZxWZlwPguRJFOBmWs6uvvyAAR9k3MvjRvYrG7xYvKChZcmnnpJCS98311CBDMqsW9MzzRFsj2gX3g==
+  dependencies:
+    "@vitest/utils" "3.0.3"
+    pathe "^2.0.1"
 
 "@vitest/snapshot@2.1.6":
   version "2.1.6"
@@ -3415,10 +3449,26 @@
     magic-string "^0.30.12"
     pathe "^1.1.2"
 
+"@vitest/snapshot@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.0.3.tgz#a20a8cfa0e7434ef94f4dff40d946a57922119de"
+  integrity sha512-kNRcHlI4txBGztuJfPEJ68VezlPAXLRT1u5UCx219TU3kOG2DplNxhWLwDf2h6emwmTPogzLnGVwP6epDaJN6Q==
+  dependencies:
+    "@vitest/pretty-format" "3.0.3"
+    magic-string "^0.30.17"
+    pathe "^2.0.1"
+
 "@vitest/spy@2.1.6":
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-2.1.6.tgz#229f9d48b90b8bdd6573723bdec0699915598080"
   integrity sha512-oTFObV8bd4SDdRka5O+mSh5w9irgx5IetrD5i+OsUUsk/shsBoHifwCzy45SAORzAhtNiprUVaK3hSCCzZh1jQ==
+  dependencies:
+    tinyspy "^3.0.2"
+
+"@vitest/spy@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.0.3.tgz#ea4e5f7f8b3513e3ac0e556557e4ed339edc82e8"
+  integrity sha512-7/dgux8ZBbF7lEIKNnEqQlyRaER9nkAL9eTmdKJkDO3hS8p59ATGwKOCUDHcBLKr7h/oi/6hP+7djQk8049T2A==
   dependencies:
     tinyspy "^3.0.2"
 
@@ -3430,6 +3480,15 @@
     "@vitest/pretty-format" "2.1.6"
     loupe "^3.1.2"
     tinyrainbow "^1.2.0"
+
+"@vitest/utils@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.0.3.tgz#25d5a2e0cd0b5529132b76482fd48139ca56c197"
+  integrity sha512-f+s8CvyzPtMFY1eZKkIHGhPsQgYo5qCm6O8KZoim9qm1/jT64qBgGpO5tHscNH6BzRHM+edLNOP+3vO8+8pE/A==
+  dependencies:
+    "@vitest/pretty-format" "3.0.3"
+    loupe "^3.1.2"
+    tinyrainbow "^2.0.0"
 
 "@vscode/l10n@^0.0.10":
   version "0.0.10"
@@ -5164,6 +5223,13 @@ debug@^4.3.7:
   dependencies:
     ms "^2.1.3"
 
+debug@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
+  integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
+  dependencies:
+    ms "^2.1.3"
+
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -5915,6 +5981,11 @@ es-module-lexer@^1.5.4:
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.5.4.tgz#a8efec3a3da991e60efa6b633a7cad6ab8d26b78"
   integrity sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==
+
+es-module-lexer@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.6.0.tgz#da49f587fd9e68ee2404fe4e256c0c7d3a81be21"
+  integrity sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==
 
 es-object-atoms@^1.0.0:
   version "1.0.0"
@@ -9418,6 +9489,13 @@ magic-string@^0.30.12:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.0"
 
+magic-string@^0.30.17:
+  version "0.30.17"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
+  integrity sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+
 make-dir@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
@@ -11130,6 +11208,11 @@ pathe@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
   integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
+
+pathe@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.2.tgz#5ed86644376915b3c7ee4d00ac8c348d671da3a5"
+  integrity sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==
 
 pathval@^2.0.0:
   version "2.0.0"
@@ -13030,7 +13113,12 @@ tinyexec@^0.3.1:
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.1.tgz#0ab0daf93b43e2c211212396bdb836b468c97c98"
   integrity sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==
 
-tinypool@^1.0.1:
+tinyexec@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
+
+tinypool@^1.0.1, tinypool@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.0.2.tgz#706193cc532f4c100f66aa00b01c42173d9051b2"
   integrity sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==
@@ -13039,6 +13127,11 @@ tinyrainbow@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-1.2.0.tgz#5c57d2fc0fb3d1afd78465c33ca885d04f02abb5"
   integrity sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==
+
+tinyrainbow@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz#9509b2162436315e80e3eee0fcce4474d2444294"
+  integrity sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==
 
 tinyspy@^3.0.2:
   version "3.0.2"
@@ -13625,6 +13718,17 @@ vite-node@2.1.6:
     pathe "^1.1.2"
     vite "^5.0.0 || ^6.0.0"
 
+vite-node@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.0.3.tgz#2127458eae8c78b92f609f4c84d613599cd14317"
+  integrity sha512-0sQcwhwAEw/UJGojbhOrnq3HtiZ3tC7BzpAa0lx3QaTX0S3YX70iGcik25UBdB96pmdwjyY2uyKNYruxCDmiEg==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.4.0"
+    es-module-lexer "^1.6.0"
+    pathe "^2.0.1"
+    vite "^5.0.0 || ^6.0.0"
+
 "vite@^5.0.0 || ^6.0.0":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/vite/-/vite-6.0.1.tgz#24c9caf24998f0598de37bed67e50ec5b9dfeaf0"
@@ -13671,6 +13775,32 @@ vitest@^2.1.6:
     tinyrainbow "^1.2.0"
     vite "^5.0.0 || ^6.0.0"
     vite-node "2.1.6"
+    why-is-node-running "^2.3.0"
+
+vitest@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.0.3.tgz#e7bcf3ba82e4a18f1f2c5083b3d989cd344cb78c"
+  integrity sha512-dWdwTFUW9rcnL0LyF2F+IfvNQWB0w9DERySCk8VMG75F8k25C7LsZoh6XfCjPvcR8Nb+Lqi9JKr6vnzH7HSrpQ==
+  dependencies:
+    "@vitest/expect" "3.0.3"
+    "@vitest/mocker" "3.0.3"
+    "@vitest/pretty-format" "^3.0.3"
+    "@vitest/runner" "3.0.3"
+    "@vitest/snapshot" "3.0.3"
+    "@vitest/spy" "3.0.3"
+    "@vitest/utils" "3.0.3"
+    chai "^5.1.2"
+    debug "^4.4.0"
+    expect-type "^1.1.0"
+    magic-string "^0.30.17"
+    pathe "^2.0.1"
+    std-env "^3.8.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.2"
+    tinypool "^1.0.2"
+    tinyrainbow "^2.0.0"
+    vite "^5.0.0 || ^6.0.0"
+    vite-node "3.0.3"
     why-is-node-running "^2.3.0"
 
 vscode-jsonrpc@8.1.0:


### PR DESCRIPTION
Vitest released a new major version soon after we merged in our migration PRs. Thankfully, this seems to be a pretty painless migration.

I left a few dangling promises in #3813 that have been fixed in `packages/utils/core-utils/spec/yarn-or-npm.spec.ts`.