### PR TITLE
ci: add tests to merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
   pull_request:
+  merge_group:
+    types: [checks_requested]
 
 env:
   NODE_VERSION: 20.17.0


### PR DESCRIPTION
> If your repository uses GitHub Actions to perform required checks on pull requests in your repository, you need to update the workflows to include the merge_group event as an additional trigger. Otherwise, status checks will not be triggered when you add a pull request to a merge queue. The merge will fail as the required status check will not be reported. The merge_group event is separate from the pull_request and push events.

ref https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#merge_group