### PR TITLE
fix(template-base): add `.yml` extension to `.yarnrc`

### DIFF
--- a/packages/api/cli/spec/util/check-system.spec.ts
+++ b/packages/api/cli/spec/util/check-system.spec.ts
@@ -104,7 +104,7 @@ describe('checkPackageManager', () => {
       }
     });
     await expect(checkPackageManager()).rejects.toThrow(
-      'When using Yarn 2+, `nodeLinker` must be set to "node-modules". Run `yarn config set nodeLinker node-modules` to set this config value, or add it to your project\'s `.yarnrc` file.',
+      'When using Yarn 2+, `nodeLinker` must be set to "node-modules". Run `yarn config set nodeLinker node-modules` to set this config value, or add it to your project\'s `.yarnrc.yml` file.',
     );
   });
 

--- a/packages/api/cli/src/util/check-system.ts
+++ b/packages/api/cli/src/util/check-system.ts
@@ -82,7 +82,7 @@ async function checkYarnConfig() {
     nodeLinker !== 'node-modules'
   ) {
     throw new Error(
-      'When using Yarn 2+, `nodeLinker` must be set to "node-modules". Run `yarn config set nodeLinker node-modules` to set this config value, or add it to your project\'s `.yarnrc` file.',
+      'When using Yarn 2+, `nodeLinker` must be set to "node-modules". Run `yarn config set nodeLinker node-modules` to set this config value, or add it to your project\'s `.yarnrc.yml` file.',
     );
   }
 }

--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -78,7 +78,7 @@ export class BaseTemplate implements ForgeTemplate {
             pm.version &&
             semver.gte(pm.version, '2.0.0')
           ) {
-            rootFiles.push('_yarnrc');
+            rootFiles.push('_yarnrc.yml');
           }
 
           if (copyCIFiles) {

--- a/packages/template/base/tmpl/_yarnrc
+++ b/packages/template/base/tmpl/_yarnrc
@@ -1,1 +1,0 @@
-nodeLinker: node-modules

--- a/packages/template/base/tmpl/_yarnrc.yml
+++ b/packages/template/base/tmpl/_yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules


### PR DESCRIPTION
I forgot to RTFM:

> Starting from the v2, they must be written in valid Yaml and have the right extension (simply calling your file .yarnrc won't do).

https://yarnpkg.com/configuration/yarnrc