### PR TITLE
ci: disable macOS x64 configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,6 +190,8 @@ workflows:
                 arch: arm64
               - executor: node/linux
                 arch: arm64
+              - executor: node/macos
+                arch: x64
       - slow-tests:
           requires:
             - lint-and-build
@@ -202,3 +204,5 @@ workflows:
                 arch: arm64
               - executor: linux-medium-plus
                 arch: arm64
+              - executor: node/macos
+                arch: x64


### PR DESCRIPTION
It looks like we're running arm64 anyways:

* https://app.circleci.com/pipelines/github/electron/forge/1901/workflows/a9ac5744-2093-4f9a-9735-b16b073e68a6/jobs/13757/parallel-runs/0/steps/0-106
* https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718