### PR TITLE
test(plugin-fuses): use local build for tests

### DIFF
--- a/packages/api/core/src/api/init-scripts/init-link.ts
+++ b/packages/api/core/src/api/init-scripts/init-link.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import path from 'node:path';
 
 import { PMDetails, spawnPackageManager } from '@electron-forge/core-utils';
@@ -34,6 +35,7 @@ export async function initLink<T>(pm: PMDetails, dir: string, task?: ForgeListrT
         });
       }
     }
+    await fs.promises.chmod(path.resolve(dir, 'node_modules', '.bin', 'electron-forge'), 0o755);
   } else {
     d('LINK_FORGE_DEPENDENCIES_ON_INIT is falsy. Skipping.');
   }

--- a/packages/plugin/fuses/spec/FusesPlugin.slow.spec.ts
+++ b/packages/plugin/fuses/spec/FusesPlugin.slow.spec.ts
@@ -1,9 +1,11 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { PACKAGE_MANAGERS, spawnPackageManager } from '@electron-forge/core-utils';
 import { CrossSpawnOptions, spawn } from '@malept/cross-spawn-promise';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { initLink } from '../../../api/core/src/api/init-scripts/init-link';
 import { getElectronExecutablePath } from '../src/util/getElectronExecutablePath';
 
 describe('FusesPlugin', () => {
@@ -25,9 +27,17 @@ describe('FusesPlugin', () => {
   const outDir = path.join(appPath, 'out', 'fuses-test-app');
 
   beforeAll(async () => {
+    await spawnPackageManager(PACKAGE_MANAGERS['yarn'], ['run', 'link:prepare']);
     delete process.env.TS_NODE_PROJECT;
     await fs.promises.copyFile(path.join(appPath, 'package.json.tmpl'), path.join(appPath, 'package.json'));
     await spawn('yarn', ['install'], spawnOptions);
+
+    // Installing deps removes symlinks that were added at the start of this
+    // spec via `api.init`. So we should re-link local forge dependencies
+    // again.
+    process.env.LINK_FORGE_DEPENDENCIES_ON_INIT = '1';
+    await initLink(PACKAGE_MANAGERS['yarn'], appPath);
+    delete process.env.LINK_FORGE_DEPENDENCIES_ON_INIT;
   });
 
   afterAll(async () => {


### PR DESCRIPTION
Split off from https://github.com/electron/forge/pull/3881

Makes `FusesPlugin.slow.spec.ts` use the local build of Forge instead of the production version of Forge.