### PR TITLE
chore: run ESLint with cache on lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "*.{html,json,md,yml}": "prettier --write",
     "*.{js,ts}": [
       "prettier --write",
-      "eslint --fix"
+      "eslint --fix --cache"
     ],
     "*.{json,lock}": "syncpack"
   },


### PR DESCRIPTION
follow-up to https://github.com/electron/forge/pull/3811

Should make our pre-commit hooks faster.