### PR TITLE
build(deps): update node-abi to latest 3.x

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10223,9 +10223,9 @@ no-case@^3.0.4:
     tslib "^2.0.3"
 
 node-abi@^3.45.0:
-  version "3.74.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.74.0.tgz#5bfb4424264eaeb91432d2adb9da23c63a301ed0"
-  integrity sha512-c5XK0MjkGBrQPGYG24GBADZud0NCbznxNx0ZkS+ebUTrmV1qTDxPxSL8zEAPURXSbLRWVexxmP4986BziahL5w==
+  version "3.75.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.75.0.tgz#2f929a91a90a0d02b325c43731314802357ed764"
+  integrity sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==
   dependencies:
     semver "^7.3.5"
 


### PR DESCRIPTION
The lack of support for Electron 36 in the lockfile's `node-abi` file breaks our integration tests in CI, I believe.

I think this will get the pipeline back up. As an alternative, we should look into pinning the Electron version installed when we initialize a Forge app in testing so that we have a more reproducible environment.