### PR TITLE
fix(cli): correctly wire up `--skip-git` opt

### DIFF
--- a/packages/api/cli/src/electron-forge-import.ts
+++ b/packages/api/cli/src/electron-forge-import.ts
@@ -10,11 +10,16 @@ program
   .version(packageJSON.version, '-V, --version', 'Output the current version.')
   .helpOption('-h, --help', 'Output usage information.')
   .argument('[dir]', 'Directory of the project to import. (default: current directory)')
+  .option('--skip-git', 'Skip initializing a git repository in the imported project.', false)
   .action(async (dir: string) => {
     const workingDir = resolveWorkingDir(dir, false);
+
+    const options = program.opts();
+
     await api.import({
       dir: workingDir,
       interactive: true,
+      skipGit: !!options.skipGit,
     });
   })
   .parse(process.argv);

--- a/packages/api/cli/src/electron-forge-init.ts
+++ b/packages/api/cli/src/electron-forge-init.ts
@@ -24,6 +24,7 @@ program
       interactive: true,
       copyCIFiles: !!options.copyCiFiles,
       force: !!options.force,
+      skipGit: !!options.skipGit,
     };
     if (options.template) initOpts.template = options.template;
 


### PR DESCRIPTION
Follow-up to https://github.com/electron/forge/pull/3860

I am a silly goose and forgot to actually wire the CLI option up to the API layer.