### PR TITLE
chore: remove cross-spawn from deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@octokit/types": "^6.1.2",
     "chalk": "^4.0.0",
     "commander": "^4.1.1",
-    "cross-spawn": "^7.0.3",
     "cross-zip": "^4.0.0",
     "debug": "^4.3.1",
     "detect-package-manager": "^3.0.2",
@@ -66,6 +65,7 @@
     "mime-types": "^2.1.25",
     "node-fetch": "^2.6.7",
     "parse-author": "^2.0.0",
+    "path-key": "^3.1.1",
     "rechoir": "^0.8.0",
     "resolve-package": "^1.0.1",
     "semver": "^7.2.1",
@@ -84,7 +84,6 @@
   "devDependencies": {
     "@electron/fuses": ">=1.0.0",
     "@electron/lint-roller": "1.10.1",
-    "@types/cross-spawn": "^6.0.1",
     "@types/debug": "^4.1.5",
     "@types/express": "^4.17.9",
     "@types/express-ws": "^3.0.0",

--- a/packages/maker/appx/package.json
+++ b/packages/maker/appx/package.json
@@ -16,9 +16,10 @@
   "dependencies": {
     "@electron-forge/maker-base": "7.6.0",
     "@electron-forge/shared-types": "7.6.0",
-    "cross-spawn": "^7.0.3",
     "fs-extra": "^10.0.0",
-    "parse-author": "^2.0.0"
+    "parse-author": "^2.0.0",
+    "path-key": "^3.1.1",
+    "which": "^2.0.2"
   },
   "optionalDependencies": {
     "electron-windows-store": "^2.1.0"

--- a/packages/maker/appx/src/MakerAppX.ts
+++ b/packages/maker/appx/src/MakerAppX.ts
@@ -2,13 +2,13 @@ import path from 'node:path';
 
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
-import resolveCommand from 'cross-spawn/lib/util/resolveCommand';
 import windowsStore from 'electron-windows-store';
 import { isValidPublisherName, makeCert } from 'electron-windows-store/lib/sign';
 import fs from 'fs-extra';
 
 import { MakerAppXConfig } from './Config';
 import getNameFromAuthor from './util/author-name';
+import { resolveCommand } from './util/resolve-command';
 
 // NB: This is not a typo, we require AppXs to be built on 64-bit
 // but if we're running in a 32-bit node.js process, we're going to
@@ -38,7 +38,7 @@ async function findSdkTool(exe: string) {
     }
   }
   if (!sdkTool || !(await fs.pathExists(sdkTool))) {
-    sdkTool = resolveCommand({ command: exe, options: { cwd: null } }, true);
+    sdkTool = resolveCommand({ command: exe, options: { cwd: null } });
   }
 
   if (!sdkTool || !(await fs.pathExists(sdkTool))) {

--- a/packages/maker/appx/src/util/resolve-command.ts
+++ b/packages/maker/appx/src/util/resolve-command.ts
@@ -1,0 +1,55 @@
+/**
+ * This code is vendored from cross-spawn@7.0.6
+ * https://github.com/moxystudio/node-cross-spawn/blob/master/lib/util/resolveCommand.js
+ */
+
+import path from 'node:path';
+
+import getPathKey from 'path-key';
+import which from 'which';
+
+function resolveCommandAttempt(parsed: { command: string; options: { env?: any; cwd?: any } }, withoutPathExt?: boolean) {
+  const env = parsed.options.env || process.env;
+  const cwd = process.cwd();
+  const hasCustomCwd = parsed.options.cwd != null;
+  // Worker threads do not have process.chdir()
+  //@ts-expect-error we want to keep this code as close as the original as possible
+  const shouldSwitchCwd = hasCustomCwd && process.chdir !== undefined && !process.chdir.disabled;
+
+  // If a custom `cwd` was specified, we need to change the process cwd
+  // because `which` will do stat calls but does not support a custom cwd
+  if (shouldSwitchCwd) {
+    try {
+      process.chdir(parsed.options.cwd);
+    } catch {
+      /* Empty */
+    }
+  }
+
+  let resolved;
+
+  try {
+    resolved = which.sync(parsed.command, {
+      path: env[getPathKey({ env })],
+      pathExt: withoutPathExt ? path.delimiter : undefined,
+    });
+  } catch {
+    /* Empty */
+  } finally {
+    if (shouldSwitchCwd) {
+      process.chdir(cwd);
+    }
+  }
+
+  // If we successfully resolved, ensure that an absolute path is returned
+  // Note that when a custom `cwd` was used, we need to resolve to an absolute path based on it
+  if (resolved) {
+    resolved = path.resolve(hasCustomCwd ? parsed.options.cwd : '', resolved);
+  }
+
+  return resolved;
+}
+
+export function resolveCommand(parsed: { command: string; options: { env?: any; cwd?: any } }) {
+  return resolveCommandAttempt(parsed) || resolveCommandAttempt(parsed, true);
+}

--- a/typings/cross-spawn/index.d.ts
+++ b/typings/cross-spawn/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'cross-spawn/lib/util/resolveCommand';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2927,13 +2927,6 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
   integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
 
-"@types/cross-spawn@^6.0.1":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@types/cross-spawn/-/cross-spawn-6.0.2.tgz#168309de311cd30a2b8ae720de6475c2fbf33ac7"
-  integrity sha512-KuwNhp3eza+Rhu8IFI5HUXRP0LIhqH5cAjubUvGXXthh4YYBuP2ntwEX+Cz8GJoZUHlKo247wPWOfA9LYEq4cw==
-  dependencies:
-    "@types/node" "*"
-
 "@types/debug@^4.0.0":
   version "4.1.8"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.8.tgz#cef723a5d0a90990313faec2d1e22aee5eecb317"
@@ -3372,16 +3365,6 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.1.tgz#28fa185f67daaf7b7a1a8c1d445132c5d979f8bd"
   integrity sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==
 
-"@vitest/expect@2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-2.1.6.tgz#5a334eb9ee9287292fbe961955cafb06f7af7da6"
-  integrity sha512-9M1UR9CAmrhJOMoSwVnPh2rELPKhYo0m/CSgqw9PyStpxtkwhmdM6XYlXGKeYyERY1N6EIuzkQ7e3Lm1WKCoUg==
-  dependencies:
-    "@vitest/spy" "2.1.6"
-    "@vitest/utils" "2.1.6"
-    chai "^5.1.2"
-    tinyrainbow "^1.2.0"
-
 "@vitest/expect@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.0.3.tgz#a83af04a68e70a9af8aa6f68442a696b4bc599c5"
@@ -3392,15 +3375,6 @@
     chai "^5.1.2"
     tinyrainbow "^2.0.0"
 
-"@vitest/mocker@2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-2.1.6.tgz#d13c5a7bd0abf432e1030f68acb43f51c4b3692e"
-  integrity sha512-MHZp2Z+Q/A3am5oD4WSH04f9B0T7UvwEb+v5W0kCYMhtXGYbdyl2NUk1wdSMqGthmhpiThPDp/hEoVwu16+u1A==
-  dependencies:
-    "@vitest/spy" "2.1.6"
-    estree-walker "^3.0.3"
-    magic-string "^0.30.12"
-
 "@vitest/mocker@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.0.3.tgz#f63a7e2e93fecaab1046038f3a9f60ea6b369173"
@@ -3410,27 +3384,12 @@
     estree-walker "^3.0.3"
     magic-string "^0.30.17"
 
-"@vitest/pretty-format@2.1.6", "@vitest/pretty-format@^2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-2.1.6.tgz#9bc642047a3efc637b41492b1f222c43be3822e4"
-  integrity sha512-exZyLcEnHgDMKc54TtHca4McV4sKT+NKAe9ix/yhd/qkYb/TP8HTyXRFDijV19qKqTZM0hPL4753zU/U8L/gAA==
-  dependencies:
-    tinyrainbow "^1.2.0"
-
 "@vitest/pretty-format@3.0.3", "@vitest/pretty-format@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.0.3.tgz#4bd59463d1c944c22287c3da2060785269098183"
   integrity sha512-gCrM9F7STYdsDoNjGgYXKPq4SkSxwwIU5nkaQvdUxiQ0EcNlez+PdKOVIsUJvh9P9IeIFmjn4IIREWblOBpP2Q==
   dependencies:
     tinyrainbow "^2.0.0"
-
-"@vitest/runner@2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-2.1.6.tgz#948cad2cccfe2e56be5b3f9979cf9a417ca59737"
-  integrity sha512-SjkRGSFyrA82m5nz7To4CkRSEVWn/rwQISHoia/DB8c6IHIhaE/UNAo+7UfeaeJRE979XceGl00LNkIz09RFsA==
-  dependencies:
-    "@vitest/utils" "2.1.6"
-    pathe "^1.1.2"
 
 "@vitest/runner@3.0.3":
   version "3.0.3"
@@ -3439,15 +3398,6 @@
   dependencies:
     "@vitest/utils" "3.0.3"
     pathe "^2.0.1"
-
-"@vitest/snapshot@2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-2.1.6.tgz#21740449221e37f80c4a8fb3e15f100f30e7934d"
-  integrity sha512-5JTWHw8iS9l3v4/VSuthCndw1lN/hpPB+mlgn1BUhFbobeIUj1J1V/Bj2t2ovGEmkXLTckFjQddsxS5T6LuVWw==
-  dependencies:
-    "@vitest/pretty-format" "2.1.6"
-    magic-string "^0.30.12"
-    pathe "^1.1.2"
 
 "@vitest/snapshot@3.0.3":
   version "3.0.3"
@@ -3458,28 +3408,12 @@
     magic-string "^0.30.17"
     pathe "^2.0.1"
 
-"@vitest/spy@2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-2.1.6.tgz#229f9d48b90b8bdd6573723bdec0699915598080"
-  integrity sha512-oTFObV8bd4SDdRka5O+mSh5w9irgx5IetrD5i+OsUUsk/shsBoHifwCzy45SAORzAhtNiprUVaK3hSCCzZh1jQ==
-  dependencies:
-    tinyspy "^3.0.2"
-
 "@vitest/spy@3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.0.3.tgz#ea4e5f7f8b3513e3ac0e556557e4ed339edc82e8"
   integrity sha512-7/dgux8ZBbF7lEIKNnEqQlyRaER9nkAL9eTmdKJkDO3hS8p59ATGwKOCUDHcBLKr7h/oi/6hP+7djQk8049T2A==
   dependencies:
     tinyspy "^3.0.2"
-
-"@vitest/utils@2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-2.1.6.tgz#2af6a82c5c45da35ecd322d0568247a6e9c95c5f"
-  integrity sha512-ixNkFy3k4vokOUTU2blIUvOgKq/N2PW8vKIjZZYsGJCMX69MRa9J2sKqX5hY/k5O5Gty3YJChepkqZ3KM9LyIQ==
-  dependencies:
-    "@vitest/pretty-format" "2.1.6"
-    loupe "^3.1.2"
-    tinyrainbow "^1.2.0"
 
 "@vitest/utils@3.0.3":
   version "3.0.3"
@@ -5216,13 +5150,6 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.3.7:
-  version "4.3.7"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"
-  integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
-  dependencies:
-    ms "^2.1.3"
-
 debug@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
@@ -5976,11 +5903,6 @@ es-module-lexer@^1.2.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.4.1.tgz#41ea21b43908fe6a287ffcbe4300f790555331f5"
   integrity sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==
-
-es-module-lexer@^1.5.4:
-  version "1.5.4"
-  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.5.4.tgz#a8efec3a3da991e60efa6b633a7cad6ab8d26b78"
-  integrity sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==
 
 es-module-lexer@^1.6.0:
   version "1.6.0"
@@ -9482,13 +9404,6 @@ macos-alias@~0.2.5:
   dependencies:
     nan "^2.4.0"
 
-magic-string@^0.30.12:
-  version "0.30.14"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.14.tgz#e9bb29870b81cfc1ec3cc656552f5a7fcbf19077"
-  integrity sha512-5c99P1WKTed11ZC0HMJOj6CDIue6F8ySu+bJL+85q1zBEIY8IklrJ1eiKC2NDRh3Ct3FcvmJPyQHb9erXMTJNw==
-  dependencies:
-    "@jridgewell/sourcemap-codec" "^1.5.0"
-
 magic-string@^0.30.17:
   version "0.30.17"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
@@ -11149,7 +11064,7 @@ path-key@^2.0.0, path-key@^2.0.1:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
-path-key@^3.0.0, path-key@^3.1.0:
+path-key@^3.0.0, path-key@^3.1.0, path-key@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
@@ -11203,11 +11118,6 @@ path-type@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
-
-pathe@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
-  integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
 
 pathe@^2.0.1:
   version "2.0.2"
@@ -13108,25 +13018,15 @@ tinybench@^2.9.0:
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
   integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
 
-tinyexec@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.1.tgz#0ab0daf93b43e2c211212396bdb836b468c97c98"
-  integrity sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==
-
 tinyexec@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
   integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
 
-tinypool@^1.0.1, tinypool@^1.0.2:
+tinypool@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.0.2.tgz#706193cc532f4c100f66aa00b01c42173d9051b2"
   integrity sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==
-
-tinyrainbow@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-1.2.0.tgz#5c57d2fc0fb3d1afd78465c33ca885d04f02abb5"
-  integrity sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==
 
 tinyrainbow@^2.0.0:
   version "2.0.0"
@@ -13707,17 +13607,6 @@ version-guard@^1.1.1:
   resolved "https://registry.yarnpkg.com/version-guard/-/version-guard-1.1.1.tgz#7a6e87a1babff1b43d6a7b0fd239731e278262fa"
   integrity sha512-MGQLX89UxmYHgDvcXyjBI0cbmoW+t/dANDppNPrno64rYr8nH4SHSuElQuSYdXGEs0mUzdQe1BY+FhVPNsAmJQ==
 
-vite-node@2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-2.1.6.tgz#d7b79c5cde56c749f619dead049944918726b91e"
-  integrity sha512-DBfJY0n9JUwnyLxPSSUmEePT21j8JZp/sR9n+/gBwQU6DcQOioPdb8/pibWfXForbirSagZCilseYIwaL3f95A==
-  dependencies:
-    cac "^6.7.14"
-    debug "^4.3.7"
-    es-module-lexer "^1.5.4"
-    pathe "^1.1.2"
-    vite "^5.0.0 || ^6.0.0"
-
 vite-node@3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.0.3.tgz#2127458eae8c78b92f609f4c84d613599cd14317"
@@ -13750,32 +13639,6 @@ vite@^5.0.12:
     rollup "^4.20.0"
   optionalDependencies:
     fsevents "~2.3.3"
-
-vitest@^2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/vitest/-/vitest-2.1.6.tgz#44d661c6b3f3a3a0c597143f78d27215ee4666cc"
-  integrity sha512-isUCkvPL30J4c5O5hgONeFRsDmlw6kzFEdLQHLezmDdKQHy8Ke/B/dgdTMEgU0vm+iZ0TjW8GuK83DiahBoKWQ==
-  dependencies:
-    "@vitest/expect" "2.1.6"
-    "@vitest/mocker" "2.1.6"
-    "@vitest/pretty-format" "^2.1.6"
-    "@vitest/runner" "2.1.6"
-    "@vitest/snapshot" "2.1.6"
-    "@vitest/spy" "2.1.6"
-    "@vitest/utils" "2.1.6"
-    chai "^5.1.2"
-    debug "^4.3.7"
-    expect-type "^1.1.0"
-    magic-string "^0.30.12"
-    pathe "^1.1.2"
-    std-env "^3.8.0"
-    tinybench "^2.9.0"
-    tinyexec "^0.3.1"
-    tinypool "^1.0.1"
-    tinyrainbow "^1.2.0"
-    vite "^5.0.0 || ^6.0.0"
-    vite-node "2.1.6"
-    why-is-node-running "^2.3.0"
 
 vitest@^3.0.3:
   version "3.0.3"


### PR DESCRIPTION
I was a bit sloppy addressing https://github.com/electron/forge/pull/3802#discussion_r1920930835. This cleans up all references to `cross-spawn`.

Edit: It turns out that we still use `cross-spawn` in MakerAppX, but only an undocumented util function that isn't part of its public API.

Instead, I've copied that function over so that we don't depend on a function that could in theory be refactored out in the future.

