### PR TITLE
fix(template-vite): make `--force` flag work

### DIFF
--- a/packages/api/core/src/api/init.ts
+++ b/packages/api/core/src/api/init.ts
@@ -86,7 +86,7 @@ export default async ({ dir = process.cwd(), interactive = false, copyCIFiles = 
         title: 'Initializing template',
         task: async ({ templateModule }, task) => {
           if (typeof templateModule.initializeTemplate === 'function') {
-            const tasks = await templateModule.initializeTemplate(dir, { copyCIFiles });
+            const tasks = await templateModule.initializeTemplate(dir, { copyCIFiles, force });
             if (tasks) {
               return task.newListr(tasks, { concurrent: false });
             }

--- a/packages/template/vite/src/ViteTemplate.ts
+++ b/packages/template/vite/src/ViteTemplate.ts
@@ -42,7 +42,7 @@ class ViteTemplate extends BaseTemplate {
 
           // TODO: Compatible with any path entry.
           // Vite uses index.html under the root path as the entry point.
-          fs.moveSync(path.join(directory, 'src', 'index.html'), path.join(directory, 'index.html'));
+          fs.moveSync(path.join(directory, 'src', 'index.html'), path.join(directory, 'index.html'), { overwrite: options.force });
           await this.updateFileByLine(path.join(directory, 'index.html'), (line) => {
             if (line.includes('link rel="stylesheet"')) return '';
             if (line.includes('</body>')) return '    <script type="module" src="/src/renderer.js"></script>\n  </body>';

--- a/packages/utils/types/src/index.ts
+++ b/packages/utils/types/src/index.ts
@@ -214,6 +214,7 @@ export type StartResult = InnerStartResult | { tasks: ForgeListrTaskDefinition[]
 
 export interface InitTemplateOptions {
   copyCIFiles?: boolean;
+  force?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
Fixes #3783

We were calling `fs.moveSync(src, dest)` from the template code, but this function fails if `dest` already exists without passing the `overwrite` flag.

To fix this, we align the `overwrite` flag with the value of `--force` being passed into the `init` command.
