### PR TITLE
fix(template-base): install correct version of plugin-fuses

### DIFF
--- a/packages/api/core/spec/fixture/custom_init/index.js
+++ b/packages/api/core/spec/fixture/custom_init/index.js
@@ -5,8 +5,8 @@ const fs = require('fs-extra');
 
 module.exports = {
   requiredForgeVersion: '>= 6.0.0-beta.1',
-  dependencies: ['debug'],
-  devDependencies: ['lodash'],
+  dependencies: [...baseTemplate.dependencies, 'debug'],
+  devDependencies: [...baseTemplate.devDependencies, 'lodash'],
   initializeTemplate: async (directory) => {
     const tasks = await baseTemplate.initializeTemplate(directory, {});
     return [

--- a/packages/api/core/src/util/install-dependencies.ts
+++ b/packages/api/core/src/util/install-dependencies.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
 import { hasYarn, yarnOrNpmSpawn } from '@electron-forge/core-utils';
 import { ExitError } from '@malept/cross-spawn-promise';
 import debug from 'debug';
@@ -30,6 +33,7 @@ export default async (dir: string, deps: string[], depType = DepType.PROD, versi
     if (versionRestriction === DepVersionRestriction.EXACT) cmd.push('--save-exact');
   }
   d('executing', JSON.stringify(cmd), 'in:', dir);
+  d(readFileSync(path.resolve(dir, 'package.json'), 'utf-8'));
   try {
     await yarnOrNpmSpawn(cmd, {
       cwd: dir,

--- a/packages/api/core/src/util/install-dependencies.ts
+++ b/packages/api/core/src/util/install-dependencies.ts
@@ -1,6 +1,3 @@
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
-
 import { hasYarn, yarnOrNpmSpawn } from '@electron-forge/core-utils';
 import { ExitError } from '@malept/cross-spawn-promise';
 import debug from 'debug';
@@ -33,7 +30,6 @@ export default async (dir: string, deps: string[], depType = DepType.PROD, versi
     if (versionRestriction === DepVersionRestriction.EXACT) cmd.push('--save-exact');
   }
   d('executing', JSON.stringify(cmd), 'in:', dir);
-  d(readFileSync(path.resolve(dir, 'package.json'), 'utf-8'));
   try {
     await yarnOrNpmSpawn(cmd, {
       cwd: dir,

--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -17,6 +17,23 @@ export class BaseTemplate implements ForgeTemplate {
 
   public requiredForgeVersion = currentForgeVersion;
 
+  get dependencies(): string[] {
+    const packageJSONPath = path.join(this.templateDir, 'package.json');
+    if (fs.pathExistsSync(packageJSONPath)) {
+      const deps = fs.readJsonSync(packageJSONPath).dependencies;
+      if (deps) {
+        return Object.entries(deps).map(([packageName, version]) => {
+          if (version === 'ELECTRON_FORGE/VERSION') {
+            version = `^${currentForgeVersion}`;
+          }
+          return `${packageName}@${version}`;
+        });
+      }
+    }
+
+    return [];
+  }
+
   get devDependencies(): string[] {
     const packageJSONPath = path.join(this.templateDir, 'package.json');
     if (fs.pathExistsSync(packageJSONPath)) {

--- a/packages/template/base/tmpl/package.json
+++ b/packages/template/base/tmpl/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@electron/fuses": "^1.7.0",
-    "@electron-forge/plugin-fuses": "^7.2.0"
+    "@electron-forge/plugin-fuses": "ELECTRON_FORGE/VERSION"
   },
   "keywords": [],
   "author": "",

--- a/packages/template/base/tmpl/package.json
+++ b/packages/template/base/tmpl/package.json
@@ -10,10 +10,6 @@
     "make": "electron-forge make",
     "publish": "electron-forge publish"
   },
-  "devDependencies": {
-    "@electron/fuses": "^1.7.0",
-    "@electron-forge/plugin-fuses": "ELECTRON_FORGE/VERSION"
-  },
   "keywords": [],
   "author": "",
   "license": "MIT"

--- a/packages/template/vite-typescript/tmpl/package.json
+++ b/packages/template/vite-typescript/tmpl/package.json
@@ -1,7 +1,5 @@
 {
   "devDependencies": {
-    "@electron/fuses": "^1.7.0",
-    "@electron-forge/plugin-fuses": "ELECTRON_FORGE/VERSION",
     "@electron-forge/plugin-vite": "ELECTRON_FORGE/VERSION",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",

--- a/packages/template/vite/tmpl/package.json
+++ b/packages/template/vite/tmpl/package.json
@@ -1,7 +1,6 @@
 {
   "devDependencies": {
     "@electron/fuses": "^1.7.0",
-    "@electron-forge/plugin-fuses": "ELECTRON_FORGE/VERSION",
     "@electron-forge/plugin-vite": "ELECTRON_FORGE/VERSION",
     "vite": "^5.0.12"
   }

--- a/packages/template/webpack-typescript/tmpl/package.json
+++ b/packages/template/webpack-typescript/tmpl/package.json
@@ -1,7 +1,5 @@
 {
   "devDependencies": {
-    "@electron/fuses": "^1.7.0",
-    "@electron-forge/plugin-fuses": "ELECTRON_FORGE/VERSION",
     "@electron-forge/plugin-webpack": "ELECTRON_FORGE/VERSION",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",


### PR DESCRIPTION
## Context

In https://github.com/electron/forge/pull/3480, we added the `@electron/fuses` plugin to our templates.

This was done by adding the dependencies directly into the `tmpl/package.json` file for each template like so:

https://github.com/electron/forge/blob/71eb328cae06d445e18dde9e9d54c7f4c282c67b/packages/template/base/tmpl/package.json#L13-L16

This approach eventually caused two problems:
1. The `import` command didn't install the correct Fuses dependency (ref https://github.com/electron/forge/issues/3509)
2. The `init` script was hard-coding the version to `^7.2.0` instead of matching the current Electron Forge version.

The first bug was fixed by https://github.com/electron/forge/pull/3535, which added both `@electron/fuses` and `@electron-forge/plugin-fuses` to the base dependencies we install via the `initNPM` utility function:

https://github.com/electron/forge/blob/34c33fa9744f3fc14e47414bf06d8c23ddd1cae6/packages/api/core/src/api/init-scripts/init-npm.ts#L18-L27

## Solution

#3535 actually made adding the deps via `tmpl/package.json` redundant because they're treated as "common" dependencies (i.e. non-template-specific) and installed anyways. The solution to fixing the second problem is just to remove the deps from `tmpl/package.json` altogether.

## `BaseTemplate` changes

While crafting this PR, I found that we actually support adding dependencies via templates in another way: adding them to the `TemplateClass.dependencies` or `TemplateClass.devDependencies` arrays.

The `BaseTemplate` has a getter for `devDependencies` that does the magic replacement for the `ELECTRON_FORGE/VERSION` syntax, but no equivalent for `dependencies`. This PR changes that. 

It also extends a specific custom initializer fixture to grab `dependencies` and `devDependencies` from the base `package.json` via these getters so that custom deps are added to what we expect from the base template.