### PR TITLE
feat: Added progress bar to git hub publisher

### DIFF
--- a/packages/publisher/github/package.json
+++ b/packages/publisher/github/package.json
@@ -8,6 +8,7 @@
   "main": "dist/PublisherGithub.js",
   "typings": "dist/PublisherGithub.d.ts",
   "devDependencies": {
+    "@types/cli-progress": "^3.11.6",
     "vitest": "^3.0.3"
   },
   "engines": {
@@ -22,6 +23,7 @@
     "@octokit/rest": "^18.0.11",
     "@octokit/types": "^6.1.2",
     "chalk": "^4.0.0",
+    "cli-progress": "^3.12.0",
     "debug": "^4.3.1",
     "fs-extra": "^10.0.0",
     "log-symbols": "^4.0.0",


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->
Fixes #3760 by @hichemfanter
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

* Integrated `cli-progress`: Replaced the previous `setStatusLine` upload counter with a `cli-progress.SingleBar` instance to show upload progress visually.
* Progress Bar Features:
1. Displays the release name (e.g., `Uploading to v1.0.0`).
2. Shows a bar, percentage, and current/total count (e.g., `|#######............| 50% (5/10))`.
3. Uses the `shades_classic` preset for a clean, styled look.

### Implementation Details:
* Added cli-progress to dependencies.
* Initialized the bar with total artifact count before uploads.
* Incremented the bar in the done callback after each artifact is processed.
* Stopped the bar after all uploads complete.

