### PR TITLE
fix(cli): add descriptive error for unsupported node version

### DIFF
--- a/packages/api/cli/package.json
+++ b/packages/api/cli/package.json
@@ -24,6 +24,7 @@
     "debug": "^4.3.1",
     "fs-extra": "^10.0.0",
     "listr2": "^7.0.2",
+    "log-symbols": "^4.0.0",
     "semver": "^7.2.1"
   },
   "engines": {

--- a/packages/api/cli/src/electron-forge.ts
+++ b/packages/api/cli/src/electron-forge.ts
@@ -3,10 +3,16 @@
 
 import { program } from 'commander';
 import { Listr } from 'listr2';
-
-import './util/terminate';
+import semver from 'semver';
 
 import packageJSON from '../package.json';
+
+if (!semver.satisfies(process.versions.node, packageJSON.engines.node)) {
+  console.error(`You are running Node.js version ${process.versions.node}, but Electron Forge requires Node.js ${packageJSON.engines.node}.`);
+  process.exit(1);
+}
+
+import './util/terminate';
 
 import { checkSystem, SystemCheckContext } from './util/check-system';
 

--- a/packages/api/cli/src/electron-forge.ts
+++ b/packages/api/cli/src/electron-forge.ts
@@ -2,19 +2,20 @@
 // This file requires a shebang above. If it is missing, this is an error.
 
 import { program } from 'commander';
-import { Listr } from 'listr2';
 import semver from 'semver';
 
 import packageJSON from '../package.json';
+import './util/terminate';
+
+import { checkSystem, SystemCheckContext } from './util/check-system';
 
 if (!semver.satisfies(process.versions.node, packageJSON.engines.node)) {
   console.error(`You are running Node.js version ${process.versions.node}, but Electron Forge requires Node.js ${packageJSON.engines.node}.`);
   process.exit(1);
 }
 
-import './util/terminate';
-
-import { checkSystem, SystemCheckContext } from './util/check-system';
+/* eslint-disable-next-line import/order */
+import { Listr } from 'listr2';
 
 program
   .version(packageJSON.version, '-V, --version', 'Output the current version.')

--- a/packages/api/cli/src/electron-forge.ts
+++ b/packages/api/cli/src/electron-forge.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 // This file requires a shebang above. If it is missing, this is an error.
 
+import chalk from 'chalk';
 import { program } from 'commander';
+import logSymbols from 'log-symbols';
 import semver from 'semver';
 
 import packageJSON from '../package.json';
@@ -10,11 +12,14 @@ import './util/terminate';
 import { checkSystem, SystemCheckContext } from './util/check-system';
 
 if (!semver.satisfies(process.versions.node, packageJSON.engines.node)) {
-  console.error(`You are running Node.js version ${process.versions.node}, but Electron Forge requires Node.js ${packageJSON.engines.node}.`);
+  console.error(
+    logSymbols.error,
+    `You are running Node.js version ${chalk.red(process.versions.node)}, but Electron Forge requires Node.js ${chalk.red(packageJSON.engines.node)}. \n`
+  );
   process.exit(1);
 }
 
-/* eslint-disable-next-line import/order */
+/* eslint-disable-next-line import/order -- Listr2 import contains JS syntax that fails as early as Node 14 */
 import { Listr } from 'listr2';
 
 program

--- a/packages/api/cli/src/util/check-system.ts
+++ b/packages/api/cli/src/util/check-system.ts
@@ -16,17 +16,6 @@ async function getGitVersion(): Promise<string | null> {
   });
 }
 
-async function checkNodeVersion() {
-  const { engines } = await fs.readJson(path.resolve(__dirname, '..', '..', 'package.json'));
-  const versionSatisfied = semver.satisfies(process.versions.node, engines.node);
-
-  if (!versionSatisfied) {
-    throw new Error(`You are running Node.js version ${process.versions.node}, but Electron Forge requires Node.js ${engines.node}.`);
-  }
-
-  return process.versions.node;
-}
-
 /**
  * Packaging an app with Electron Forge requires `node_modules` to be on disk.
  * With `pnpm`, this can be done in a few different ways.
@@ -128,13 +117,6 @@ export async function checkSystem(callerTask: ForgeListrTask<SystemCheckContext>
             } else {
               throw new Error('Could not find git in environment');
             }
-          },
-        },
-        {
-          title: 'Checking node version',
-          task: async (_, task) => {
-            const nodeVersion = await checkNodeVersion();
-            task.title = `Found node@${nodeVersion}`;
           },
         },
         {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixes #3554

This PR introduces an early Node.js version check in the `electron-forge.ts` CLI entry point. This prevents syntax errors caused by unsupported Node versions and provides a clear error message to the user.