### PR TITLE
fix(maker-wix): set default arch

### DIFF
--- a/packages/maker/wix/src/MakerWix.ts
+++ b/packages/maker/wix/src/MakerWix.ts
@@ -10,6 +10,10 @@ import semver from 'semver';
 import { MakerWixConfig } from './Config';
 import getNameFromAuthor from './util/author-name';
 
+function isValidWixArch(arch: string): arch is 'x64' | 'ia64' | 'x86' {
+  return ['x64', 'ia64', 'x86'].includes(arch);
+}
+
 export default class MakerWix extends MakerBase<MakerWixConfig> {
   name = 'wix';
 
@@ -35,12 +39,17 @@ export default class MakerWix extends MakerBase<MakerWixConfig> {
       );
     }
 
+    if (!isValidWixArch(targetArch)) {
+      throw new Error(`Invalid arch: ${targetArch}`);
+    }
+
     const creator = new MSICreator({
       description: packageJSON.description,
       name: appName,
       version,
       manufacturer: getNameFromAuthor(packageJSON.author),
       exe: `${appName}.exe`,
+      arch: targetArch,
       ...this.config,
       appDirectory: dir,
       outputDirectory: outPath,


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

`electron-wix-msi` defaults to `x86` arch.

Even if `@electron-forge` is set to make `x64` installer, by default `x86` installer will be created, and the app will be installed to `C:\Program Files (x86)\`.

⚠️ Note: this might be considered a breaking change - new installation will be in a new directory (`C:\Program Files\` after `C:\Program Files (x86)\`).

Alternative: maker users can manually pass arch.