### PR TITLE
fix: remove unused `ts-node` in template

### DIFF
--- a/packages/template/vite-typescript/tmpl/package.json
+++ b/packages/template/vite-typescript/tmpl/package.json
@@ -6,7 +6,6 @@
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^8.0.1",
     "eslint-plugin-import": "^2.25.0",
-    "ts-node": "^10.0.0",
     "typescript": "~4.5.4",
     "vite": "^5.0.12"
   }

--- a/packages/template/webpack-typescript/tmpl/package.json
+++ b/packages/template/webpack-typescript/tmpl/package.json
@@ -11,7 +11,6 @@
     "node-loader": "^2.0.0",
     "style-loader": "^3.0.0",
     "ts-loader": "^9.2.2",
-    "ts-node": "^10.0.0",
     "typescript": "~4.5.4"
   }
 }


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
Please check off all of the steps as they are completed by replacing [ ] with [x].
-->

- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Remove ts-node as we don't need it