### PR TITLE
fix(maker-flatpak): fix flatpakArch for arm64

### DIFF
--- a/packages/maker/flatpak/src/MakerFlatpak.ts
+++ b/packages/maker/flatpak/src/MakerFlatpak.ts
@@ -14,6 +14,8 @@ export function flatpakArch(nodeArch: ForgeArch): string {
       return 'x86_64';
     case 'armv7l':
       return 'arm';
+    case 'arm64':
+      return 'aarch64';
     // arm => arm
     default:
       return nodeArch;


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Hi,

this PR is a fix for the issue described in #3838
It fixes it by adding translating the "arm64" architecture string from electron-forge, into "aarch64", which is what Flatpak is actually expecting.
The same thing was done for "x64" and "x86_64" as well.


closes #3838