### PR TITLE
fix: add electron-winstaller in onlyBuiltDependencies

### DIFF
--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -108,7 +108,7 @@ export class BaseTemplate implements ForgeTemplate {
     // As of pnpm v10, no postinstall scripts will run unless allowlisted through `onlyBuiltDependencies`
     if (pm.executable === 'pnpm') {
       packageJSON.pnpm = {
-        onlyBuiltDependencies: ['electron', "electron-winstaller"],
+        onlyBuiltDependencies: ['electron', 'electron-winstaller'],
       };
     }
 

--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -108,7 +108,7 @@ export class BaseTemplate implements ForgeTemplate {
     // As of pnpm v10, no postinstall scripts will run unless allowlisted through `onlyBuiltDependencies`
     if (pm.executable === 'pnpm') {
       packageJSON.pnpm = {
-        onlyBuiltDependencies: ['electron'],
+        onlyBuiltDependencies: ['electron', "electron-winstaller"],
       };
     }
 


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Add `electron-winstaller` in `onlyBuiltDependencies` when using pnpm.

Related issue: https://github.com/electron/forge/issues/3892 https://github.com/electron/forge/issues/3900

There are also some issues related in **Squirrel.Windows**: https://github.com/Squirrel/Squirrel.Windows/issues/1715, indicating that the same error will occur when using Chinese characters in the path. Maybe we could also mention it in the doc?
