### PR TITLE
fix(package): revert `quiet` default value

### DIFF
--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -300,7 +300,7 @@ export const listrPackage = (
               asar: false,
               overwrite: true,
               ignore: [/^\/out\//g],
-              quiet: false,
+              quiet: true,
               ...forgeConfig.packagerConfig,
               dir: ctx.dir,
               arch: arch as PackagerArch,
@@ -313,6 +313,8 @@ export const listrPackage = (
               out: calculatedOutDir,
               electronVersion: await getElectronVersion(ctx.dir, packageJSON),
             };
+
+            console.log('erick');
 
             if (packageOpts.all) {
               throw new Error('config.forge.packagerConfig.all is not supported by Electron Forge');

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -314,8 +314,6 @@ export const listrPackage = (
               electronVersion: await getElectronVersion(ctx.dir, packageJSON),
             };
 
-            console.log('erick');
-
             if (packageOpts.all) {
               throw new Error('config.forge.packagerConfig.all is not supported by Electron Forge');
             }


### PR DESCRIPTION
Fast follow-up to https://github.com/electron/forge/pull/3831

The default value should still be `quiet: true` even if we let users configure it.