### PR TITLE
chore: add `actions/stale` for issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,14 +4,14 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   stale:
     runs-on: ubuntu-latest
-
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Close issues that have been blocked for two weeks
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          only-labels: 'blocked/needs-info,blocked/needs-repro'
+          labels-to-remove-when-unstale: 'blocked/needs-info,blocked/needs-repro'
+          days-before-pr-stale: 9001 # good luck to whoever leaves their PR up for 25 years


### PR DESCRIPTION
Our issue tracker is slowly getting larger. This PR implements [actions/stale](https://github.com/actions/stale) to close out issues that have [`blocked/needs-repro`](https://github.com/electron/forge/issues?q=is%3Aissue%20state%3Aopen%20label%3Ablocked%2Fneeds-repro) or [`blocked/needs-info`](https://github.com/electron/forge/issues?q=is%3Aissue%20state%3Aopen%20label%3Ablocked%2Fneeds-info) labels if they haven't gotten a response within 14 days.

If an answer is given within 14 days, then the `blocked/` label is removed and the maintainer will need to re-triage.