### PR TITLE
test: re-order slow API tests

### DIFF
--- a/packages/api/core/spec/fast/init-scripts/find-template.spec.ts
+++ b/packages/api/core/spec/fast/init-scripts/find-template.spec.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { findTemplate } from '../../src/api/init-scripts/find-template';
+import { findTemplate } from '../../../src/api/init-scripts/find-template';
 
 describe('findTemplate', () => {
   /**

--- a/packages/api/core/spec/fast/init-scripts/find-template.spec.ts
+++ b/packages/api/core/spec/fast/init-scripts/find-template.spec.ts
@@ -38,7 +38,7 @@ describe('findTemplate', () => {
           ...mod.default,
           npm: {
             ...mod.default.npm,
-            packages: path.resolve(__dirname, '..', 'fixture', 'global-stub', 'node_modules'),
+            packages: path.resolve(__dirname, '..', '..', 'fixture', 'global-stub', 'node_modules'),
           },
         },
       };

--- a/packages/api/core/spec/fast/init-scripts/init-git.spec.ts
+++ b/packages/api/core/spec/fast/init-scripts/init-git.spec.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { initGit } from '../../src/api/init-scripts/init-git';
+import { initGit } from '../../../src/api/init-scripts/init-git';
 
 let dir: string;
 let dirID = Date.now();

--- a/packages/api/core/spec/slow/api.slow.spec.ts
+++ b/packages/api/core/spec/slow/api.slow.spec.ts
@@ -312,13 +312,10 @@ describe.each([PACKAGE_MANAGERS['npm'], PACKAGE_MANAGERS['yarn'], PACKAGE_MANAGE
       };
     });
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       if (process.platform === 'win32') {
         await fs.promises.copyFile(path.join(__dirname, '..', 'fixture', 'bogus-private-key.pvk'), path.join(dir, 'default.pvk'));
         devCert = await createDefaultCertificate('CN=Test Author', { certFilePath: dir });
-      }
-
-      if (process.platform !== 'win32') {
         process.env.DISABLE_SQUIRREL_TEST = 'true';
       }
     });

--- a/packages/api/core/spec/slow/api.slow.spec.ts
+++ b/packages/api/core/spec/slow/api.slow.spec.ts
@@ -169,7 +169,7 @@ describe.each([PACKAGE_MANAGERS['npm'], PACKAGE_MANAGERS['yarn'], PACKAGE_MANAGE
     });
   });
 
-  describe('after init', () => {
+  describe('package', () => {
     beforeAll(async () => {
       dir = path.join(await ensureTestDirIsNonexistent(), 'electron-forge-test');
       await api.init({ dir });
@@ -201,236 +201,267 @@ describe.each([PACKAGE_MANAGERS['npm'], PACKAGE_MANAGERS['yarn'], PACKAGE_MANAGE
       };
     });
 
-    describe('package', () => {
-      it('throws an error when packagerConfig.all is set', async () => {
-        await updatePackageJSON(dir, async (packageJSON) => {
-          assert(packageJSON.config.forge.packagerConfig);
-          packageJSON.config.forge.packagerConfig.all = true;
-        });
-        await expect(api.package({ dir })).rejects.toThrow(/packagerConfig\.all is not supported by Electron Forge/);
-        await updatePackageJSON(dir, async (packageJSON) => {
-          assert(packageJSON.config.forge.packagerConfig);
-          delete packageJSON.config.forge.packagerConfig.all;
-        });
+    it('throws an error when packagerConfig.all is set', async () => {
+      await updatePackageJSON(dir, async (packageJSON) => {
+        assert(packageJSON.config.forge.packagerConfig);
+        packageJSON.config.forge.packagerConfig.all = true;
       });
-
-      it('can package without errors', async () => {
-        await updatePackageJSON(dir, async (packageJSON) => {
-          assert(packageJSON.config.forge.packagerConfig);
-          packageJSON.config.forge.packagerConfig.asar = true;
-        });
-
-        await api.package({ dir });
-
-        // If config.forge is set in package.json, it should not exist in the packaged app's package.json
-        const cleanPackageJSON = await readMetadata({
-          src: path.resolve(dir, 'out', `Test-App-${process.platform}-${process.arch}`),
-          logger: console.error,
-        });
-        expect(cleanPackageJSON).not.toHaveProperty('config.forge');
-
-        // However, it should remain in the original package.json
-        const normalPackageJSON = await readRawPackageJson(dir);
-        expect(normalPackageJSON).toHaveProperty('config.forge');
-      });
-
-      describe('with custom outDir', () => {
-        it('should package to custom directory', async () => {
-          const outDir = `${dir}/foo`;
-
-          expect(fs.existsSync(outDir)).toEqual(false);
-
-          await api.package({ dir, outDir });
-
-          expect(fs.existsSync(outDir)).toEqual(true);
-        });
-
-        it('can make from custom directory', async () => {
-          await updatePackageJSON(dir, async (packageJSON) => {
-            // eslint-disable-next-line n/no-missing-require
-            packageJSON.config.forge.makers = [{ name: require.resolve('@electron-forge/maker-zip') } as IForgeResolvableMaker];
-          });
-
-          await api.make({ dir, skipPackage: true, outDir: `${dir}/foo` });
-
-          // Cleanup here to ensure things dont break in the make tests
-          await fs.promises.rm(path.resolve(dir, 'foo'), { recursive: true, force: true });
-          await fs.promises.rm(path.resolve(dir, 'out'), { recursive: true, force: true });
-        });
-      });
-
-      describe('with prebuilt native module deps installed', () => {
-        beforeAll(async () => {
-          await installDeps(pm, dir, ['ref-napi']);
-
-          return async () => {
-            await fs.promises.rm(path.resolve(dir, 'node_modules/ref-napi'), { recursive: true, force: true });
-            await updatePackageJSON(dir, async (packageJSON) => {
-              delete packageJSON.dependencies['ref-napi'];
-            });
-          };
-        });
-
-        it('should succeed', async () => {
-          await api.package({ dir });
-        });
+      await expect(api.package({ dir })).rejects.toThrow(/packagerConfig\.all is not supported by Electron Forge/);
+      await updatePackageJSON(dir, async (packageJSON) => {
+        assert(packageJSON.config.forge.packagerConfig);
+        delete packageJSON.config.forge.packagerConfig.all;
       });
     });
 
-    describe('make', () => {
-      let devCert: string;
-
-      beforeAll(async () => {
-        if (process.platform === 'win32') {
-          await fs.promises.copyFile(path.join(__dirname, '..', 'fixture', 'bogus-private-key.pvk'), path.join(dir, 'default.pvk'));
-          devCert = await createDefaultCertificate('CN=Test Author', { certFilePath: dir });
-        }
-
-        if (process.platform !== 'win32') {
-          process.env.DISABLE_SQUIRREL_TEST = 'true';
-        }
+    it('can package without errors', async () => {
+      await updatePackageJSON(dir, async (packageJSON) => {
+        assert(packageJSON.config.forge.packagerConfig);
+        packageJSON.config.forge.packagerConfig.asar = true;
       });
 
-      function getMakers(good: boolean) {
-        const allMakers = [
-          '@electron-forge/maker-appx',
-          '@electron-forge/maker-deb',
-          '@electron-forge/maker-dmg',
-          '@electron-forge/maker-flatpak',
-          '@electron-forge/maker-rpm',
-          '@electron-forge/maker-snap',
-          '@electron-forge/maker-squirrel',
-          '@electron-forge/maker-wix',
-          '@electron-forge/maker-zip',
-        ];
-        return allMakers
-          .map((maker) => require.resolve(maker))
-          .filter((makerPath) => {
-            // eslint-disable-next-line @typescript-eslint/no-require-imports
-            const MakerClass = require(makerPath).default;
-            const maker = new MakerClass();
+      await api.package({ dir });
 
-            // Skip the Squirrel.Windows maker test on non-Windows platforms
-            if (makerPath.includes('MakerSquirrel') && process.platform !== 'win32') {
-              return false;
-            }
-            return maker.isSupportedOnCurrentPlatform() === good && maker.externalBinariesExist() === good;
-          })
-          .map((makerPath) => {
-            const makerDefinition = {
-              name: makerPath,
-              platforms: [process.platform],
-              config: {
-                devCert,
-              },
-            };
+      // If config.forge is set in package.json, it should not exist in the packaged app's package.json
+      const cleanPackageJSON = await readMetadata({
+        src: path.resolve(dir, 'out', `Test-App-${process.platform}-${process.arch}`),
+        logger: console.error,
+      });
+      expect(cleanPackageJSON).not.toHaveProperty('config.forge');
 
-            if (process.platform === 'win32') {
-              (makerDefinition.config as Record<string, unknown>).makeVersionWinStoreCompatible = true;
-            }
+      // However, it should remain in the original package.json
+      const normalPackageJSON = await readRawPackageJson(dir);
+      expect(normalPackageJSON).toHaveProperty('config.forge');
+    });
 
-            return makerDefinition;
+    describe('with custom outDir', () => {
+      it('should package to custom directory', async () => {
+        const outDir = `${dir}/foo`;
+
+        expect(fs.existsSync(outDir)).toEqual(false);
+
+        await api.package({ dir, outDir });
+
+        expect(fs.existsSync(outDir)).toEqual(true);
+      });
+
+      it('can make from custom directory', async () => {
+        await updatePackageJSON(dir, async (packageJSON) => {
+          // eslint-disable-next-line n/no-missing-require
+          packageJSON.config.forge.makers = [{ name: require.resolve('@electron-forge/maker-zip') } as IForgeResolvableMaker];
+        });
+
+        await api.make({ dir, skipPackage: true, outDir: `${dir}/foo` });
+
+        // Cleanup here to ensure things dont break in the make tests
+        await fs.promises.rm(path.resolve(dir, 'foo'), { recursive: true, force: true });
+        await fs.promises.rm(path.resolve(dir, 'out'), { recursive: true, force: true });
+      });
+    });
+
+    describe('with prebuilt native module deps installed', () => {
+      beforeAll(async () => {
+        await installDeps(pm, dir, ['ref-napi']);
+
+        return async () => {
+          await fs.promises.rm(path.resolve(dir, 'node_modules/ref-napi'), { recursive: true, force: true });
+          await updatePackageJSON(dir, async (packageJSON) => {
+            delete packageJSON.dependencies['ref-napi'];
           });
+        };
+      });
+
+      it('should succeed', async () => {
+        await api.package({ dir });
+      });
+    });
+  });
+
+  describe('make', () => {
+    let devCert: string;
+
+    beforeAll(async () => {
+      dir = path.join(await ensureTestDirIsNonexistent(), 'electron-forge-test');
+      await api.init({ dir });
+
+      await updatePackageJSON(dir, async (packageJSON) => {
+        packageJSON.name = 'testapp';
+        packageJSON.version = '1.0.0-beta.1';
+        packageJSON.productName = 'Test-App';
+        packageJSON.config = packageJSON.config || {};
+        packageJSON.config.forge = {
+          ...packageJSON.config.forge,
+          packagerConfig: {
+            asar: false,
+          },
+        };
+
+        if (process.platform === 'linux') {
+          packageJSON.config.forge.packagerConfig = {
+            ...packageJSON.config.forge.packagerConfig,
+            executableName: 'testapp',
+          };
+        }
+        packageJSON.homepage = 'http://www.example.com/';
+        packageJSON.author = 'Test Author';
+      });
+
+      await api.package({ dir });
+
+      return async () => {
+        await fs.promises.rm(dir, { recursive: true, force: true });
+      };
+    });
+
+    beforeAll(async () => {
+      if (process.platform === 'win32') {
+        await fs.promises.copyFile(path.join(__dirname, '..', 'fixture', 'bogus-private-key.pvk'), path.join(dir, 'default.pvk'));
+        devCert = await createDefaultCertificate('CN=Test Author', { certFilePath: dir });
       }
 
-      const goodMakers = getMakers(true);
-      const badMakers = getMakers(false);
+      if (process.platform !== 'win32') {
+        process.env.DISABLE_SQUIRREL_TEST = 'true';
+      }
+    });
 
-      describe.each(goodMakers.map((m) => [path.basename(m.name), m]))('for target %s', async (_, target) => {
-        beforeAll(async () => {
-          await updatePackageJSON(dir, async (packageJSON) => {
-            packageJSON.config.forge.makers = [target as IForgeResolvableMaker];
-          });
-        });
-        it('can make without errors', async () => {
-          const outputs = await api.make({
-            dir,
-            skipPackage: true,
-          });
-          for (const outputResult of outputs) {
-            for (const output of outputResult.artifacts) {
-              expect(fs.existsSync(output)).toEqual(true);
-              expect(output.startsWith(path.resolve(dir, 'out', 'make'))).toEqual(true);
-            }
+    function getMakers(good: boolean) {
+      const allMakers = [
+        '@electron-forge/maker-appx',
+        '@electron-forge/maker-deb',
+        '@electron-forge/maker-dmg',
+        '@electron-forge/maker-flatpak',
+        '@electron-forge/maker-rpm',
+        '@electron-forge/maker-snap',
+        '@electron-forge/maker-squirrel',
+        '@electron-forge/maker-wix',
+        '@electron-forge/maker-zip',
+      ];
+      return allMakers
+        .map((maker) => require.resolve(maker))
+        .filter((makerPath) => {
+          const MakerClass = require(makerPath).default;
+          const maker = new MakerClass();
+
+          // Skip the Squirrel.Windows maker test on non-Windows platforms
+          if (makerPath.includes('MakerSquirrel') && process.platform !== 'win32') {
+            return false;
           }
+          return maker.isSupportedOnCurrentPlatform() === good && maker.externalBinariesExist() === good;
+        })
+        .map((makerPath) => {
+          const makerDefinition = {
+            name: makerPath,
+            platforms: [process.platform],
+            config: {
+              devCert,
+            },
+          };
+
+          if (process.platform === 'win32') {
+            (makerDefinition.config as Record<string, unknown>).makeVersionWinStoreCompatible = true;
+          }
+
+          return makerDefinition;
+        });
+    }
+
+    const goodMakers = getMakers(true);
+    const badMakers = getMakers(false);
+
+    describe.each(goodMakers.map((m) => [path.basename(m.name), m]))('for target %s', async (_, target) => {
+      beforeAll(async () => {
+        await updatePackageJSON(dir, async (packageJSON) => {
+          packageJSON.config.forge.makers = [target as IForgeResolvableMaker];
         });
       });
 
-      describe.each(badMakers.map((m) => [path.basename(m.name), m]))('for target %s', async (_, target) => {
-        beforeAll(async () => {
-          await updatePackageJSON(dir, async (packageJSON) => {
-            packageJSON.config.forge.makers = [target as IForgeResolvableMaker];
-          });
+      it('can make without errors', async () => {
+        const outputs = await api.make({
+          dir,
+          skipPackage: true,
         });
+        for (const outputResult of outputs) {
+          for (const output of outputResult.artifacts) {
+            expect(fs.existsSync(output)).toEqual(true);
+            expect(output.startsWith(path.resolve(dir, 'out', 'make'))).toEqual(true);
+          }
+        }
+      });
+    });
 
-        it(`fails`, async () => {
-          await expect(
-            api.make({
-              dir,
-              skipPackage: true,
-            })
-          ).rejects.toThrow();
+    describe.each(badMakers.map((m) => [path.basename(m.name), m]))('for target %s', async (_, target) => {
+      beforeAll(async () => {
+        await updatePackageJSON(dir, async (packageJSON) => {
+          packageJSON.config.forge.makers = [target as IForgeResolvableMaker];
         });
       });
 
-      it('throws an error when given an unrecognized platform', async () => {
-        await expect(api.make({ dir, platform: 'dos' })).rejects.toThrow(/invalid platform/);
-      });
-
-      it("throws an error when the specified maker doesn't support the current platform", async () => {
-        const makerPath = path.resolve(__dirname, '../fixture/maker-unsupported');
+      it(`throws due to unsupported platform`, async () => {
         await expect(
           api.make({
             dir,
-            overrideTargets: [
-              {
-                name: makerPath,
-              } as IForgeResolvableMaker,
-            ],
             skipPackage: true,
           })
-        ).rejects.toThrow(/the maker declared that it cannot run/);
+        ).rejects.toThrow();
       });
+    });
 
-      it("throws an error when the specified maker doesn't implement isSupportedOnCurrentPlatform()", async () => {
-        const makerPath = path.resolve(__dirname, '../fixture/maker-incompatible');
-        await expect(
-          api.make({
-            dir,
-            overrideTargets: [
-              {
-                name: makerPath,
-              } as IForgeResolvableMaker,
-            ],
-            skipPackage: true,
-          })
-        ).rejects.toThrow(/incompatible with this version/);
-      });
+    it('throws an error when given an unrecognized platform', async () => {
+      await expect(api.make({ dir, platform: 'dos' })).rejects.toThrow(/invalid platform/);
+    });
 
-      it('throws an error when no makers are configured for the given platform', async () => {
-        await expect(
-          api.make({
-            dir,
-            overrideTargets: [
-              {
-                name: path.resolve(__dirname, '../fixture/maker-wrong-platform'),
-              } as IForgeResolvableMaker,
-            ],
-            platform: 'linux',
-            skipPackage: true,
-          })
-        ).rejects.toThrow('Could not find any make targets configured for the "linux" platform.');
-      });
+    it("throws an error when the specified maker doesn't support the current platform", async () => {
+      const makerPath = path.resolve(__dirname, '../fixture/maker-unsupported');
+      await expect(
+        api.make({
+          dir,
+          overrideTargets: [
+            {
+              name: makerPath,
+            } as IForgeResolvableMaker,
+          ],
+          skipPackage: true,
+        })
+      ).rejects.toThrow(/the maker declared that it cannot run/);
+    });
 
-      it.runIf(process.platform === 'darwin')('can make for the MAS platform successfully', async () => {
-        await expect(
-          api.make({
-            dir,
-            overrideTargets: [require.resolve('@electron-forge/maker-zip'), require.resolve('@electron-forge/maker-dmg')],
-            platform: 'mas',
-          })
-        ).resolves.toHaveLength(2);
-      });
+    it("throws an error when the specified maker doesn't implement isSupportedOnCurrentPlatform()", async () => {
+      const makerPath = path.resolve(__dirname, '../fixture/maker-incompatible');
+      await expect(
+        api.make({
+          dir,
+          overrideTargets: [
+            {
+              name: makerPath,
+            } as IForgeResolvableMaker,
+          ],
+          skipPackage: true,
+        })
+      ).rejects.toThrow(/incompatible with this version/);
+    });
+
+    it('throws an error when no makers are configured for the given platform', async () => {
+      await expect(
+        api.make({
+          dir,
+          overrideTargets: [
+            {
+              name: path.resolve(__dirname, '../fixture/maker-wrong-platform'),
+            } as IForgeResolvableMaker,
+          ],
+          platform: 'linux',
+          skipPackage: true,
+        })
+      ).rejects.toThrow('Could not find any make targets configured for the "linux" platform.');
+    });
+
+    it.runIf(process.platform === 'darwin')('can make for the MAS platform successfully', async () => {
+      await expect(
+        api.make({
+          dir,
+          overrideTargets: [require.resolve('@electron-forge/maker-zip'), require.resolve('@electron-forge/maker-dmg')],
+          platform: 'mas',
+        })
+      ).resolves.toHaveLength(2);
     });
   });
 });

--- a/packages/api/core/spec/slow/api.slow.spec.ts
+++ b/packages/api/core/spec/slow/api.slow.spec.ts
@@ -8,14 +8,13 @@ import { createDefaultCertificate } from '@electron-forge/maker-appx';
 import { ForgeConfig, IForgeResolvableMaker } from '@electron-forge/shared-types';
 import { ensureTestDirIsNonexistent, expectLintToPass } from '@electron-forge/test-utils';
 import { readMetadata } from 'electron-installer-common';
-import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 // eslint-disable-next-line n/no-missing-import
-import { api, InitOptions } from '../../src/api';
+import { api } from '../../src/api';
 import installDeps from '../../src/util/install-dependencies';
 import { readRawPackageJson } from '../../src/util/read-package-json';
 
-type BeforeInitFunction = () => void;
 type PackageJSON = Record<string, unknown> & {
   config: {
     forge: ForgeConfig;
@@ -29,7 +28,7 @@ async function updatePackageJSON(dir: string, packageJSONUpdater: (packageJSON: 
   await fs.promises.writeFile(path.resolve(dir, 'package.json'), JSON.stringify(packageJSON), 'utf-8');
 }
 
-describe.each([PACKAGE_MANAGERS['npm'], PACKAGE_MANAGERS['yarn'], PACKAGE_MANAGERS['pnpm']])(`init (with $executable)`, (pm) => {
+describe.each([PACKAGE_MANAGERS['npm']])(`init (with $executable)`, (pm) => {
   let dir: string;
 
   beforeAll(async () => {
@@ -45,165 +44,8 @@ describe.each([PACKAGE_MANAGERS['npm'], PACKAGE_MANAGERS['yarn'], PACKAGE_MANAGE
     };
   });
 
-  const beforeInitTest = (params?: Partial<InitOptions>, beforeInit?: BeforeInitFunction) => {
-    beforeAll(async () => {
-      dir = await ensureTestDirIsNonexistent();
-      if (beforeInit) {
-        beforeInit();
-      }
-      await api.init({ ...params, dir });
-    });
-  };
-
-  describe('init (with skipGit)', () => {
-    beforeAll(async () => {
-      dir = await ensureTestDirIsNonexistent();
-
-      return async () => {
-        await fs.promises.rm(dir, { recursive: true, force: true });
-      };
-    });
-
-    it('should not initialize a git repo if passed the skipGit option', async () => {
-      await api.init({
-        dir,
-        skipGit: true,
-      });
-      expect(fs.existsSync(path.join(dir, '.git'))).toEqual(false);
-    });
-  });
-
-  describe('init', () => {
-    beforeInitTest();
-
-    afterAll(() => fs.promises.rm(dir, { recursive: true, force: true }));
-
-    it('should fail in initializing an already initialized directory', async () => {
-      await expect(api.init({ dir })).rejects.toThrow(
-        `The specified path: "${dir}" is not empty.  Please ensure it is empty before initializing a new project`
-      );
-    });
-
-    it('should initialize an already initialized directory when forced to', async () => {
-      await api.init({
-        dir,
-        force: true,
-      });
-    });
-
-    it('should create a new folder with a npm module inside', async () => {
-      expect(fs.existsSync(dir), 'the target dir should have been created').toEqual(true);
-      expect(fs.existsSync(path.join(dir, 'package.json'))).toEqual(true);
-      expect(fs.existsSync(path.join(dir, '.git'))).toEqual(true);
-      expect(fs.existsSync(path.resolve(dir, 'node_modules/electron')), 'electron should exist').toEqual(true);
-      expect(fs.existsSync(path.resolve(dir, 'node_modules/electron-squirrel-startup')), 'electron-squirrel-startup should exist').toEqual(true);
-      expect(fs.existsSync(path.resolve(dir, 'node_modules/@electron-forge/cli')), '@electron-forge/cli should exist').toEqual(true);
-      expect(fs.existsSync(path.join(dir, 'forge.config.js'))).toEqual(true);
-    });
-
-    describe('lint', () => {
-      it('should initially pass the linting process', () => expectLintToPass(dir));
-    });
-  });
-
-  describe.skip('init with CI files enabled', () => {
-    beforeInitTest({ copyCIFiles: true });
-    it.todo('should copy over the CI config files correctly');
-  });
-
-  describe('init (with custom templater)', () => {
-    beforeInitTest({ template: path.resolve(__dirname, '../fixture/custom_init') });
-
-    it('should add custom dependencies', async () => {
-      const packageJSON = await import(path.resolve(dir, 'package.json'));
-      expect(packageJSON.dependencies).toHaveProperty('debug');
-    });
-
-    it('should add custom devDependencies', async () => {
-      const packageJSON = await import(path.resolve(dir, 'package.json'));
-      expect(packageJSON.devDependencies).toHaveProperty('lodash');
-    });
-
-    it('should create dot files correctly', async () => {
-      expect(fs.existsSync(dir), 'the target dir should have been created').toEqual(true);
-      expect(fs.existsSync(path.join(dir, '.bar'))).toEqual(true);
-    });
-
-    it('should create deep files correctly', async () => {
-      expect(fs.existsSync(path.join(dir, 'src/foo.js'))).toBe(true);
-      expect(fs.existsSync(path.join(dir, 'src/index.html'))).toBe(true);
-    });
-
-    describe('lint', () => {
-      it('should initially pass the linting process', () => expectLintToPass(dir));
-    });
-
-    afterAll(async () => {
-      await fs.promises.rm(dir, { recursive: true, force: true });
-      execSync('npm unlink -g', {
-        cwd: path.resolve(__dirname, '../fixture/custom_init'),
-      });
-    });
-  });
-
-  describe('init (with a templater sans required Forge version)', () => {
-    beforeAll(async () => {
-      dir = await ensureTestDirIsNonexistent();
-
-      return async () => {
-        await fs.promises.rm(dir, { recursive: true, force: true });
-      };
-    });
-
-    it('should fail in initializing', async () => {
-      await expect(
-        api.init({
-          dir,
-          template: path.resolve(__dirname, '../fixture/template-sans-forge-version'),
-        })
-      ).rejects.toThrow(/it does not specify its required Forge version\.$/);
-    });
-  });
-
-  describe('init (with a templater with a non-matching Forge version)', () => {
-    beforeAll(async () => {
-      dir = await ensureTestDirIsNonexistent();
-
-      return async () => {
-        await fs.promises.rm(dir, { recursive: true, force: true });
-      };
-    });
-
-    it('should fail in initializing', async () => {
-      await expect(
-        api.init({
-          dir,
-          template: path.resolve(__dirname, '../fixture/template-nonmatching-forge-version'),
-        })
-      ).rejects.toThrow(/is not compatible with this version of Electron Forge/);
-    });
-  });
-
-  describe('init (with a nonexistent templater)', () => {
-    beforeAll(async () => {
-      dir = await ensureTestDirIsNonexistent();
-
-      return async () => {
-        await fs.promises.rm(dir, { recursive: true, force: true });
-      };
-    });
-
-    it('should fail in initializing', async () => {
-      await expect(
-        api.init({
-          dir,
-          template: 'does-not-exist',
-        })
-      ).rejects.toThrow('Failed to locate custom template');
-    });
-  });
-
   describe('import', () => {
+    let dir: string;
     beforeEach(async () => {
       dir = await ensureTestDirIsNonexistent();
       await fs.promises.mkdir(dir);
@@ -226,56 +68,141 @@ describe.each([PACKAGE_MANAGERS['npm'], PACKAGE_MANAGERS['yarn'], PACKAGE_MANAGE
 
       expect(fs.existsSync(path.join(dir, 'forge.config.js'))).toEqual(true);
 
-      await spawnPackageManager(pm, ['install'], { cwd: dir });
-
       await api.package({ dir });
 
       const outDirContents = fs.readdirSync(path.join(dir, 'out'));
-      expect(outDirContents).toHaveLength(1);
-      expect(outDirContents[0]).toEqual(`ProductName-${process.platform}-${process.arch}`);
+      expect(outDirContents).toEqual([`ProductName-${process.platform}-${process.arch}`]);
     });
   });
 
-  describe('Electron Forge API', () => {
-    let dir: string;
+  describe('init', () => {
+    beforeEach(async () => {
+      dir = await ensureTestDirIsNonexistent();
+      return async () => {
+        await fs.promises.rm(dir, { recursive: true, force: true });
+      };
+    });
 
-    describe('after init', () => {
-      let devCert: string;
+    it('should successfully initialize a Forge project', async () => {
+      await api.init({ dir });
 
-      beforeAll(async () => {
-        dir = path.join(await ensureTestDirIsNonexistent(), 'electron-forge-test');
-        await api.init({ dir });
+      expect(fs.existsSync(dir), 'the target dir should have been created').toEqual(true);
+      expect(fs.existsSync(path.join(dir, 'package.json'))).toEqual(true);
+      expect(fs.existsSync(path.join(dir, '.git'))).toEqual(true);
+      expect(fs.existsSync(path.resolve(dir, 'node_modules/electron')), 'electron should exist').toEqual(true);
+      expect(fs.existsSync(path.resolve(dir, 'node_modules/electron-squirrel-startup')), 'electron-squirrel-startup should exist').toEqual(true);
+      expect(fs.existsSync(path.resolve(dir, 'node_modules/@electron-forge/cli')), '@electron-forge/cli should exist').toEqual(true);
+      expect(fs.existsSync(path.join(dir, 'forge.config.js'))).toEqual(true);
+      await expectLintToPass(dir);
+    });
 
-        await updatePackageJSON(dir, async (packageJSON) => {
-          packageJSON.name = 'testapp';
-          packageJSON.version = '1.0.0-beta.1';
-          packageJSON.productName = 'Test-App';
-          packageJSON.config = packageJSON.config || {};
-          packageJSON.config.forge = {
-            ...packageJSON.config.forge,
-            packagerConfig: {
-              asar: false,
-            },
-          };
-          if (process.platform === 'win32') {
-            await fs.promises.copyFile(path.join(__dirname, '..', 'fixture', 'bogus-private-key.pvk'), path.join(dir, 'default.pvk'));
-            devCert = await createDefaultCertificate('CN=Test Author', { certFilePath: dir });
-          } else if (process.platform === 'linux') {
-            packageJSON.config.forge.packagerConfig = {
-              ...packageJSON.config.forge.packagerConfig,
-              executableName: 'testapp',
-            };
-          }
-          packageJSON.homepage = 'http://www.example.com/';
-          packageJSON.author = 'Test Author';
-        });
-
-        return async () => {
-          await fs.promises.rm(dir, { recursive: true, force: true });
-        };
+    describe('when directory already exists', async () => {
+      beforeEach(async () => {
+        await fs.promises.mkdir(dir);
+        await fs.promises.writeFile(path.resolve(dir, 'foo'), 'bar', 'utf-8');
       });
 
-      it('throws an error when all is set', async () => {
+      it('should fail by default', async () => {
+        await expect(api.init({ dir })).rejects.toThrow();
+      });
+
+      it('should successfully initialize if --force flag is on', async () => {
+        await expect(api.init({ dir, force: true })).resolves.toBeUndefined();
+      });
+    });
+
+    describe('with skipGit', () => {
+      it('should not initialize a git repo if passed the skipGit option', async () => {
+        await api.init({
+          dir,
+          skipGit: true,
+        });
+        expect(fs.existsSync(path.join(dir, '.git'))).toEqual(false);
+      });
+    });
+
+    describe('with custom templates', () => {
+      it('writes custom files correctly', async () => {
+        await api.init({ template: path.resolve(__dirname, '../fixture/custom_init'), dir });
+
+        // Dependencies should have been written properly
+        const packageJSON = await import(path.resolve(dir, 'package.json'));
+        expect(packageJSON.dependencies).toHaveProperty('debug');
+        expect(packageJSON.devDependencies).toHaveProperty('lodash');
+
+        // can write .dot files
+        expect(fs.existsSync(path.join(dir, '.bar'))).toEqual(true);
+
+        // can create files in subfolders
+        expect(fs.existsSync(path.join(dir, 'src/foo.js'))).toBe(true);
+        expect(fs.existsSync(path.join(dir, 'src/index.html'))).toBe(true);
+
+        await expectLintToPass(dir);
+      });
+
+      it('fails if template does not specify a Forge version', async () => {
+        await expect(
+          api.init({
+            dir,
+            template: path.resolve(__dirname, '../fixture/template-sans-forge-version'),
+          })
+        ).rejects.toThrow(/it does not specify its required Forge version\.$/);
+      });
+
+      it('fails if template has a mismatched Forge version', async () => {
+        await expect(
+          api.init({
+            dir,
+            template: path.resolve(__dirname, '../fixture/template-nonmatching-forge-version'),
+          })
+        ).rejects.toThrow(/is not compatible with this version of Electron Forge/);
+      });
+
+      it('fail if template does not exist', async () => {
+        await expect(
+          api.init({
+            dir,
+            template: 'does-not-exist',
+          })
+        ).rejects.toThrow('Failed to locate custom template');
+      });
+    });
+  });
+
+  describe.only('after init', () => {
+    beforeAll(async () => {
+      dir = path.join(await ensureTestDirIsNonexistent(), 'electron-forge-test');
+      await api.init({ dir });
+
+      await updatePackageJSON(dir, async (packageJSON) => {
+        packageJSON.name = 'testapp';
+        packageJSON.version = '1.0.0-beta.1';
+        packageJSON.productName = 'Test-App';
+        packageJSON.config = packageJSON.config || {};
+        packageJSON.config.forge = {
+          ...packageJSON.config.forge,
+          packagerConfig: {
+            asar: false,
+          },
+        };
+
+        if (process.platform === 'linux') {
+          packageJSON.config.forge.packagerConfig = {
+            ...packageJSON.config.forge.packagerConfig,
+            executableName: 'testapp',
+          };
+        }
+        packageJSON.homepage = 'http://www.example.com/';
+        packageJSON.author = 'Test Author';
+      });
+
+      return async () => {
+        await fs.promises.rm(dir, { recursive: true, force: true });
+      };
+    });
+
+    describe('package', () => {
+      it('throws an error when packagerConfig.all is set', async () => {
         await updatePackageJSON(dir, async (packageJSON) => {
           assert(packageJSON.config.forge.packagerConfig);
           packageJSON.config.forge.packagerConfig.all = true;
@@ -287,27 +214,49 @@ describe.each([PACKAGE_MANAGERS['npm'], PACKAGE_MANAGERS['yarn'], PACKAGE_MANAGE
         });
       });
 
-      it('can package to outDir without errors', async () => {
-        const outDir = `${dir}/foo`;
-
-        expect(fs.existsSync(outDir)).toEqual(false);
-
-        await api.package({ dir, outDir });
-
-        expect(fs.existsSync(outDir)).toEqual(true);
-      });
-
-      it('can make from custom outDir without errors', async () => {
+      it('can package without errors', async () => {
         await updatePackageJSON(dir, async (packageJSON) => {
-          // eslint-disable-next-line n/no-missing-require
-          packageJSON.config.forge.makers = [{ name: require.resolve('@electron-forge/maker-zip') } as IForgeResolvableMaker];
+          assert(packageJSON.config.forge.packagerConfig);
+          packageJSON.config.forge.packagerConfig.asar = true;
         });
 
-        await api.make({ dir, skipPackage: true, outDir: `${dir}/foo` });
+        await api.package({ dir });
 
-        // Cleanup here to ensure things dont break in the make tests
-        await fs.promises.rm(path.resolve(dir, 'foo'), { recursive: true, force: true });
-        await fs.promises.rm(path.resolve(dir, 'out'), { recursive: true, force: true });
+        // If config.forge is set in package.json, it should not exist in the packaged app's package.json
+        const cleanPackageJSON = await readMetadata({
+          src: path.resolve(dir, 'out', `Test-App-${process.platform}-${process.arch}`),
+          logger: console.error,
+        });
+        expect(cleanPackageJSON).not.toHaveProperty('config.forge');
+
+        // However, it should remain in the original package.json
+        const normalPackageJSON = await readRawPackageJson(dir);
+        expect(normalPackageJSON).toHaveProperty('config.forge');
+      });
+
+      describe('with custom outDir', () => {
+        it('should package to custom directory', async () => {
+          const outDir = `${dir}/foo`;
+
+          expect(fs.existsSync(outDir)).toEqual(false);
+
+          await api.package({ dir, outDir });
+
+          expect(fs.existsSync(outDir)).toEqual(true);
+        });
+
+        it('can make from custom directory', async () => {
+          await updatePackageJSON(dir, async (packageJSON) => {
+            // eslint-disable-next-line n/no-missing-require
+            packageJSON.config.forge.makers = [{ name: require.resolve('@electron-forge/maker-zip') } as IForgeResolvableMaker];
+          });
+
+          await api.make({ dir, skipPackage: true, outDir: `${dir}/foo` });
+
+          // Cleanup here to ensure things dont break in the make tests
+          await fs.promises.rm(path.resolve(dir, 'foo'), { recursive: true, force: true });
+          await fs.promises.rm(path.resolve(dir, 'out'), { recursive: true, force: true });
+        });
       });
 
       describe('with prebuilt native module deps installed', () => {
@@ -322,181 +271,168 @@ describe.each([PACKAGE_MANAGERS['npm'], PACKAGE_MANAGERS['yarn'], PACKAGE_MANAGE
           };
         });
 
-        it('can package without errors', async () => {
+        it('should succeed', async () => {
           await api.package({ dir });
         });
       });
+    });
 
-      it('can package without errors', async () => {
-        await updatePackageJSON(dir, async (packageJSON) => {
-          assert(packageJSON.config.forge.packagerConfig);
-          packageJSON.config.forge.packagerConfig.asar = true;
-        });
+    describe('make', () => {
+      let devCert: string;
 
-        await api.package({ dir });
-      });
-
-      describe('after package', () => {
-        it('should have deleted the forge config from the packaged app', async () => {
-          const cleanPackageJSON = await readMetadata({
-            src: path.resolve(dir, 'out', `Test-App-${process.platform}-${process.arch}`),
-            logger: console.error,
-          });
-          expect(cleanPackageJSON).not.toHaveProperty('config.forge');
-        });
-
-        it('should not affect the actual forge config', async () => {
-          const normalPackageJSON = await readRawPackageJson(dir);
-          expect(normalPackageJSON).toHaveProperty('config.forge');
-        });
+      beforeAll(async () => {
+        if (process.platform === 'win32') {
+          await fs.promises.copyFile(path.join(__dirname, '..', 'fixture', 'bogus-private-key.pvk'), path.join(dir, 'default.pvk'));
+          devCert = await createDefaultCertificate('CN=Test Author', { certFilePath: dir });
+        }
 
         if (process.platform !== 'win32') {
           process.env.DISABLE_SQUIRREL_TEST = 'true';
         }
+      });
 
-        function getMakers(good: boolean) {
-          const allMakers = [
-            '@electron-forge/maker-appx',
-            '@electron-forge/maker-deb',
-            '@electron-forge/maker-dmg',
-            '@electron-forge/maker-flatpak',
-            '@electron-forge/maker-rpm',
-            '@electron-forge/maker-snap',
-            '@electron-forge/maker-squirrel',
-            '@electron-forge/maker-wix',
-            '@electron-forge/maker-zip',
-          ];
-          return allMakers
-            .map((maker) => require.resolve(maker))
-            .filter((makerPath) => {
-              // eslint-disable-next-line @typescript-eslint/no-require-imports
-              const MakerClass = require(makerPath).default;
-              const maker = new MakerClass();
-              return maker.isSupportedOnCurrentPlatform() === good && maker.externalBinariesExist() === good;
-            })
-            .map((makerPath) => () => {
-              const makerDefinition = {
-                name: makerPath,
-                platforms: [process.platform],
-                config: {
-                  devCert,
-                },
-              };
+      function getMakers(good: boolean) {
+        const allMakers = [
+          '@electron-forge/maker-appx',
+          '@electron-forge/maker-deb',
+          '@electron-forge/maker-dmg',
+          '@electron-forge/maker-flatpak',
+          '@electron-forge/maker-rpm',
+          '@electron-forge/maker-snap',
+          '@electron-forge/maker-squirrel',
+          '@electron-forge/maker-wix',
+          '@electron-forge/maker-zip',
+        ];
+        return allMakers
+          .map((maker) => require.resolve(maker))
+          .filter((makerPath) => {
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            const MakerClass = require(makerPath).default;
+            const maker = new MakerClass();
+            return maker.isSupportedOnCurrentPlatform() === good && maker.externalBinariesExist() === good;
+          })
+          .map((makerPath) => () => {
+            const makerDefinition = {
+              name: makerPath,
+              platforms: [process.platform],
+              config: {
+                devCert,
+              },
+            };
 
-              if (process.platform === 'win32') {
-                (makerDefinition.config as Record<string, unknown>).makeVersionWinStoreCompatible = true;
-              }
-
-              return makerDefinition;
-            });
-        }
-
-        const goodMakers = getMakers(true);
-        const badMakers = getMakers(false);
-
-        const testMakeTarget = function testMakeTarget(
-          target: () => { name: string },
-          shouldPass: boolean,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          ...options: any[]
-        ) {
-          describe(`make (with target=${target().name})`, async () => {
-            beforeAll(async () => {
-              await updatePackageJSON(dir, async (packageJSON) => {
-                packageJSON.config.forge.makers = [target() as IForgeResolvableMaker];
-              });
-            });
-
-            for (const optionsFetcher of options) {
-              if (shouldPass) {
-                it(`successfully makes for config: ${JSON.stringify(optionsFetcher())}`, async () => {
-                  const outputs = await api.make(optionsFetcher());
-                  for (const outputResult of outputs) {
-                    for (const output of outputResult.artifacts) {
-                      expect(fs.existsSync(output)).toEqual(true);
-                      expect(output.startsWith(path.resolve(dir, 'out', 'make'))).toEqual(true);
-                    }
-                  }
-                });
-              } else {
-                it(`fails for config: ${JSON.stringify(optionsFetcher())}`, async () => {
-                  await expect(api.make(optionsFetcher())).rejects.toThrow();
-                });
-              }
+            if (process.platform === 'win32') {
+              (makerDefinition.config as Record<string, unknown>).makeVersionWinStoreCompatible = true;
             }
+
+            return makerDefinition;
           });
-        };
+      }
 
-        const targetOptionFetcher = () => ({ dir, skipPackage: true });
-        for (const maker of goodMakers) {
-          testMakeTarget(maker, true, targetOptionFetcher);
-        }
+      const goodMakers = getMakers(true);
+      const badMakers = getMakers(false);
 
-        for (const maker of badMakers) {
-          testMakeTarget(maker, false, targetOptionFetcher);
-        }
+      console.log({ good: goodMakers.map((m) => m().name), bad: badMakers.map((m) => m().name) });
 
-        describe('make', () => {
-          it('throws an error when given an unrecognized platform', async () => {
-            await expect(api.make({ dir, platform: 'dos' })).rejects.toThrow(/invalid platform/);
-          });
-
-          it("throws an error when the specified maker doesn't support the current platform", async () => {
-            const makerPath = path.resolve(__dirname, '../fixture/maker-unsupported');
-            await expect(
-              api.make({
-                dir,
-                overrideTargets: [
-                  {
-                    name: makerPath,
-                  } as IForgeResolvableMaker,
-                ],
-                skipPackage: true,
-              })
-            ).rejects.toThrow(/the maker declared that it cannot run/);
+      const testMakeTarget = (
+        target: () => { name: string },
+        shouldPass: boolean,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...options: any[]
+      ) => {
+        describe(`make (with target=${path.basename(target().name)})`, async () => {
+          beforeAll(async () => {
+            await updatePackageJSON(dir, async (packageJSON) => {
+              packageJSON.config.forge.makers = [target() as IForgeResolvableMaker];
+            });
           });
 
-          it("throws an error when the specified maker doesn't implement isSupportedOnCurrentPlatform()", async () => {
-            const makerPath = path.resolve(__dirname, '../fixture/maker-incompatible');
-            await expect(
-              api.make({
-                dir,
-                overrideTargets: [
-                  {
-                    name: makerPath,
-                  } as IForgeResolvableMaker,
-                ],
-                skipPackage: true,
-              })
-            ).rejects.toThrow(/incompatible with this version/);
-          });
-
-          it('throws an error when no makers are configured for the given platform', async () => {
-            await expect(
-              api.make({
-                dir,
-                overrideTargets: [
-                  {
-                    name: path.resolve(__dirname, '../fixture/maker-wrong-platform'),
-                  } as IForgeResolvableMaker,
-                ],
-                platform: 'linux',
-                skipPackage: true,
-              })
-            ).rejects.toThrow('Could not find any make targets configured for the "linux" platform.');
-          });
-
-          it.runIf(process.platform === 'darwin')('can make for the MAS platform successfully', async () => {
-            await expect(
-              api.make({
-                dir,
-                // eslint-disable-next-line n/no-missing-require
-                overrideTargets: [require.resolve('@electron-forge/maker-zip'), require.resolve('@electron-forge/maker-dmg')],
-                platform: 'mas',
-              })
-            ).resolves.toHaveLength(2);
-          });
+          for (const optionsFetcher of options) {
+            if (shouldPass) {
+              it(`successfully makes for config: ${JSON.stringify(optionsFetcher())}`, async () => {
+                const outputs = await api.make(optionsFetcher());
+                for (const outputResult of outputs) {
+                  for (const output of outputResult.artifacts) {
+                    expect(fs.existsSync(output)).toEqual(true);
+                    expect(output.startsWith(path.resolve(dir, 'out', 'make'))).toEqual(true);
+                  }
+                }
+              });
+            } else {
+              it(`fails for config: ${JSON.stringify(optionsFetcher())}`, async () => {
+                await expect(api.make(optionsFetcher())).rejects.toThrow();
+              });
+            }
+          }
         });
+      };
+
+      const targetOptionFetcher = () => ({ dir, skipPackage: true });
+      for (const maker of goodMakers) {
+        testMakeTarget(maker, true, targetOptionFetcher);
+      }
+
+      for (const maker of badMakers) {
+        testMakeTarget(maker, false, targetOptionFetcher);
+      }
+
+      it('throws an error when given an unrecognized platform', async () => {
+        await expect(api.make({ dir, platform: 'dos' })).rejects.toThrow(/invalid platform/);
+      });
+
+      it("throws an error when the specified maker doesn't support the current platform", async () => {
+        const makerPath = path.resolve(__dirname, '../fixture/maker-unsupported');
+        await expect(
+          api.make({
+            dir,
+            overrideTargets: [
+              {
+                name: makerPath,
+              } as IForgeResolvableMaker,
+            ],
+            skipPackage: true,
+          })
+        ).rejects.toThrow(/the maker declared that it cannot run/);
+      });
+
+      it("throws an error when the specified maker doesn't implement isSupportedOnCurrentPlatform()", async () => {
+        const makerPath = path.resolve(__dirname, '../fixture/maker-incompatible');
+        await expect(
+          api.make({
+            dir,
+            overrideTargets: [
+              {
+                name: makerPath,
+              } as IForgeResolvableMaker,
+            ],
+            skipPackage: true,
+          })
+        ).rejects.toThrow(/incompatible with this version/);
+      });
+
+      it('throws an error when no makers are configured for the given platform', async () => {
+        await expect(
+          api.make({
+            dir,
+            overrideTargets: [
+              {
+                name: path.resolve(__dirname, '../fixture/maker-wrong-platform'),
+              } as IForgeResolvableMaker,
+            ],
+            platform: 'linux',
+            skipPackage: true,
+          })
+        ).rejects.toThrow('Could not find any make targets configured for the "linux" platform.');
+      });
+
+      it.runIf(process.platform === 'darwin')('can make for the MAS platform successfully', async () => {
+        await expect(
+          api.make({
+            dir,
+            // eslint-disable-next-line n/no-missing-require
+            overrideTargets: [require.resolve('@electron-forge/maker-zip'), require.resolve('@electron-forge/maker-dmg')],
+            platform: 'mas',
+          })
+        ).resolves.toHaveLength(2);
       });
     });
   });

--- a/packages/maker/squirrel/src/MakerSquirrel.ts
+++ b/packages/maker/squirrel/src/MakerSquirrel.ts
@@ -13,8 +13,7 @@ export default class MakerSquirrel extends MakerBase<MakerSquirrelConfig> {
   defaultPlatforms: ForgePlatform[] = ['win32'];
 
   isSupportedOnCurrentPlatform(): boolean {
-    console.log('erick', process.env.DISABLE_SQUIRREL_TEST);
-    return this.isInstalled('electron-winstaller') && !process.env.DISABLE_SQUIRREL_TEST;
+    return this.isInstalled('electron-winstaller');
   }
 
   async make({ dir, makeDir, targetArch, packageJSON, appName, forgeConfig }: MakerOptions): Promise<string[]> {

--- a/packages/maker/squirrel/src/MakerSquirrel.ts
+++ b/packages/maker/squirrel/src/MakerSquirrel.ts
@@ -13,6 +13,7 @@ export default class MakerSquirrel extends MakerBase<MakerSquirrelConfig> {
   defaultPlatforms: ForgePlatform[] = ['win32'];
 
   isSupportedOnCurrentPlatform(): boolean {
+    console.log('erick', process.env.DISABLE_SQUIRREL_TEST);
     return this.isInstalled('electron-winstaller') && !process.env.DISABLE_SQUIRREL_TEST;
   }
 


### PR DESCRIPTION
`api.slow.spec.ts` is the slowest test suite that we have, but is the set of integration tests that test our Forge commands end-to-end.

This PR does a few things to clean up the implementation of this suite:

* Removes the `beforeInitTest` helper in favour of directly calling `api.init` in our tests. This makes the tests a bit easier to read.
* Re-orders `describe` and `it` blocks to better represent the hierarchy of tests.
* Avoids dynamically calling `it` in loops to create tests for Makers. Instead, leverage `describe.each` and `it.each`.
* Removes the `process.env.DISABLE_SQUIRREL_TEST` environment variable from the MakerSquirrel implementation code, which we were using to disable the maker in tests.

```
 ✓  slow  packages/api/core/spec/slow/api.slow.spec.ts (66 tests) 418819ms
   ✓ with package manager = 'npm' > import > creates forge.config.js and can successfully package the application 15300ms
   ✓ with package manager = 'npm' > init > should successfully initialize a Forge project 12011ms
   ✓ with package manager = 'npm' > init > when directory already exists > should fail by default
   ✓ with package manager = 'npm' > init > when directory already exists > should successfully initialize if --force flag is on 11617ms
   ✓ with package manager = 'npm' > init > with skipGit > should not initialize a git repo if passed the skipGit option 11941ms
   ✓ with package manager = 'npm' > init > with custom templates > writes custom files correctly 13095ms
   ✓ with package manager = 'npm' > init > with custom templates > fails if template does not specify a Forge version
   ✓ with package manager = 'npm' > init > with custom templates > fails if template has a mismatched Forge version
   ✓ with package manager = 'npm' > init > with custom templates > fail if template does not exist
   ✓ with package manager = 'npm' > after init > package > throws an error when packagerConfig.all is set
   ✓ with package manager = 'npm' > after init > package > can package without errors 1626ms
   ✓ with package manager = 'npm' > after init > package > with custom outDir > should package to custom directory 1571ms
   ✓ with package manager = 'npm' > after init > package > with custom outDir > can make from custom directory 8327ms
   ✓ with package manager = 'npm' > after init > package > with prebuilt native module deps installed > should succeed 5342ms
   ✓ with package manager = 'npm' > after init > make > for target MakerDMG.js > can make without errors 7982ms
   ✓ with package manager = 'npm' > after init > make > for target MakerZIP.js > can make without errors 8461ms
   ✓ with package manager = 'npm' > after init > make > for target MakerSnap.js > fails
   ✓ with package manager = 'npm' > after init > make > throws an error when given an unrecognized platform
   ✓ with package manager = 'npm' > after init > make > throws an error when the specified maker doesn't support the current platform
   ✓ with package manager = 'npm' > after init > make > throws an error when the specified maker doesn't implement isSupportedOnCurrentPlatform()
   ✓ with package manager = 'npm' > after init > make > throws an error when no makers are configured for the given platform
   ✓ with package manager = 'npm' > after init > make > can make for the MAS platform successfully 12305ms
   ✓ with package manager = 'yarn' > import > creates forge.config.js and can successfully package the application 13890ms
   ✓ with package manager = 'yarn' > init > should successfully initialize a Forge project 12201ms
   ✓ with package manager = 'yarn' > init > when directory already exists > should fail by default
   ✓ with package manager = 'yarn' > init > when directory already exists > should successfully initialize if --force flag is on 12100ms
   ✓ with package manager = 'yarn' > init > with skipGit > should not initialize a git repo if passed the skipGit option 12313ms
   ✓ with package manager = 'yarn' > init > with custom templates > writes custom files correctly 13007ms
   ✓ with package manager = 'yarn' > init > with custom templates > fails if template does not specify a Forge version
   ✓ with package manager = 'yarn' > init > with custom templates > fails if template has a mismatched Forge version
   ✓ with package manager = 'yarn' > init > with custom templates > fail if template does not exist
   ✓ with package manager = 'yarn' > after init > package > throws an error when packagerConfig.all is set
   ✓ with package manager = 'yarn' > after init > package > can package without errors 1716ms
   ✓ with package manager = 'yarn' > after init > package > with custom outDir > should package to custom directory 1698ms
   ✓ with package manager = 'yarn' > after init > package > with custom outDir > can make from custom directory 8548ms
   ✓ with package manager = 'yarn' > after init > package > with prebuilt native module deps installed > should succeed 5601ms
   ✓ with package manager = 'yarn' > after init > make > for target MakerDMG.js > can make without errors 7900ms
   ✓ with package manager = 'yarn' > after init > make > for target MakerZIP.js > can make without errors 8643ms
   ✓ with package manager = 'yarn' > after init > make > for target MakerSnap.js > fails
   ✓ with package manager = 'yarn' > after init > make > throws an error when given an unrecognized platform
   ✓ with package manager = 'yarn' > after init > make > throws an error when the specified maker doesn't support the current platform
   ✓ with package manager = 'yarn' > after init > make > throws an error when the specified maker doesn't implement isSupportedOnCurrentPlatform()
   ✓ with package manager = 'yarn' > after init > make > throws an error when no makers are configured for the given platform
   ✓ with package manager = 'yarn' > after init > make > can make for the MAS platform successfully 11345ms
   ✓ with package manager = 'pnpm' > import > creates forge.config.js and can successfully package the application 14841ms
   ✓ with package manager = 'pnpm' > init > should successfully initialize a Forge project 16937ms
   ✓ with package manager = 'pnpm' > init > when directory already exists > should fail by default
   ✓ with package manager = 'pnpm' > init > when directory already exists > should successfully initialize if --force flag is on 19314ms
   ✓ with package manager = 'pnpm' > init > with skipGit > should not initialize a git repo if passed the skipGit option 12969ms
   ✓ with package manager = 'pnpm' > init > with custom templates > writes custom files correctly 13816ms
   ✓ with package manager = 'pnpm' > init > with custom templates > fails if template does not specify a Forge version
   ✓ with package manager = 'pnpm' > init > with custom templates > fails if template has a mismatched Forge version
   ✓ with package manager = 'pnpm' > init > with custom templates > fail if template does not exist
   ✓ with package manager = 'pnpm' > after init > package > throws an error when packagerConfig.all is set
   ✓ with package manager = 'pnpm' > after init > package > can package without errors 1747ms
   ✓ with package manager = 'pnpm' > after init > package > with custom outDir > should package to custom directory 1705ms
   ✓ with package manager = 'pnpm' > after init > package > with custom outDir > can make from custom directory 8611ms
   ✓ with package manager = 'pnpm' > after init > package > with prebuilt native module deps installed > should succeed 5991ms
   ✓ with package manager = 'pnpm' > after init > make > for target MakerDMG.js > can make without errors 7868ms
   ✓ with package manager = 'pnpm' > after init > make > for target MakerZIP.js > can make without errors 8510ms
   ✓ with package manager = 'pnpm' > after init > make > for target MakerSnap.js > fails
   ✓ with package manager = 'pnpm' > after init > make > throws an error when given an unrecognized platform
   ✓ with package manager = 'pnpm' > after init > make > throws an error when the specified maker doesn't support the current platform
   ✓ with package manager = 'pnpm' > after init > make > throws an error when the specified maker doesn't implement isSupportedOnCurrentPlatform()
   ✓ with package manager = 'pnpm' > after init > make > throws an error when no makers are configured for the given platform
   ✓ with package manager = 'pnpm' > after init > make > can make for the MAS platform successfully 10904ms
```

I also went ahead and moved a few more files around to better reflect the folder structure of the `src/` folder.
