### PR TITLE
fix(core-utils): trim `spawnPackageManager` output

### DIFF
--- a/packages/api/cli/src/util/check-system.ts
+++ b/packages/api/cli/src/util/check-system.ts
@@ -37,8 +37,8 @@ async function checkNodeVersion() {
  */
 async function checkPnpmConfig() {
   const { pnpm } = PACKAGE_MANAGERS;
-  const hoistPattern = (await spawnPackageManager(pnpm, ['config', 'get', 'hoist-pattern'])).trim();
-  const publicHoistPattern = (await spawnPackageManager(pnpm, ['config', 'get', 'public-hoist-pattern'])).trim();
+  const hoistPattern = await spawnPackageManager(pnpm, ['config', 'get', 'hoist-pattern']);
+  const publicHoistPattern = await spawnPackageManager(pnpm, ['config', 'get', 'public-hoist-pattern']);
 
   if (hoistPattern !== 'undefined' || publicHoistPattern !== 'undefined') {
     d(
@@ -50,7 +50,7 @@ async function checkPnpmConfig() {
     return;
   }
 
-  const nodeLinker = (await spawnPackageManager(pnpm, ['config', 'get', 'node-linker'])).trim();
+  const nodeLinker = await spawnPackageManager(pnpm, ['config', 'get', 'node-linker']);
   if (nodeLinker !== 'hoisted') {
     throw new Error(
       'When using pnpm, `node-linker` must be set to "hoisted" (or a custom `hoist-pattern` or `public-hoist-pattern` must be defined). Run `pnpm config set node-linker hoisted` to set this config value, or add it to your project\'s `.npmrc` file.'

--- a/packages/api/cli/src/util/check-system.ts
+++ b/packages/api/cli/src/util/check-system.ts
@@ -37,8 +37,8 @@ async function checkNodeVersion() {
  */
 async function checkPnpmConfig() {
   const { pnpm } = PACKAGE_MANAGERS;
-  const hoistPattern = await spawnPackageManager(pnpm, ['config', 'get', 'hoist-pattern']);
-  const publicHoistPattern = await spawnPackageManager(pnpm, ['config', 'get', 'public-hoist-pattern']);
+  const hoistPattern = (await spawnPackageManager(pnpm, ['config', 'get', 'hoist-pattern'])).trim();
+  const publicHoistPattern = (await spawnPackageManager(pnpm, ['config', 'get', 'public-hoist-pattern'])).trim();
 
   if (hoistPattern !== 'undefined' || publicHoistPattern !== 'undefined') {
     d(

--- a/packages/api/cli/src/util/check-system.ts
+++ b/packages/api/cli/src/util/check-system.ts
@@ -50,7 +50,7 @@ async function checkPnpmConfig() {
     return;
   }
 
-  const nodeLinker = await spawnPackageManager(pnpm, ['config', 'get', 'node-linker']);
+  const nodeLinker = (await spawnPackageManager(pnpm, ['config', 'get', 'node-linker'])).trim();
   if (nodeLinker !== 'hoisted') {
     throw new Error(
       'When using pnpm, `node-linker` must be set to "hoisted" (or a custom `hoist-pattern` or `public-hoist-pattern` must be defined). Run `pnpm config set node-linker hoisted` to set this config value, or add it to your project\'s `.npmrc` file.'

--- a/packages/utils/core-utils/src/package-manager.ts
+++ b/packages/utils/core-utils/src/package-manager.ts
@@ -107,5 +107,6 @@ export const resolvePackageManager: () => Promise<PMDetails> = async () => {
 };
 
 export const spawnPackageManager = async (pm: PMDetails, args?: CrossSpawnArgs, opts?: CrossSpawnOptions): Promise<string> => {
-  return spawn(pm.executable, args, opts);
+  const result = await spawn(pm.executable, args, opts);
+  return typeof result === 'string' ? result.trim() : result;
 };

--- a/packages/utils/core-utils/src/package-manager.ts
+++ b/packages/utils/core-utils/src/package-manager.ts
@@ -107,6 +107,5 @@ export const resolvePackageManager: () => Promise<PMDetails> = async () => {
 };
 
 export const spawnPackageManager = async (pm: PMDetails, args?: CrossSpawnArgs, opts?: CrossSpawnOptions): Promise<string> => {
-  const result = await spawn(pm.executable, args, opts);
-  return typeof result === 'string' ? result.trim() : result;
+  return (await spawn(pm.executable, args, opts)).trim();
 };


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->
Fixes #3864 by @mato533
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

* Added `.trim()` to pnpm config get outputs:
* Modified the retrieval of `hoistPattern`, `publicHoistPattern`, and `nodeLinker` to use `.trim()` on the results of `spawnPackageManager`. This removes trailing newlines (`\n`) from the `pnpm config get` output, ensuring accurate string comparisons.
* Before: `"undefined\n" !== 'undefined'` caused the check to misinterpret unset values as custom configurations.
* After: `"undefined\n".trim()` becomes `"undefined"`, correctly triggering the node-linker check when hoist patterns are unset.
