### PR TITLE
chore: add `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Prettier 3.6 (https://github.com/electron/forge/pull/3977)
+717faf963b103b55f7041dc26e4fd825215aaf1d


### PR DESCRIPTION
Adds https://github.com/electron/forge/pull/3977 to [`.git-blame-ignore-revs`](https://github.blog/changelog/2022-03-23-ignore-commits-in-the-blame-view-beta/) to avoid polluting the blame with large formatting changes.