### PR TITLE
fix(start): pass app args with correct amount of `--`

### DIFF
--- a/packages/api/cli/src/electron-forge-start.ts
+++ b/packages/api/cli/src/electron-forge-start.ts
@@ -37,7 +37,6 @@ import { resolveWorkingDir } from './util/resolve-working-dir';
                                     
       ...will pass the arguments "-d -f foo.txt" to the Electron app.`
     )
-    .passThroughOptions(true) // allows args to be passed down to the Electron executable
     .action((targetDir: string) => {
       dir = resolveWorkingDir(targetDir);
     })

--- a/packages/api/cli/src/electron-forge.ts
+++ b/packages/api/cli/src/electron-forge.ts
@@ -19,6 +19,7 @@ program
   .command('package', 'Package the current Electron application.')
   .command('make', 'Generate distributables for the current Electron application.')
   .command('publish', 'Publish the current Electron application.')
+  .passThroughOptions(true)
   .hook('preSubcommand', async (_command, subcommand) => {
     if (!process.argv.includes('--help') && !process.argv.includes('-h')) {
       const runner = new Listr<SystemCheckContext>(


### PR DESCRIPTION
## Problem statement

Fixes https://github.com/electron/forge/issues/3873.

In https://github.com/electron/forge/pull/3848, we upgraded the `commander` library from v4 to v11, which brought in half a decade's worth of updates.

This change required us to use the newer `passThroughOptions()` setting to pass args to `process.argv` instead of to the program itself. I had previously tested that this worked specifically with the following invocation:

```
yarn start -- --inspect-electron -- --arg1 --arg2
```

However, as reported in the aforementioned issue, this approach didn't work with `yarn start yarn start -- -- --arg1 --arg2` when attempting to pass in app args without passing any args to Forge.

## Root cause

By inspecting the value of `process.argv` at the top level of `electron-forge-start.ts`, I noticed that the `--` values were being swallowed, leading to args being passed straight to the CLI instead of the app itself. However, all `--` args were being passed properly to the top-level `electron-forge.ts` file.

I think I had `passThroughOptions` misconfigured by not setting it at the top level, meaning that `electron-forge` would swallow one set of `--` params even before it would touch the `electron-forge start` command level.

## Test cases

We don't have CLI-level tests in Forge, so I went around and tested this manually.

With `npm start`:

```
$ npm start -- -- --remote-debugging-port=9222

> 20250310-start-test@1.0.0 start
> electron-forge start -- --remote-debugging-port=9222

✔ Checking your system
✔ Locating application
✔ Loading configuration
✔ Preparing native dependencies [0.1s]
✔ Running generateAssets hook
✔ Running preStart hook


DevTools listening on ws://127.0.0.1:9222/devtools/browser/9c325fd8-49ce-4f9e-aa34-82ba23742c6d
```

With `yarn start`:

```
$ yarn start -- -- --remote-debugging-port=9222

yarn start -- -- --remote-debugging-port=9222
yarn run v1.22.22
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
$ electron-forge start -- --remote-debugging-port=9222
✔ Checking your system
✔ Locating application
✔ Loading configuration
✔ Preparing native dependencies [0.1s]
✔ Running generateAssets hook
✔ Running preStart hook


DevTools listening on ws://127.0.0.1:9222/devtools/browser/4988f349-e621-470d-9150-6473f90f51e1
```

With `npx electron-forge start`:

```
$ npx electron-forge start -- --remote-debugging-port=9222
✔ Checking your system
✔ Locating application
✔ Loading configuration
✔ Preparing native dependencies [0.1s]
✔ Running generateAssets hook
✔ Running preStart hook


DevTools listening on ws://127.0.0.1:9222/devtools/browser/34d362be-29c5-49a5-9e37-dd70e7153ff2
```

Validating that there are no regressions with passing a CLI flag to Forge _before_ passing additional args to the Electron app:

```
> npx electron-forge start --inspect-electron -- --remote-debugging-port=9222
✔ Checking your system
✔ Locating application
✔ Loading configuration
✔ Preparing native dependencies [0.1s]
✔ Running generateAssets hook
✔ Running preStart hook

Debugger listening on ws://127.0.0.1:9229/06515d95-2934-4e72-8763-6c4831f545d9
For help, see: https://nodejs.org/en/docs/inspector

DevTools listening on ws://127.0.0.1:9222/devtools/browser/f837a86f-a45c-464d-89ad-4750579c7701
```



