### PR TITLE
fix(plugin-vite): only copy `/public` in the renderer

### DIFF
--- a/packages/plugin/vite/src/config/vite.main.config.ts
+++ b/packages/plugin/vite/src/config/vite.main.config.ts
@@ -7,6 +7,7 @@ export function getConfig(forgeEnv: ConfigEnv<'build'>, userConfig: UserConfig =
   const define = getBuildDefine(forgeEnv);
   const config: UserConfig = {
     build: {
+      copyPublicDir: false,
       rollupOptions: {
         external,
       },

--- a/packages/plugin/vite/src/config/vite.preload.config.ts
+++ b/packages/plugin/vite/src/config/vite.preload.config.ts
@@ -6,6 +6,7 @@ export function getConfig(forgeEnv: ConfigEnv<'build'>, userConfig: UserConfig =
   const { forgeConfigSelf } = forgeEnv;
   const config: UserConfig = {
     build: {
+      copyPublicDir: false,
       rollupOptions: {
         external,
         // Preload scripts may contain Web assets, so use the `build.rollupOptions.input` instead `build.lib.entry`.

--- a/packages/plugin/vite/src/config/vite.renderer.config.ts
+++ b/packages/plugin/vite/src/config/vite.renderer.config.ts
@@ -12,6 +12,7 @@ export function getConfig(forgeEnv: ConfigEnv<'renderer'>, userConfig: UserConfi
     mode,
     base: './',
     build: {
+      copyPublicDir: true,
       outDir: `.vite/renderer/${name}`,
     },
     plugins: [pluginExposeRenderer(name)],


### PR DESCRIPTION
Not sure if this should count as a breaking change, but the default setting should be to use `/public` for web/renderer content.

As it is, the public dir in Vite gets duplicated in the output build.