### PR TITLE
fix(package): set `process.env.npm_config_arch` for each arch in universal build

### DIFF
--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -413,6 +413,7 @@ export const listrPackage = (
                               newRoot: true,
                             },
                             async (childTrace, _, task) => {
+                              process.env.npm_config_arch = target.arch;
                               return delayTraceTillSignal(
                                 childTrace,
                                 task.newListr(

--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -413,7 +413,10 @@ export const listrPackage = (
                               newRoot: true,
                             },
                             async (childTrace, _, task) => {
-                              process.env.npm_config_arch = target.arch;
+                              const originalConfigArch = process.env.npm_config_arch;
+                              if (target.forUniversal) {
+                                process.env.npm_config_arch = target.arch;
+                              }
                               return delayTraceTillSignal(
                                 childTrace,
                                 task.newListr(
@@ -440,6 +443,9 @@ export const listrPackage = (
                                       title: 'Finalizing package',
                                       task: childTrace({ name: 'finalize-package', category: '@electron-forge/core' }, async () => {
                                         await addSignalAndWait(signalPackageDone, target);
+                                        if (target.forUniversal) {
+                                          process.env.npm_config_arch = originalConfigArch;
+                                        }
                                       }),
                                     },
                                   ],


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Closes #3657
 
This one line will set `process.env.npm_config_arch` to the appropriate architecture as the build creates multiple versions for the Mac universal app.
