### PR TITLE
feat: Publisher S3 add ChecksumCalculation

### DIFF
--- a/packages/publisher/s3/src/Config.ts
+++ b/packages/publisher/s3/src/Config.ts
@@ -63,6 +63,33 @@ export interface PublisherS3Config {
    */
   s3ForcePathStyle?: boolean;
   /**
+   * Controls whether checksums are calculated for requests sent to S3.
+   * 
+   * Possible values:
+   * - "WHEN_SUPPORTED" - Calculate checksums for all requests
+   * - "WHEN_REQUIRED" - Only calculate checksums when required by the service
+   * 
+   * See:
+   * https://github.com/aws/aws-sdk-js-v3/blob/main/packages/middleware-flexible-checksums/src/constants.ts
+   * 
+   * Default: "WHEN_SUPPORTED"
+   */
+  requestChecksumCalculation?: string
+
+  /**
+   * Controls whether checksums in responses from S3 are validated.
+   * 
+   * Possible values:
+   * - "WHEN_SUPPORTED" - Validate checksums for all responses
+   * - "WHEN_REQUIRED" - Only validate checksums when provided by the service
+   * 
+   * See:
+   * https://github.com/aws/aws-sdk-js-v3/blob/main/packages/middleware-flexible-checksums/src/constants.ts
+   * 
+   * Default: "WHEN_SUPPORTED"
+   */
+  responseChecksumValidation?: string
+  /**
    * Custom function to provide the key to upload a given file to
    */
   keyResolver?: (fileName: string, platform: string, arch: string) => string;

--- a/packages/publisher/s3/src/Config.ts
+++ b/packages/publisher/s3/src/Config.ts
@@ -64,31 +64,36 @@ export interface PublisherS3Config {
   s3ForcePathStyle?: boolean;
   /**
    * Controls whether checksums are calculated for requests sent to S3.
-   * 
+   *
    * Possible values:
    * - "WHEN_SUPPORTED" - Calculate checksums for all requests
    * - "WHEN_REQUIRED" - Only calculate checksums when required by the service
-   * 
+   *
    * See:
    * https://github.com/aws/aws-sdk-js-v3/blob/main/packages/middleware-flexible-checksums/src/constants.ts
-   * 
+   *
    * Default: "WHEN_SUPPORTED"
    */
-  requestChecksumCalculation?: string
-
+  requestChecksumCalculation?:
+    | import('@aws-sdk/middleware-flexible-checksums').RequestChecksumCalculation
+    | import('@aws-sdk/types').Provider<import('@aws-sdk/middleware-flexible-checksums').RequestChecksumCalculation>
+    | undefined;
   /**
    * Controls whether checksums in responses from S3 are validated.
-   * 
+   *
    * Possible values:
    * - "WHEN_SUPPORTED" - Validate checksums for all responses
    * - "WHEN_REQUIRED" - Only validate checksums when provided by the service
-   * 
+   *
    * See:
    * https://github.com/aws/aws-sdk-js-v3/blob/main/packages/middleware-flexible-checksums/src/constants.ts
-   * 
+   *
    * Default: "WHEN_SUPPORTED"
    */
-  responseChecksumValidation?: string
+  responseChecksumValidation?:
+    | import('@aws-sdk/middleware-flexible-checksums').ResponseChecksumValidation
+    | import('@aws-sdk/types').Provider<import('@aws-sdk/middleware-flexible-checksums').ResponseChecksumValidation>
+    | undefined;
   /**
    * Custom function to provide the key to upload a given file to
    */

--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -48,8 +48,8 @@ export default class PublisherS3 extends PublisherStatic<PublisherS3Config> {
       region: this.config.region,
       endpoint: this.config.endpoint,
       forcePathStyle: !!this.config.s3ForcePathStyle,
-      requestChecksumCalculation: this.config.requestChecksumCalculation || "WHEN_SUPPORTED",
-      responseChecksumValidation: this.config.responseChecksumValidation || "WHEN_SUPPORTED",
+      requestChecksumCalculation: this.config.requestChecksumCalculation || "WHEN_SUPPORTED" as const,
+      responseChecksumValidation: this.config.responseChecksumValidation || "WHEN_SUPPORTED" as const,
     });
 
     d('creating s3 client with options:', this.config);

--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -48,8 +48,8 @@ export default class PublisherS3 extends PublisherStatic<PublisherS3Config> {
       region: this.config.region,
       endpoint: this.config.endpoint,
       forcePathStyle: !!this.config.s3ForcePathStyle,
-      requestChecksumCalculation: this.config.requestChecksumCalculation || "WHEN_SUPPORTED" as const,
-      responseChecksumValidation: this.config.responseChecksumValidation || "WHEN_SUPPORTED" as const,
+      requestChecksumCalculation: this.config.requestChecksumCalculation || ('WHEN_SUPPORTED' as const),
+      responseChecksumValidation: this.config.responseChecksumValidation || ('WHEN_SUPPORTED' as const),
     });
 
     d('creating s3 client with options:', this.config);

--- a/packages/publisher/s3/src/PublisherS3.ts
+++ b/packages/publisher/s3/src/PublisherS3.ts
@@ -48,6 +48,8 @@ export default class PublisherS3 extends PublisherStatic<PublisherS3Config> {
       region: this.config.region,
       endpoint: this.config.endpoint,
       forcePathStyle: !!this.config.s3ForcePathStyle,
+      requestChecksumCalculation: this.config.requestChecksumCalculation || "WHEN_SUPPORTED",
+      responseChecksumValidation: this.config.responseChecksumValidation || "WHEN_SUPPORTED",
     });
 
     d('creating s3 client with options:', this.config);


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

## Summarize your changes:

This pull request introduces new configuration options for checksum handling in the `PublisherS3` class. The changes primarily focus on allowing users to control checksum calculations and validations for requests and responses to and from S3.

This is local only tested against backblaze S3 and cloudflare R2.

### Configuration Enhancements:

* [`packages/publisher/s3/src/Config.ts`](diffhunk://#diff-6af20bd00170cbc92aebaf09d7cbe37c6e50671a915879a2818e5689ac23909aR65-R91): Added `requestChecksumCalculation` and `responseChecksumValidation` options to the `PublisherS3Config` interface. These options allow users to specify when checksums should be calculated and validated, respectively.

### Implementation Updates:

* [`packages/publisher/s3/src/PublisherS3.ts`](diffhunk://#diff-55fcfafef0ce7bb897f6ef6af7ba4947e106029d7e92efcbf324edd5a502ab2eR51-R52): Updated the `PublisherS3` class to include the new checksum configuration options when creating the S3 client. Default values are set to "WHEN_SUPPORTED" if not provided.