### PR TITLE
feat(cli): show template sources when initializing

### DIFF
--- a/packages/api/core/src/api/init.ts
+++ b/packages/api/core/src/api/init.ts
@@ -81,10 +81,13 @@ export default async ({
         },
       },
       {
-        title: `Locating custom template: "${template}"`,
-        task: async (ctx) => {
-          ctx.templateModule = await findTemplate(template);
+        title: `Resolving template: ${chalk.cyan(template)}`,
+        task: async (ctx, task) => {
+          const tmpl = await findTemplate(template);
+          ctx.templateModule = tmpl.template;
+          task.output = `Using ${chalk.green(tmpl.name)} (${tmpl.type} module)`;
         },
+        rendererOptions: { persistentOutput: true },
       },
       {
         title: 'Initializing directory',


### PR DESCRIPTION
A common issue for Electron Forge's init command is that our internal template search logic prioritizes globally installed templates over locally installed ones.

In practice, this means that if you installed `npm install -g create-electron-app` at some point (we used to recommend that in our docs a long time ago), you'll run into a bug where `init` fails because it tries to fetch the global module installed with an incompatible Forge version.

ref https://github.com/electron/forge/issues/3874

This PR addresses the issue by suffixing `(local module)` or `(global module)` to the end of the file and resolving the actual template module name.

```
✔ Resolving package manager: yarn
✔ Resolving template: webpack-typescript
  › Using @electron-forge/template-webpack-typescript (local module)
```