### PR TITLE
fix(cli): error if system check fails

### DIFF
--- a/packages/api/cli/src/electron-forge.ts
+++ b/packages/api/cli/src/electron-forge.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 // This file requires a shebang above. If it is missing, this is an error.
 
-import chalk from 'chalk';
 import { program } from 'commander';
 import { Listr } from 'listr2';
 
@@ -36,18 +35,14 @@ program
         ],
         {
           concurrent: false,
-          exitOnError: false,
+          exitOnError: true,
           fallbackRendererCondition: Boolean(process.env.DEBUG) || Boolean(process.env.CI),
         }
       );
 
-      await runner.run();
-
-      if (runner.errors.length) {
-        console.error(
-          chalk.red(`\nIt looks like you are missing some dependencies you need to get Electron running.
-Make sure you have git installed and Node.js version ${packageJSON.engines.node}`)
-        );
+      try {
+        await runner.run();
+      } catch {
         process.exit(1);
       }
     }

--- a/packages/api/cli/src/util/check-system.ts
+++ b/packages/api/cli/src/util/check-system.ts
@@ -145,7 +145,7 @@ export async function checkSystem(callerTask: ForgeListrTask<{ command: string }
       ],
       {
         concurrent: true,
-        exitOnError: false,
+        exitOnError: true,
         rendererOptions: {
           collapseSubtasks: true,
         },


### PR DESCRIPTION
Fixes #3849

```
> npm install -g yarn@0.28.4
npm warn deprecated yarn@0.28.4: It is recommended to install Yarn using the native installation method for your environment. See https://yarnpkg.com/en/docs/install

changed 1 package in 848ms

> yarn start
yarn start v0.28.4
$ electron-forge start
❯ Checking your system
  ✖ Checking node version
  ✖ Incompatible version of yarn detected: "0.28.4" must be in range >= 1.0.0
error Command failed with exit code 1.
```