### PR TITLE
fix: upgrade `commander` 4 -> 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@octokit/rest": "^18.0.11",
     "@octokit/types": "^6.1.2",
     "chalk": "^4.0.0",
-    "commander": "^4.1.1",
+    "commander": "^11.1.0",
     "cross-spawn": "^7.0.3",
     "cross-zip": "^4.0.0",
     "debug": "^4.3.1",

--- a/packages/api/cli/package.json
+++ b/packages/api/cli/package.json
@@ -19,7 +19,7 @@
     "@electron-forge/shared-types": "7.6.1",
     "@electron/get": "^3.0.0",
     "chalk": "^4.0.0",
-    "commander": "^4.1.1",
+    "commander": "^11.1.0",
     "debug": "^4.3.1",
     "fs-extra": "^10.0.0",
     "listr2": "^7.0.2",

--- a/packages/api/cli/src/electron-forge-import.ts
+++ b/packages/api/cli/src/electron-forge-import.ts
@@ -1,16 +1,15 @@
-import path from 'node:path';
-
 import { api } from '@electron-forge/core';
-import program from 'commander';
-import fs from 'fs-extra';
+import { program } from 'commander';
 
 import './util/terminate';
+import packageJSON from '../package.json';
+
 import workingDir from './util/working-dir';
 
 (async () => {
   let dir = process.cwd();
   program
-    .version((await fs.readJson(path.resolve(__dirname, '../package.json'))).version, '-V, --version', 'Output the current version')
+    .version(packageJSON.version, '-V, --version', 'Output the current version')
     .helpOption('-h, --help', 'Output usage information')
     .arguments('[name]')
     .action((name) => {

--- a/packages/api/cli/src/electron-forge-init.ts
+++ b/packages/api/cli/src/electron-forge-init.ts
@@ -1,16 +1,15 @@
-import path from 'node:path';
-
 import { api, InitOptions } from '@electron-forge/core';
-import program from 'commander';
-import fs from 'fs-extra';
+import { program } from 'commander';
 
 import './util/terminate';
+import packageJSON from '../package.json';
+
 import workingDir from './util/working-dir';
 
 (async () => {
   let dir = process.cwd();
   program
-    .version((await fs.readJson(path.resolve(__dirname, '../package.json'))).version, '-V, --version', 'Output the current version')
+    .version(packageJSON.version, '-V, --version', 'Output the current version')
     .arguments('[name]')
     .option('-t, --template [name]', 'Name of the Forge template to use')
     .option('-c, --copy-ci-files', 'Whether to copy the templated CI files', false)
@@ -21,13 +20,15 @@ import workingDir from './util/working-dir';
     })
     .parse(process.argv);
 
+  const options = program.opts();
+
   const initOpts: InitOptions = {
     dir,
     interactive: true,
-    copyCIFiles: !!program.copyCiFiles,
-    force: !!program.force,
+    copyCIFiles: !!options.copyCiFiles,
+    force: !!options.force,
   };
-  if (program.template) initOpts.template = program.template;
+  if (options.template) initOpts.template = options.template;
 
   await api.init(initOpts);
 })();

--- a/packages/api/cli/src/electron-forge-make.ts
+++ b/packages/api/cli/src/electron-forge-make.ts
@@ -1,17 +1,16 @@
-import path from 'node:path';
-
 import { initializeProxy } from '@electron/get';
 import { api, MakeOptions } from '@electron-forge/core';
-import program from 'commander';
-import fs from 'fs-extra';
+import { program } from 'commander';
 
 import './util/terminate';
+import packageJSON from '../package.json';
+
 import workingDir from './util/working-dir';
 
 export async function getMakeOptions(): Promise<MakeOptions> {
   let dir = process.cwd();
   program
-    .version((await fs.readJson(path.resolve(__dirname, '../package.json'))).version, '-V, --version', 'Output the current version')
+    .version(packageJSON.version, '-V, --version', 'Output the current version')
     .arguments('[cwd]')
     .option('--skip-package', 'Assume the app is already packaged')
     .option('-a, --arch [arch]', 'Target architecture')
@@ -24,14 +23,16 @@ export async function getMakeOptions(): Promise<MakeOptions> {
     })
     .parse(process.argv);
 
+  const options = program.opts();
+
   const makeOpts: MakeOptions = {
     dir,
     interactive: true,
-    skipPackage: program.skipPackage,
+    skipPackage: options.skipPackage,
   };
-  if (program.targets) makeOpts.overrideTargets = program.targets.split(',');
-  if (program.arch) makeOpts.arch = program.arch;
-  if (program.platform) makeOpts.platform = program.platform;
+  if (options.targets) makeOpts.overrideTargets = options.targets.split(',');
+  if (options.arch) makeOpts.arch = options.arch;
+  if (options.platform) makeOpts.platform = options.platform;
 
   return makeOpts;
 }

--- a/packages/api/cli/src/electron-forge-package.ts
+++ b/packages/api/cli/src/electron-forge-package.ts
@@ -1,17 +1,16 @@
-import path from 'node:path';
-
 import { initializeProxy } from '@electron/get';
 import { api, PackageOptions } from '@electron-forge/core';
-import program from 'commander';
-import fs from 'fs-extra';
+import { program } from 'commander';
 
 import './util/terminate';
+import packageJSON from '../package.json';
+
 import workingDir from './util/working-dir';
 
 (async () => {
   let dir: string = process.cwd();
   program
-    .version((await fs.readJson(path.resolve(__dirname, '../package.json'))).version, '-V, --version', 'Output the current version')
+    .version(packageJSON.version, '-V, --version', 'Output the current version')
     .arguments('[cwd]')
     .option('-a, --arch [arch]', 'Target architecture')
     .option('-p, --platform [platform]', 'Target build platform')
@@ -21,14 +20,16 @@ import workingDir from './util/working-dir';
     })
     .parse(process.argv);
 
+  const options = program.opts();
+
   initializeProxy();
 
   const packageOpts: PackageOptions = {
     dir,
     interactive: true,
   };
-  if (program.arch) packageOpts.arch = program.arch;
-  if (program.platform) packageOpts.platform = program.platform;
+  if (options.arch) packageOpts.arch = options.arch;
+  if (options.platform) packageOpts.platform = options.platform;
 
   await api.package(packageOpts);
 })();

--- a/packages/api/cli/src/electron-forge-publish.ts
+++ b/packages/api/cli/src/electron-forge-publish.ts
@@ -1,18 +1,17 @@
-import path from 'node:path';
-
 import { initializeProxy } from '@electron/get';
 import { api, PublishOptions } from '@electron-forge/core';
-import program from 'commander';
-import fs from 'fs-extra';
+import { program } from 'commander';
 
 import './util/terminate';
+import packageJSON from '../package.json';
+
 import { getMakeOptions } from './electron-forge-make';
 import workingDir from './util/working-dir';
 
 (async () => {
   let dir = process.cwd();
   program
-    .version((await fs.readJson(path.resolve(__dirname, '../package.json'))).version, '-V, --version', 'Output the current version')
+    .version(packageJSON.version, '-V, --version', 'Output the current version')
     .arguments('[cwd]')
     .option('--target [target[,target...]]', 'The comma-separated deployment targets, defaults to "github"')
     .option('--dry-run', "Triggers a publish dry run which saves state and doesn't upload anything")
@@ -24,15 +23,17 @@ import workingDir from './util/working-dir';
     })
     .parse(process.argv);
 
+  const options = program.opts();
+
   initializeProxy();
 
   const publishOpts: PublishOptions = {
     dir,
     interactive: true,
-    dryRun: program.dryRun,
-    dryRunResume: program.fromDryRun,
+    dryRun: options.dryRun,
+    dryRunResume: options.fromDryRun,
   };
-  if (program.target) publishOpts.publishTargets = program.target.split(',');
+  if (options.target) publishOpts.publishTargets = options.target.split(',');
 
   publishOpts.makeOptions = await getMakeOptions();
 

--- a/packages/api/cli/src/electron-forge-start.ts
+++ b/packages/api/cli/src/electron-forge-start.ts
@@ -1,11 +1,10 @@
-import path from 'node:path';
-
 import { api, StartOptions } from '@electron-forge/core';
 import { ElectronProcess } from '@electron-forge/shared-types';
-import program from 'commander';
-import fs from 'fs-extra';
+import { program } from 'commander';
 
 import './util/terminate';
+import packageJSON from '../package.json';
+
 import workingDir from './util/working-dir';
 
 (async () => {
@@ -20,7 +19,7 @@ import workingDir from './util/working-dir';
 
   let dir = process.cwd();
   program
-    .version((await fs.readJson(path.resolve(__dirname, '../package.json'))).version, '-V, --version', 'Output the current version')
+    .version(packageJSON.version, '-V, --version', 'Output the current version')
     .arguments('[cwd]')
     .option('-p, --app-path <path>', "Override the path to the Electron app to launch (defaults to '.')")
     .option('-l, --enable-logging', 'Enable advanced logging.  This will log internal Electron things')
@@ -28,35 +27,38 @@ import workingDir from './util/working-dir';
     .option('--vscode', 'Used to enable arg transformation for debugging Electron through VSCode.  Do not use yourself.')
     .option('-i, --inspect-electron', 'Triggers inspect mode on Electron to allow debugging the main process.  Electron >1.7 only')
     .option('--inspect-brk-electron', 'Triggers inspect-brk mode on Electron to allow debugging the main process.  Electron >1.7 only')
-    .helpOption('-h, --help', 'Output usage information')
+    .addHelpText(
+      'after',
+      `
+      Any arguments found after "--" will be passed to the Electron app. For example...
+      
+          $ npx electron-forge start /path/to/project --enable-logging -- -d -f foo.txt
+                                    
+      ...will pass the arguments "-d -f foo.txt" to the Electron app.`
+    )
+    .passThroughOptions(true) // allows args to be passed down to the Electron executable
     .action((cwd) => {
       dir = workingDir(dir, cwd);
     })
     .parse(commandArgs);
 
-  program.on('--help', () => {
-    console.log('  Any arguments found after "--" will be passed to the Electron app, e.g.');
-    console.log('');
-    console.log('    $ electron-forge /path/to/project -l -- -d -f foo.txt');
-    console.log('');
-    console.log('  will pass the arguments "-d -f foo.txt" to the Electron app');
-  });
+  const options = program.opts();
 
   const opts: StartOptions = {
     dir,
     interactive: true,
-    enableLogging: !!program.enableLogging,
-    runAsNode: !!program.runAsNode,
-    inspect: !!program.inspectElectron,
-    inspectBrk: !!program.inspectBrkElectron,
+    enableLogging: !!options.enableLogging,
+    runAsNode: !!options.runAsNode,
+    inspect: !!options.inspectElectron,
+    inspectBrk: !!options.inspectBrkElectron,
   };
 
-  if (program.vscode && appArgs) {
+  if (options.vscode && appArgs) {
     // Args are in the format ~arg~ so we need to strip the "~"
     appArgs = appArgs.map((arg) => arg.substr(1, arg.length - 2)).filter((arg) => arg.length > 0);
   }
 
-  if (program.appPath) opts.appPath = program.appPath;
+  if (options.appPath) opts.appPath = options.appPath;
   if (appArgs) opts.args = appArgs;
 
   const spawned = await api.start(opts);

--- a/packages/api/cli/src/electron-forge.ts
+++ b/packages/api/cli/src/electron-forge.ts
@@ -2,35 +2,17 @@
 // This file requires a shebang above. If it is missing, this is an error.
 
 import chalk from 'chalk';
-import program from 'commander';
+import { program } from 'commander';
 import { Listr } from 'listr2';
 
 import './util/terminate';
 
+import packageJSON from '../package.json';
+
 import { checkSystem } from './util/check-system';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const metadata = require('../package.json');
-
-const originalSC = program.executeSubCommand.bind(program);
-program.executeSubCommand = (argv: string[], args: string[], unknown: string[]) => {
-  let indexOfDoubleDash = process.argv.indexOf('--');
-  indexOfDoubleDash = indexOfDoubleDash < 0 ? process.argv.length + 1 : indexOfDoubleDash;
-
-  const passThroughArgs = args.filter((arg) => process.argv.indexOf(arg) > indexOfDoubleDash);
-  const normalArgs = args.filter((arg) => process.argv.indexOf(arg) <= indexOfDoubleDash);
-
-  let newArgs = args;
-  let newUnknown = unknown;
-  if (passThroughArgs.length > 0) {
-    newArgs = normalArgs.concat(unknown).concat('--').concat(passThroughArgs);
-    newUnknown = [];
-  }
-  return originalSC(argv, newArgs, newUnknown);
-};
-
 program
-  .version(metadata.version, '-V, --version', 'Output the current version')
+  .version(packageJSON.version, '-V, --version', 'Output the current version')
   .option('--verbose', 'Enables verbose mode')
   .helpOption('-h, --help', 'Output usage information')
   .command('init', 'Initialize a new Electron application')
@@ -39,13 +21,8 @@ program
   .command('package', 'Package the current Electron application')
   .command('make', 'Generate distributables for the current Electron application')
   .command('publish', 'Publish the current Electron application')
-  .on('command:*', async (commands) => {
-    if (!program._execs.has(commands[0])) {
-      console.error();
-      console.error(chalk.red(`Unknown command "${program.args.join(' ')}".`));
-      console.error('See --help for a list of available commands.');
-      process.exit(1);
-    } else if (!process.argv.includes('--help') && !process.argv.includes('--h')) {
+  .hook('preSubcommand', async () => {
+    if (!process.argv.includes('--help') && !process.argv.includes('--h')) {
       const runner = new Listr<never>(
         [
           {
@@ -66,7 +43,7 @@ program
       if (runner.errors.length) {
         console.error(
           chalk.red(`\nIt looks like you are missing some dependencies you need to get Electron running.
-Make sure you have git installed and Node.js version ${metadata.engines.node}`)
+Make sure you have git installed and Node.js version ${packageJSON.engines.node}`)
         );
         process.exit(1);
       }

--- a/packages/api/cli/src/electron-forge.ts
+++ b/packages/api/cli/src/electron-forge.ts
@@ -22,7 +22,7 @@ program
   .command('make', 'Generate distributables for the current Electron application')
   .command('publish', 'Publish the current Electron application')
   .hook('preSubcommand', async () => {
-    if (!process.argv.includes('--help') && !process.argv.includes('--h')) {
+    if (!process.argv.includes('--help') && !process.argv.includes('-h')) {
       const runner = new Listr<never>(
         [
           {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -11,7 +11,8 @@
     "esModuleInterop": true,
     "declaration": true,
     "composite": true,
-    "declarationMap": true
+    "declarationMap": true,
+    "resolveJsonModule": true
   },
   "exclude": ["node_modules", "dist", "test", "index.ts", "spec", "tmpl"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4792,15 +4792,15 @@ commander@11.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-11.0.0.tgz#43e19c25dbedc8256203538e8d7e9346877a6f67"
   integrity sha512-9HMlXtt/BNoYr8ooyjjNRdIilOTkVJXB+GhxMTtOKwk0R4j4lS4NpjuqmRxroBfnfTSHQIHQB7wryHhXarNjmQ==
 
+commander@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
+  integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
+
 commander@^2.19.0, commander@^2.20.0, commander@^2.9.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
-commander@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
-  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
 commander@^5.0.0:
   version "5.1.0"


### PR DESCRIPTION
## Motivation

This PR bumps up our version of `commander`, which is woefully out of date. The motivation here is to reduce friction to make further improvements to our CLI, since commander's API has changed a lot in the last few years.

Note that `commander@11` was the latest major version that supports Node 16, while 13 is the current latest major version.

## Changes

This migration was done by reading the [CHANGELOG.md](https://github.com/tj/commander.js/blob/master/CHANGELOG.md) for `commander` and ensuring that everything compiled in TypeScript.

Here's a brief explanation of all the changes.

### Named exports

The main `program` object is now a named export.

```diff
- import program from 'commander';
+ import { program } from 'commander';
```

### Options syntax

Options for each command are now accessed via the `program.opts()` function rather than being extended on the `program` object itself.

```diff
- console.log(program.myOption);
+ const options = program.opts();
+ console.log(options.myOption);
```

### Reading from `package.json`

Getting the Forge version is necessary to get the `--version` flag to work. We did this inconsistently across our various CLI commands (either via `fs.readJson` or `require` call). TypeScript has the [`resolveJsonModule`](https://www.typescriptlang.org/tsconfig/#resolveJsonModule) config flag as of TS 2.9.

```ts
import packageJSON from '../package.json';

program
  .version(packageJSON.version, '-V, --version', 'Output the current version')
```

### Unknown command handling

We previously handled unknown commands with a custom `command:*` event listener, but newer versions of `commander` automatically exit with an error when given an unknown subcommand.

https://github.com/electron/forge/blob/ec9ba2176ce8c7b9fc711a388bae5d453a4d2feb/packages/api/cli/src/electron-forge.ts#L43-L47

Note that I had to move from a `command:*` listener to a `preSubcommand` hook because `command:*` would swallow any unknown command errors.

### Pass through arguments

Forge supports passing args through to the Electron executable app via CLI. This was previously implemented by monkeypatching the `program.executeSubCommand` helper function, but that function is no longer part of `commander`'s public API.

Instead, the `program.passThroughOptions` helper enables this behaviour directly. Previously, the monkeypatching was done in the root `electron-forge` command, but this PR changes it to only pass through options on `electron-forge start`.

I tested this with a minimal tester app that just printed out `process.argv` in the main process:

```sh
yarn start -- --inspect-electron -- --arg1 --arg2
yarn run v1.22.22
$ electron-forge start --inspect-electron -- --arg1 --arg2
✔ Locating application
✔ Loading configuration
✔ Preparing native dependencies [0.2s]
✔ Running generateAssets hook
✔ Running preStart hook

argv [
  '/Users/erick.zhao/Developer/dump/20250210-commander-11/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron',
  '.',
  '--inspect',
  '--arg1',
  '--arg2'
]
```

```sh
npm start -- --inspect-electron -- --arg1 --arg2

> 20250210-commander-11@1.0.0 start
> electron-forge start --inspect-electron -- --arg1 --arg2

✔ Locating application
✔ Loading configuration
✔ Preparing native dependencies [0.1s]
✔ Running generateAssets hook
✔ Running preStart hook

argv [
  '/Users/erick.zhao/Developer/dump/20250210-commander-11/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron',
  '.',
  '--inspect',
  '--arg1',
  '--arg2'
]
```

Instead, the `passThroughOptions(true)` helper function automatically stops parsing at the

### Adding help text

In theory, we're supposed to add a bit of helper text to instruct users how to pass through args to their Electron application.

https://github.com/electron/forge/blob/ec9ba2176ce8c7b9fc711a388bae5d453a4d2feb/packages/api/cli/src/electron-forge-start.ts#L37-L43

However, this doesn't work as of Forge 7.6.1:

```sh
yarn run v1.22.22
$ electron-forge start --help
✔ Checking your system
Usage: electron-forge-start [options] [cwd]

Options:
  -V, --version           Output the current version
  -p, --app-path <path>   Override the path to the Electron app to launch (defaults to '.')
  -l, --enable-logging    Enable advanced logging.  This will log internal Electron things
  -n, --run-as-node       Run the Electron app as a Node.JS script
  --vscode                Used to enable arg transformation for debugging Electron through VSCode.  Do not use yourself.
  -i, --inspect-electron  Triggers inspect mode on Electron to allow debugging the main process.  Electron >1.7 only
  --inspect-brk-electron  Triggers inspect-brk mode on Electron to allow debugging the main process.  Electron >1.7 only
  -h, --help              Output usage information
✨  Done in 1.08s.
```

This PR fixes that by calling the `addHelpText()` helper function.

```ts
program
  .addHelpText(
      'after',
      `
      Any arguments found after "--" will be passed to the Electron app. For example...
      
          $ npx electron-forge start /path/to/project --enable-logging -- -d -f foo.txt
                                    
      ...will pass the arguments "-d -f foo.txt" to the Electron app.`
    )
```
