### PR TITLE
fix(plugin-webpack): make entry point consistent between dev and prod

### DIFF
--- a/packages/plugin/webpack/spec/WebpackConfig.spec.ts
+++ b/packages/plugin/webpack/spec/WebpackConfig.spec.ts
@@ -147,7 +147,7 @@ describe('WebpackConfigGenerator', () => {
       const generator = new WebpackConfigGenerator(config, '/', false, 3000);
       const defines = generator.getDefines();
 
-      expect(defines.HELLO_WEBPACK_ENTRY).toEqual("'http://localhost:3000/hello'");
+      expect(defines.HELLO_WEBPACK_ENTRY).toEqual("'http://localhost:3000/hello/index.html'");
     });
 
     describe('PRELOAD_WEBPACK_ENTRY', () => {

--- a/packages/plugin/webpack/src/WebpackConfig.ts
+++ b/packages/plugin/webpack/src/WebpackConfig.ts
@@ -116,10 +116,7 @@ export default class WebpackConfigGenerator {
     }
     const protocol = this.pluginConfig.devServer?.server === 'https' ? 'https' : 'http';
     const baseUrl = `${protocol}://localhost:${this.port}/${entryPoint.name}`;
-    if (basename !== 'index.html') {
-      return `'${baseUrl}/${basename}'`;
-    }
-    return `'${baseUrl}'`;
+    return `'${baseUrl}/${basename}'`;
   }
 
   toEnvironmentVariable(entryPoint: WebpackPluginEntryPoint, preload = false): string {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**
There's was no need to omit the `index.html` in development mode in the first place, and it makes relative URL resolve differently than in production.