### PR TITLE
fix(plugin-fuses): only use fuses v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "xterm-addon-search": "^0.8.0"
   },
   "devDependencies": {
-    "@electron/fuses": ">=1.0.0",
+    "@electron/fuses": "^1.0.0",
     "@electron/lint-roller": "1.10.1",
     "@types/cross-spawn": "^6.0.1",
     "@types/debug": "^4.1.5",
@@ -139,7 +139,7 @@
     "electron-wix-msi": "^5.1.3"
   },
   "peerDependencies": {
-    "@electron/fuses": ">=1.0.0"
+    "@electron/fuses": "^1.0.0"
   },
   "lint-staged": {
     "*.{html,json,md,yml}": "prettier --write",

--- a/packages/api/core/src/api/init-scripts/init-npm.ts
+++ b/packages/api/core/src/api/init-scripts/init-npm.ts
@@ -16,7 +16,7 @@ export function siblingDep(name: string): string {
 
 export const deps = ['electron-squirrel-startup'];
 export const devDeps = [
-  '@electron/fuses',
+  '@electron/fuses@^1.0.0',
   siblingDep('cli'),
   siblingDep('maker-squirrel'),
   siblingDep('maker-zip'),

--- a/packages/plugin/fuses/package.json
+++ b/packages/plugin/fuses/package.json
@@ -14,12 +14,12 @@
   ],
   "typings": "dist/FusesPlugin.d.ts",
   "devDependencies": {
-    "@electron/fuses": ">=1.0.0",
+    "@electron/fuses": "^1.0.0",
     "@malept/cross-spawn-promise": "^2.0.0",
     "xvfb-maybe": "^0.2.1"
   },
   "peerDependencies": {
-    "@electron/fuses": ">=1.0.0"
+    "@electron/fuses": "^1.0.0"
   },
   "engines": {
     "node": ">= 16.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -867,10 +867,10 @@
     glob "^7.1.6"
     minimatch "^3.0.4"
 
-"@electron/fuses@>=1.0.0":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@electron/fuses/-/fuses-1.6.1.tgz#c639e018202a59e3cd8911fa943e22c63dd3e6fc"
-  integrity sha512-J7kRMlc0vP03uzUuhHNEqffqZMZ6FRe0YGMOJO4kJObmYkOg38mMTvbbktEj+oteH5nfyhbQUkHIYnMSh7T/CQ==
+"@electron/fuses@^1.0.0":
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/@electron/fuses/-/fuses-1.8.0.tgz#ad34d3cc4703b1258b83f6989917052cfc1490a0"
+  integrity sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==
   dependencies:
     chalk "^4.1.1"
     fs-extra "^9.0.1"


### PR DESCRIPTION
The `>=1.0.0` version range we had for the Fuses plugin broke installing the base template if you're on Node < 22.12 because we released a new SemVer major version that only supports Node 22.