### PR TITLE
ci(stale): use `any-of-labels`

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          only-labels: 'blocked/needs-info,blocked/needs-repro'
+          any-of-labels: 'blocked/needs-info,blocked/needs-repro'
           labels-to-remove-when-unstale: 'blocked/needs-info,blocked/needs-repro'
           days-before-pr-stale: 9001 # good luck to whoever leaves their PR up for 25 years


### PR DESCRIPTION
This action wasn't working because I had `only-labels` (AND) with two mutually exclusive labels. We instead want [`any-of-labels`](https://github.com/actions/stale?tab=readme-ov-file#any-of-labels), which is an OR operation.