### PR TITLE
fix(maker-wix): version with pre-release tag breaks app start

### DIFF
--- a/packages/maker/wix/package.json
+++ b/packages/maker/wix/package.json
@@ -19,7 +19,8 @@
     "chalk": "^4.0.0",
     "electron-wix-msi": "^5.1.3",
     "log-symbols": "^4.0.0",
-    "parse-author": "^2.0.0"
+    "parse-author": "^2.0.0",
+    "semver": "^7.2.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/maker/wix/src/Config.ts
+++ b/packages/maker/wix/src/Config.ts
@@ -62,7 +62,7 @@ export interface MakerWixConfig {
    */
   upgradeCode?: string;
   /**
-   * The app's version
+   * The app's version. It must be a valid semantic version.
    */
   version?: string;
   /**

--- a/packages/maker/wix/src/MakerWix.ts
+++ b/packages/maker/wix/src/MakerWix.ts
@@ -5,6 +5,7 @@ import { ForgePlatform } from '@electron-forge/shared-types';
 import chalk from 'chalk';
 import { MSICreator, MSICreatorOptions } from 'electron-wix-msi/lib/creator';
 import logSymbols from 'log-symbols';
+import semver from 'semver';
 
 import { MakerWixConfig } from './Config';
 import getNameFromAuthor from './util/author-name';
@@ -23,12 +24,13 @@ export default class MakerWix extends MakerBase<MakerWixConfig> {
     await this.ensureDirectory(outPath);
 
     const { version } = packageJSON;
-    if (version.includes('-') || version.includes('+')) {
+    const parsed = semver.prerelease(version);
+    if (Array.isArray(parsed) && parsed.length > 0) {
       console.warn(
         logSymbols.warning,
         chalk.yellow(
           'WARNING: MSI packages follow Windows version format "major.minor.build.revision".\n' +
-            `The provided semantic version "${version}" will be transformed to Windows version format.`
+            `The provided semantic version "${version}" will be transformed to Windows version format. Prerelease component will not be retained.`
         )
       );
     }

--- a/packages/maker/wix/src/MakerWix.ts
+++ b/packages/maker/wix/src/MakerWix.ts
@@ -22,13 +22,15 @@ export default class MakerWix extends MakerBase<MakerWixConfig> {
     const outPath = path.resolve(makeDir, `wix/${targetArch}`);
     await this.ensureDirectory(outPath);
 
-    let { version } = packageJSON;
-    if (version.includes('-')) {
+    const { version } = packageJSON;
+    if (version.includes('-') || version.includes('+')) {
       console.warn(
         logSymbols.warning,
-        chalk.yellow('WARNING: WiX distributables do not handle prerelease information in the app version, removing it from the MSI')
+        chalk.yellow(
+          'WARNING: MSI packages follow Windows version format "major.minor.build.revision".\n' +
+            `The provided semantic version "${version}" will be transformed to Windows version format.`
+        )
       );
-      version = this.normalizeWindowsVersion(version);
     }
 
     const creator = new MSICreator({

--- a/packages/maker/wix/src/MakerWix.ts
+++ b/packages/maker/wix/src/MakerWix.ts
@@ -24,8 +24,8 @@ export default class MakerWix extends MakerBase<MakerWixConfig> {
     await this.ensureDirectory(outPath);
 
     const { version } = packageJSON;
-    const parsed = semver.prerelease(version);
-    if (Array.isArray(parsed) && parsed.length > 0) {
+    const parsed = semver.parse(version);
+    if ((Array.isArray(parsed?.prerelease) && parsed.prerelease.length > 0) || (Array.isArray(parsed?.build) && parsed.build.length > 0)) {
       console.warn(
         logSymbols.warning,
         chalk.yellow(


### PR DESCRIPTION
### Resolves

- Fix: https://github.com/electron/forge/issues/3805

### Details

1. `@electron-forge/maker-wix` replaces **the version (semantic version)** with the windows compatible, _making it an invalid semantic version_, e.g. `1.2.3-beta` -> `1.2.3.0`
2. `electron-wix-msi` expects a semantic `version` as an input option and then separates it into 2 versions:
   - `semanticVersion` - used as an actual app version, e.g. `1.2.3-beta`
   - `windowsCompliantVersion` - used as an `.msi` version that follows the Windows version format and doesn't support semver, e.g. `1.2.3.0`
   - See: https://github.com/electron-userland/electron-wix-msi/blob/3d476237f631380e2252027c4fde20eacccd438e/src/creator.ts#L204-L205
3. `StubExecutable` expects the app to be in `app-{semver}` folder and search to the latest semantic version
   - If there is no semantic version - it finds **nothing**
   - See: https://github.com/bitdisaster/Squirrel.Msi/blob/master/src/StubExecutable/Semver200_parser.cpp
4. Because `@electron-forge/maker-wix` passes an invalid semantic version as the version `StubExecutable` cannot run the app

As a result, building with a version with a pre-release tag or build metadata results in an unstartable installation.

### Notes

I kept the note. But I think it can be moved to the documentation instead.