### PR TITLE
fix(template): use esm imports for vite template only

### DIFF
--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -70,8 +70,7 @@ export class BaseTemplate implements ForgeTemplate {
   }
 
   async copyTemplateFile(destDir: string, basename: string): Promise<void> {
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await this.copy(path.join(this.templateDir!, basename), path.resolve(destDir, basename));
+    await this.copy(path.join(this.templateDir, basename), path.resolve(destDir, basename));
   }
 
   async initializePackageJSON(directory: string): Promise<void> {

--- a/packages/template/vite/src/ViteTemplate.ts
+++ b/packages/template/vite/src/ViteTemplate.ts
@@ -25,6 +25,7 @@ class ViteTemplate extends BaseTemplate {
           await this.copyTemplateFile(directory, 'vite.renderer.config.mjs');
           await this.copyTemplateFile(path.join(directory, 'src'), 'renderer.js');
           await this.copyTemplateFile(path.join(directory, 'src'), 'preload.js');
+          await this.copyTemplateFile(path.join(directory, 'src'), 'index.js');
 
           await this.updateFileByLine(
             path.resolve(directory, 'src', 'index.js'),

--- a/packages/template/vite/tmpl/index.js
+++ b/packages/template/vite/tmpl/index.js
@@ -1,8 +1,9 @@
-const { app, BrowserWindow } = require('electron');
-const path = require('node:path');
+import { app, BrowserWindow } from 'electron';
+import path from 'node:path';
+import started from 'electron-squirrel-startup';
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
-if (require('electron-squirrel-startup')) {
+if (started) {
   app.quit();
 }
 


### PR DESCRIPTION
Fixes https://github.com/electron/forge/issues/3806

I believe there was an issue that was requiring us to use esm-style imports with the Vite template on Windows, but the initial PR also changed up the base template, which _didn't_ accept this syntax.