### PR TITLE
test: increase test timeout

### DIFF
--- a/vitest.workspace.mts
+++ b/vitest.workspace.mts
@@ -14,8 +14,8 @@ export default defineWorkspace([
     test: {
       include: ['**/spec/**/*.slow.spec.ts'],
       name: 'slow',
-      hookTimeout: 120000,
-      testTimeout: 120000,
+      hookTimeout: 160000,
+      testTimeout: 160000,
     },
   },
 ]);


### PR DESCRIPTION
We get somewhat frequent flakes in the test due to the 120s timeout for slow tests since they might initialize and package a full app. Let's bump that up to try to fix that.