### PR TITLE
fix: wait for previous app to exit before restarting

### DIFF
--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -238,15 +238,17 @@ export default autoTrace(
     };
 
     if (interactive) {
-      process.stdin.on('data', async (data) => {
+      process.stdin.on('data', (data) => {
         if (data.toString().trim() === 'rs' && lastSpawned) {
           readline.moveCursor(process.stdout, 0, -1);
           readline.clearLine(process.stdout, 0);
           readline.cursorTo(process.stdout, 0);
           console.info(`${chalk.green('✔ ')}${chalk.dim('Restarting Electron app')}`);
           lastSpawned.restarted = true;
+          lastSpawned.on('exit', async () => {
+            lastSpawned!.emit('restarted', await forgeSpawnWrapper());
+          });
           lastSpawned.kill('SIGTERM');
-          lastSpawned.emit('restarted', await forgeSpawnWrapper());
         }
       });
       process.stdin.resume();


### PR DESCRIPTION
Some apps take a while to exit and spawning two of them at the same time can cause weird issues, so this ensures we don't start App 2 until App 1 has fully exit'ed.