### PR TITLE
fix(package): make `packagerConfig.quiet` configurable

### DIFF
--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -300,8 +300,8 @@ export const listrPackage = (
               asar: false,
               overwrite: true,
               ignore: [/^\/out\//g],
+              quiet: false,
               ...forgeConfig.packagerConfig,
-              quiet: true,
               dir: ctx.dir,
               arch: arch as PackagerArch,
               platform,
@@ -313,7 +313,6 @@ export const listrPackage = (
               out: calculatedOutDir,
               electronVersion: await getElectronVersion(ctx.dir, packageJSON),
             };
-            packageOpts.quiet = true;
 
             if (packageOpts.all) {
               throw new Error('config.forge.packagerConfig.all is not supported by Electron Forge');


### PR DESCRIPTION
Fixes https://github.com/electron/forge/issues/3540

Note that these logs _will_ show up at the bottom after execution because we use Listr2 for the Forge CLI. The workaround is to use set `DEBUG` to anything or to set `CI=true` to use the Listr2 fallback renderer.

ref: https://github.com/electron/forge/issues/3796#issuecomment-2574552674