### PR TITLE
feat(cli): add `--skip-git` option

### DIFF
--- a/packages/api/cli/src/electron-forge-init.ts
+++ b/packages/api/cli/src/electron-forge-init.ts
@@ -13,6 +13,7 @@ program
   .option('-t, --template [name]', 'Name of the Forge template to use.', 'base')
   .option('-c, --copy-ci-files', 'Whether to copy the templated CI files.', false)
   .option('-f, --force', 'Whether to overwrite an existing directory.', false)
+  .option('--skip-git', 'Skip initializing a git repository in the initialized project.', false)
   .action(async (dir) => {
     const workingDir = resolveWorkingDir(dir, false);
 

--- a/packages/api/cli/src/electron-forge.ts
+++ b/packages/api/cli/src/electron-forge.ts
@@ -8,7 +8,7 @@ import './util/terminate';
 
 import packageJSON from '../package.json';
 
-import { checkSystem } from './util/check-system';
+import { checkSystem, SystemCheckContext } from './util/check-system';
 
 program
   .version(packageJSON.version, '-V, --version', 'Output the current version.')
@@ -21,14 +21,13 @@ program
   .command('publish', 'Publish the current Electron application.')
   .hook('preSubcommand', async (_command, subcommand) => {
     if (!process.argv.includes('--help') && !process.argv.includes('-h')) {
-      const runner = new Listr<{
-        command: string;
-      }>(
+      const runner = new Listr<SystemCheckContext>(
         [
           {
             title: 'Checking your system',
             task: async (ctx, task) => {
               ctx.command = subcommand.name();
+              ctx.git = !process.argv.includes('--skip-git');
               return await checkSystem(task);
             },
           },

--- a/packages/api/cli/src/util/check-system.ts
+++ b/packages/api/cli/src/util/check-system.ts
@@ -105,21 +105,22 @@ export async function checkPackageManager() {
  */
 const SKIP_SYSTEM_CHECK = path.resolve(os.homedir(), '.skip-forge-system-check');
 
-type SystemCheckContext = {
+export type SystemCheckContext = {
+  command: string;
   git: boolean;
   node: boolean;
   packageManager: boolean;
 };
 
-export async function checkSystem(callerTask: ForgeListrTask<{ command: string }>) {
+export async function checkSystem(callerTask: ForgeListrTask<SystemCheckContext>) {
   if (!(await fs.pathExists(SKIP_SYSTEM_CHECK))) {
     d('checking system, create ~/.skip-forge-system-check to stop doing this');
-    return callerTask.newListr<{ command: string } & SystemCheckContext>(
+    return callerTask.newListr<SystemCheckContext>(
       [
         {
           title: 'Checking git exists',
           // We only call the `initGit` helper in the `init` and `import` commands
-          enabled: (ctx): boolean => ctx.command === 'init' || ctx.command === 'import',
+          enabled: (ctx): boolean => (ctx.command === 'init' || ctx.command === 'import') && ctx.git,
           task: async (_, task) => {
             const gitVersion = await getGitVersion();
             if (gitVersion) {

--- a/packages/api/core/spec/slow/api.slow.spec.ts
+++ b/packages/api/core/spec/slow/api.slow.spec.ts
@@ -55,6 +55,24 @@ describe.each([PACKAGE_MANAGERS['npm'], PACKAGE_MANAGERS['yarn'], PACKAGE_MANAGE
     });
   };
 
+  describe('init (with skipGit)', () => {
+    beforeAll(async () => {
+      dir = await ensureTestDirIsNonexistent();
+
+      return async () => {
+        await fs.promises.rm(dir, { recursive: true, force: true });
+      };
+    });
+
+    it('should not initialize a git repo if passed the skipGit option', async () => {
+      await api.init({
+        dir,
+        skipGit: true,
+      });
+      expect(fs.existsSync(path.join(dir, '.git'))).toEqual(false);
+    });
+  });
+
   describe('init', () => {
     beforeInitTest();
 

--- a/packages/api/core/src/api/import.ts
+++ b/packages/api/core/src/api/import.ts
@@ -50,13 +50,26 @@ export interface ImportOptions {
    * The path to the directory containing generated distributables
    */
   outDir?: string;
+  /**
+   * By default, Forge initializes a git repository in the project directory. Set this option to `true` to skip this step.
+   */
+  skipGit?: boolean;
 }
 
 export default autoTrace(
   { name: 'import()', category: '@electron-forge/core' },
   async (
     childTrace,
-    { dir = process.cwd(), interactive = false, confirmImport, shouldContinueOnExisting, shouldRemoveDependency, shouldUpdateScript, outDir }: ImportOptions
+    {
+      dir = process.cwd(),
+      interactive = false,
+      confirmImport,
+      shouldContinueOnExisting,
+      shouldRemoveDependency,
+      shouldUpdateScript,
+      outDir,
+      skipGit = false,
+    }: ImportOptions
   ): Promise<void> => {
     const listrOptions: ForgeListrOptions<{ pm: PMDetails }> = {
       concurrent: false,
@@ -86,7 +99,9 @@ export default autoTrace(
               }
             }
 
-            await initGit(dir);
+            if (!skipGit) {
+              await initGit(dir);
+            }
           }),
         },
         {

--- a/packages/api/core/src/api/init.ts
+++ b/packages/api/core/src/api/init.ts
@@ -39,6 +39,10 @@ export interface InitOptions {
    * The custom template to use. If left empty, the default template is used
    */
   template?: string;
+  /**
+   * By default, Forge initializes a git repository in the project directory. Set this option to `true` to skip this step.
+   */
+  skipGit?: boolean;
 }
 
 async function validateTemplate(template: string, templateModule: ForgeTemplate): Promise<void> {
@@ -54,7 +58,14 @@ async function validateTemplate(template: string, templateModule: ForgeTemplate)
   }
 }
 
-export default async ({ dir = process.cwd(), interactive = false, copyCIFiles = false, force = false, template = 'base' }: InitOptions): Promise<void> => {
+export default async ({
+  dir = process.cwd(),
+  interactive = false,
+  copyCIFiles = false,
+  force = false,
+  template = 'base',
+  skipGit = false,
+}: InitOptions): Promise<void> => {
   d(`Initializing in: ${dir}`);
 
   const runner = new Listr<{
@@ -79,9 +90,15 @@ export default async ({ dir = process.cwd(), interactive = false, copyCIFiles = 
         title: 'Initializing directory',
         task: async (_, task) => {
           await initDirectory(dir, task, force);
-          await initGit(dir);
         },
         rendererOptions: { persistentOutput: true },
+      },
+      {
+        title: 'Initializing git repository',
+        enabled: !skipGit,
+        task: async () => {
+          await initGit(dir);
+        },
       },
       {
         title: 'Preparing template',


### PR DESCRIPTION
ref https://github.com/electron/forge/issues/3638

Allows users to skip initializing a Git repository with the `--skip-git` flag. Applies to both `import` and `init` commands.