### PR TITLE
fix(core-utils): correctly fall back package manager lockfile

### DIFF
--- a/packages/utils/core-utils/spec/package-manager.spec.ts
+++ b/packages/utils/core-utils/spec/package-manager.spec.ts
@@ -99,7 +99,7 @@ describe('package-manager', () => {
   });
 
   it('should use the package manager for the nearest ancestor lockfile if detected', async () => {
-    vi.mocked(findUp).mockResolvedValue('yarn.lock');
+    vi.mocked(findUp).mockResolvedValue('/Users/foo/bar/yarn.lock');
     await expect(resolvePackageManager()).resolves.toHaveProperty('executable', 'yarn');
   });
 


### PR DESCRIPTION
Follow-up to https://github.com/electron/forge/pull/3822.

Subtle bug here where `findUp` returns the absolute path so we need to `path.basename` it to grab the correct package manager. Fixed the test which had bad arrangement code.