### PR TITLE
fix: hide promises from promisify

### DIFF
--- a/packages/api/core/src/api/package.ts
+++ b/packages/api/core/src/api/package.ts
@@ -37,13 +37,19 @@ type DoneFunction = (err?: Error) => void;
 type PromisifiedHookFunction = (buildPath: string, electronVersion: string, platform: string, arch: string) => Promise<void>;
 type PromisifiedFinalizePackageTargetsHookFunction = (targets: TargetDefinition[]) => Promise<void>;
 
+function hidePromiseFromPromisfy<P extends unknown[]>(fn: (...args: P) => Promise<void>): (...args: P) => void {
+  return (...args: P) => {
+    void fn(...args);
+  };
+}
+
 /**
  * Runs given hooks sequentially by mapping them to promises and iterating
  * through while awaiting
  */
 function sequentialHooks(hooks: HookFunction[]): PromisifiedHookFunction[] {
   return [
-    async (buildPath: string, electronVersion: string, platform: string, arch: string, done: DoneFunction) => {
+    hidePromiseFromPromisfy(async (buildPath: string, electronVersion: string, platform: string, arch: string, done: DoneFunction) => {
       for (const hook of hooks) {
         try {
           await promisify(hook)(buildPath, electronVersion, platform, arch);
@@ -53,12 +59,12 @@ function sequentialHooks(hooks: HookFunction[]): PromisifiedHookFunction[] {
         }
       }
       done();
-    },
+    }),
   ] as PromisifiedHookFunction[];
 }
 function sequentialFinalizePackageTargetsHooks(hooks: FinalizePackageTargetsHookFunction[]): PromisifiedFinalizePackageTargetsHookFunction[] {
   return [
-    async (targets: TargetDefinition[], done: DoneFunction) => {
+    hidePromiseFromPromisfy(async (targets: TargetDefinition[], done: DoneFunction) => {
       for (const hook of hooks) {
         try {
           await promisify(hook)(targets);
@@ -67,7 +73,7 @@ function sequentialFinalizePackageTargetsHooks(hooks: FinalizePackageTargetsHook
         }
       }
       done();
-    },
+    }),
   ] as PromisifiedFinalizePackageTargetsHookFunction[];
 }
 
@@ -227,22 +233,22 @@ export const listrPackage = (
             const pruneEnabled = !('prune' in forgeConfig.packagerConfig) || forgeConfig.packagerConfig.prune;
 
             const afterCopyHooks: HookFunction[] = [
-              async (buildPath, electronVersion, platform, arch, done) => {
+              hidePromiseFromPromisfy(async (buildPath, electronVersion, platform, arch, done) => {
                 signalDone(signalCopyDone, { platform, arch });
                 done();
-              },
-              async (buildPath, electronVersion, pPlatform, pArch, done) => {
+              }),
+              hidePromiseFromPromisfy(async (buildPath, electronVersion, pPlatform, pArch, done) => {
                 const bins = await glob(path.join(buildPath, '**/.bin/**/*'));
                 for (const bin of bins) {
                   await fs.remove(bin);
                 }
                 done();
-              },
-              async (buildPath, electronVersion, pPlatform, pArch, done) => {
+              }),
+              hidePromiseFromPromisfy(async (buildPath, electronVersion, pPlatform, pArch, done) => {
                 await runHook(forgeConfig, 'packageAfterCopy', buildPath, electronVersion, pPlatform, pArch);
                 done();
-              },
-              async (buildPath, electronVersion, pPlatform, pArch, done) => {
+              }),
+              hidePromiseFromPromisfy(async (buildPath, electronVersion, pPlatform, pArch, done) => {
                 const targetKey = getTargetKey({ platform: pPlatform, arch: pArch });
                 await listrCompatibleRebuildHook(
                   buildPath,
@@ -255,23 +261,23 @@ export const listrPackage = (
                 );
                 signalRebuildDone.get(targetKey)?.pop()?.();
                 done();
-              },
-              async (buildPath, electronVersion, pPlatform, pArch, done) => {
+              }),
+              hidePromiseFromPromisfy(async (buildPath, electronVersion, pPlatform, pArch, done) => {
                 const copiedPackageJSON = await readMutatedPackageJson(buildPath, forgeConfig);
                 if (copiedPackageJSON.config && copiedPackageJSON.config.forge) {
                   delete copiedPackageJSON.config.forge;
                 }
                 await fs.writeJson(path.resolve(buildPath, 'package.json'), copiedPackageJSON, { spaces: 2 });
                 done();
-              },
+              }),
               ...(await resolveHooks(forgeConfig.packagerConfig.afterCopy, ctx.dir)),
             ];
 
             const afterCompleteHooks: HookFunction[] = [
-              async (buildPath, electronVersion, pPlatform, pArch, done) => {
+              hidePromiseFromPromisfy(async (buildPath, electronVersion, pPlatform, pArch, done) => {
                 signalPackageDone.get(getTargetKey({ platform: pPlatform, arch: pArch }))?.pop()?.();
                 done();
-              },
+              }),
               ...(await resolveHooks(forgeConfig.packagerConfig.afterComplete, ctx.dir)),
             ];
 
@@ -281,13 +287,15 @@ export const listrPackage = (
               afterPruneHooks.push(...(await resolveHooks(forgeConfig.packagerConfig.afterPrune, ctx.dir)));
             }
 
-            afterPruneHooks.push((async (buildPath, electronVersion, pPlatform, pArch, done) => {
-              await runHook(forgeConfig, 'packageAfterPrune', buildPath, electronVersion, pPlatform, pArch);
-              done();
-            }) as HookFunction);
+            afterPruneHooks.push(
+              hidePromiseFromPromisfy(async (buildPath, electronVersion, pPlatform, pArch, done) => {
+                await runHook(forgeConfig, 'packageAfterPrune', buildPath, electronVersion, pPlatform, pArch);
+                done();
+              }) as HookFunction
+            );
 
             const afterExtractHooks = [
-              (async (buildPath, electronVersion, pPlatform, pArch, done) => {
+              hidePromiseFromPromisfy(async (buildPath, electronVersion, pPlatform, pArch, done) => {
                 await runHook(forgeConfig, 'packageAfterExtract', buildPath, electronVersion, pPlatform, pArch);
                 done();
               }) as HookFunction,


### PR DESCRIPTION
Takes function, wraps function, hides return value.

Get's rid of these deprecation warnings:
```
(node:7781) [DEP0174] DeprecationWarning: Calling promisify on a function that returns a Promise is likely a mistake.
    at node:internal/util:473:17
    at new Promise (<anonymous>)
    at AsyncFunction.<anonymous> (node:internal/util:458:12)
    at /Users/.../app/node_modules/@electron/packager/dist/hooks.js:9:73
    at Array.map (<anonymous>)
    at promisifyHooks (/Users/.../app/node_modules/@electron/packager/dist/hooks.js:9:29)
    at MacApp.copyTemplate (/Users/.../app/node_modules/@electron/packager/dist/platform.js:137:46)
    at async MacApp.buildApp (/Users/.../app/node_modules/@electron/packager/dist/platform.js:125:9)
    at async MacApp.initialize (/Users/.../app/node_modules/@electron/packager/dist/platform.js:120:13)
    at async MacApp.create (/Users/.../app/node_modules/@electron/packager/dist/mac.js:321:9)
    at async Promise.all (index 0)
    at async packager (/Users/.../app/node_modules/@electron/packager/dist/packager.js:237:22)
```

Closes https://github.com/electron/forge/issues/3828