### PR TITLE
fix(core): load TypeScript configurations with `jiti`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "got": "^11.8.5",
     "html-webpack-plugin": "^5.5.3",
     "interpret": "^3.1.1",
+    "jiti": "^2.4.2",
     "listr2": "^7.0.2",
     "lodash": "^4.17.20",
     "log-symbols": "^4.0.0",

--- a/packages/api/core/package.json
+++ b/packages/api/core/package.json
@@ -52,6 +52,7 @@
     "global-dirs": "^3.0.0",
     "got": "^11.8.5",
     "interpret": "^3.1.1",
+    "jiti": "^2.4.2",
     "listr2": "^7.0.2",
     "lodash": "^4.17.20",
     "log-symbols": "^4.0.0",

--- a/packages/api/core/spec/fast/util/forge-config.spec.ts
+++ b/packages/api/core/spec/fast/util/forge-config.spec.ts
@@ -252,10 +252,24 @@ describe('findConfig', () => {
       expect(conf.buildIdentifier).toEqual('yml');
     });
 
-    it('should resolve the TS file exports of forge.config.ts if config.forge does not exist and the TS config exists', async () => {
-      const fixturePath = path.resolve(__dirname, '../../fixture/dummy_default_ts_conf');
-      const conf = await findConfig(fixturePath);
-      expect(conf.buildIdentifier).toEqual('typescript');
+    describe('TypeScript', () => {
+      it('should resolve forge.config.ts', async () => {
+        const fixturePath = path.resolve(__dirname, '../../fixture/dummy_default_ts_conf');
+        const conf = await findConfig(fixturePath);
+        expect(conf.buildIdentifier).toEqual('typescript');
+      });
+
+      it('should resolve forge.config.cts', async () => {
+        const fixturePath = path.resolve(__dirname, '../../fixture/dummy_default_cts_conf');
+        const conf = await findConfig(fixturePath);
+        expect(conf.buildIdentifier).toEqual('typescript-commonjs');
+      });
+
+      it('should resolve forge.config.mts', async () => {
+        const fixturePath = path.resolve(__dirname, '../../fixture/dummy_default_mts_conf');
+        const conf = await findConfig(fixturePath);
+        expect(conf.buildIdentifier).toEqual('typescript-esm');
+      });
     });
   });
 });

--- a/packages/api/core/spec/fixture/dummy_default_cts_conf/forge.config.cts
+++ b/packages/api/core/spec/fixture/dummy_default_cts_conf/forge.config.cts
@@ -1,0 +1,7 @@
+import type { ForgeConfig } from '@electron-forge/shared-types';
+
+const config: ForgeConfig = {
+  buildIdentifier: 'typescript-commonjs',
+};
+
+export default config;

--- a/packages/api/core/spec/fixture/dummy_default_cts_conf/package.json
+++ b/packages/api/core/spec/fixture/dummy_default_cts_conf/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "",
+  "productName": "",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "electron-forge start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@electron-forge/shared-types": "*",
+    "electron": "99.99.99"
+  }
+}

--- a/packages/api/core/spec/fixture/dummy_default_mts_conf/forge.config.mts
+++ b/packages/api/core/spec/fixture/dummy_default_mts_conf/forge.config.mts
@@ -1,0 +1,7 @@
+import type { ForgeConfig } from '@electron-forge/shared-types';
+
+const config: ForgeConfig = {
+  buildIdentifier: 'typescript-esm',
+};
+
+export default config;

--- a/packages/api/core/spec/fixture/dummy_default_mts_conf/package.json
+++ b/packages/api/core/spec/fixture/dummy_default_mts_conf/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "",
+  "productName": "",
+  "version": "1.0.0",
+  "description": "",
+  "main": "src/index.js",
+  "type": "module",
+  "scripts": {
+    "start": "electron-forge start"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@electron-forge/shared-types": "*",
+    "electron": "99.99.99"
+  }
+}

--- a/packages/api/core/src/util/forge-config.ts
+++ b/packages/api/core/src/util/forge-config.ts
@@ -135,7 +135,7 @@ export default async (dir: string): Promise<ResolvedForgeConfig> => {
     for (const extension of ['.js', '.mts', ...Object.keys(interpret.extensions)]) {
       const pathToConfig = path.resolve(dir, `forge.config${extension}`);
       if (await fs.pathExists(pathToConfig)) {
-        // Use rechoir to parse any alternative syntaxes (except for TypeScript when tsx register is supported)
+        // Use rechoir to parse alternative syntaxes (except for TypeScript where we use jiti)
         if (!['.cts', '.mts', '.ts'].includes(extension)) {
           rechoir.prepare(interpret.extensions, pathToConfig, dir);
         }

--- a/packages/plugin/webpack/spec/fixtures/apps/native-modules/package-lock.json
+++ b/packages/plugin/webpack/spec/fixtures/apps/native-modules/package-lock.json
@@ -12,7 +12,7 @@
         "native-hello-world": "^2.0.0"
       },
       "devDependencies": {
-        "@vercel/webpack-asset-relocator-loader": "1.7.0",
+        "@vercel/webpack-asset-relocator-loader": "1.7.3",
         "electron": "^33.3.1"
       }
     },
@@ -126,11 +126,14 @@
       }
     },
     "node_modules/@vercel/webpack-asset-relocator-loader": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.7.0.tgz",
-      "integrity": "sha512-1Dy3BdOliDwxA7VZSIg55E1d/us2KvsCQOZV25fgufG//CsnZBGiSAL7qewTQf7YVHH0A9PHgzwMmKIZ8aFYVw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.7.3.tgz",
+      "integrity": "sha512-vizrI18v8Lcb1PmNNUBz7yxPxxXoOeuaVEjTG9MjvDrphjiSxFZrRJ5tIghk+qdLFRCXI5HBCshgobftbmrC5g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.10.0"
+      }
     },
     "node_modules/bindings": {
       "version": "1.5.0",
@@ -440,6 +443,16 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-stream": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -568,6 +581,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -587,6 +613,22 @@
       },
       "engines": {
         "node": ">=10.19.0"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/json-buffer": {
@@ -722,6 +764,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -761,6 +810,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-alpn": {
@@ -856,6 +926,19 @@
       },
       "engines": {
         "node": ">= 8.0"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/type-fest": {

--- a/packages/plugin/webpack/spec/fixtures/apps/native-modules/package-lock.json
+++ b/packages/plugin/webpack/spec/fixtures/apps/native-modules/package-lock.json
@@ -12,7 +12,7 @@
         "native-hello-world": "^2.0.0"
       },
       "devDependencies": {
-        "@vercel/webpack-asset-relocator-loader": "1.7.3",
+        "@vercel/webpack-asset-relocator-loader": "1.7.0",
         "electron": "^33.3.1"
       }
     },
@@ -126,14 +126,11 @@
       }
     },
     "node_modules/@vercel/webpack-asset-relocator-loader": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.7.3.tgz",
-      "integrity": "sha512-vizrI18v8Lcb1PmNNUBz7yxPxxXoOeuaVEjTG9MjvDrphjiSxFZrRJ5tIghk+qdLFRCXI5HBCshgobftbmrC5g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.7.0.tgz",
+      "integrity": "sha512-1Dy3BdOliDwxA7VZSIg55E1d/us2KvsCQOZV25fgufG//CsnZBGiSAL7qewTQf7YVHH0A9PHgzwMmKIZ8aFYVw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve": "^1.10.0"
-      }
+      "license": "MIT"
     },
     "node_modules/bindings": {
       "version": "1.5.0",
@@ -443,16 +440,6 @@
         "node": ">=6 <7 || >=8"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-stream": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
@@ -581,19 +568,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
@@ -613,22 +587,6 @@
       },
       "engines": {
         "node": ">=10.19.0"
-      }
-    },
-    "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/json-buffer": {
@@ -764,13 +722,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -810,27 +761,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-alpn": {
@@ -926,19 +856,6 @@
       },
       "engines": {
         "node": ">= 8.0"
-      }
-    },
-    "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/type-fest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8822,6 +8822,11 @@ jest-worker@^27.4.5:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
+jiti@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.4.2.tgz#d19b7732ebb6116b06e2038da74a55366faef560"
+  integrity sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==
+
 jju@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"


### PR DESCRIPTION
Fixes https://github.com/electron/forge/issues/3872 Fixes https://github.com/electron/forge/issues/3676 Fixes https://github.com/electron/forge/issues/3609 Fixes https://github.com/electron/forge/issues/3780 Fixes https://github.com/electron/forge/issues/3671

Closes #3881

## Problem statement

#3872 reported that TypeScript configurations stopped working in Node 23.6, which is the first version where [type stripping](https://nodejs.org/api/typescript.html#type-stripping) in Node.js is available unflagged.

Simply using a `forge.config.ts` file fails to load with Node v23.6 and above, which indicates some sort of failure in our existing TS config toolchain.


<details>
<summary><b>How does `forge.config.ts` get loaded?</b></summary>
#2993 added support for arbitrary non-JavaScript configuration files using Gulp's `interpret` and `rechoir` modules.

Given a list of file extensions supported by `interpret`, `rechoir` registers that extension's module loader with Node.js.

For most use-cases, this would load the `forge.config.ts` config file with `ts-node`, although any supported Interpret module loader would work (e.g. CoffeeScript, YAML, etc.)
</details>

## Solution

This PR uses `jiti` to load TypeScript Forge configurations. `jiti` is used by [a lot of existing libraries](https://github.com/unjs/jiti?tab=readme-ov-file#-used-in).

The code change is lightweight because we can use `jiti.import` as a drop-in replacement for Node's default dynamic module import.

## Alternatives considered

### `tsx`

This PR supersedes #3881, which was my attempt at using `tsx`'s programmatic API to register itself as a module loader for both CJS and ESM TypeScript config files.

The `tsx` approach didn't work because we had to unregister the module loader after the config was done loading, which caused issues if a user would `await import` any code within a Forge hook (thanks @MarshallOfSound for pointing that out).

### Using Node.js type stripping directly

I tried using type stripping directly, but found that it was non-trivial to enable due it not considering `tsconfig.json` at all and just converting the `forge.config.ts` to `forge.config.js` without additional transpilation (e.g. any `import` statements remain `import` statements in the JS output).

With `require(esm)` in Node 22.12, it becomes _possible_, but requires us to diverge how our configs are written for Node 22.12 vs prior versions.



