### PR TITLE
fix(cli): deduplicate default information

### DIFF
--- a/packages/api/cli/src/electron-forge-init.ts
+++ b/packages/api/cli/src/electron-forge-init.ts
@@ -13,8 +13,8 @@ import workingDir from './util/working-dir';
     .version((await fs.readJson(path.resolve(__dirname, '../package.json'))).version, '-V, --version', 'Output the current version')
     .arguments('[name]')
     .option('-t, --template [name]', 'Name of the Forge template to use')
-    .option('-c, --copy-ci-files', 'Whether to copy the templated CI files (defaults to false)', false)
-    .option('-f, --force', 'Whether to overwrite an existing directory (defaults to false)', false)
+    .option('-c, --copy-ci-files', 'Whether to copy the templated CI files', false)
+    .option('-f, --force', 'Whether to overwrite an existing directory', false)
     .helpOption('-h, --help', 'Output usage information')
     .action((name) => {
       dir = workingDir(dir, name, false);


### PR DESCRIPTION
```
Usage: electron-forge-init [options] [name]

Options:
  -V, --version          Output the current version
  -t, --template [name]  Name of the Forge template to use
  -c, --copy-ci-files    Whether to copy the templated CI files (defaults to false) (default: false)
  -f, --force            Whether to overwrite an existing directory (defaults to false) (default: false)
  -h, --help             Output usage information
```

It looks like `commander` already shows the default information, so we shouldn't print it twice.