### PR TITLE
build: ignore fixture package.json in socket

### DIFF
--- a/packages/api/core/spec/fixture/async_forge_config/package.json
+++ b/packages/api/core/spec/fixture/async_forge_config/package.json
@@ -2,6 +2,7 @@
   "name": "async-test",
   "devDependencies": {
     "electron": "^1000.0.0",
+    "@electron/package-does-not-exist": "1.0.0",
     "@electron-forge/cli": "6.0.0",
     "@electron-forge/core": "6.0.0"
   }

--- a/packages/api/core/spec/fixture/forge-config-no-package-json-config/package.json
+++ b/packages/api/core/spec/fixture/forge-config-no-package-json-config/package.json
@@ -2,6 +2,7 @@
   "name": "test",
   "devDependencies": {
     "electron": "^1000.0.0",
+    "@electron/package-does-not-exist": "1.0.0",
     "@electron-forge/cli": "6.0.0"
   }
 }

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,5 @@
+version: 2
+
+projectIgnorePaths:
+  - 'packages/api/core/spec/fixture/async_forge_config'
+  - 'packages/api/core/spec/fixture/forge-config-no-package-json-config'


### PR DESCRIPTION
Also ensures these package.json files can't be resolved / installed even if someone accidentally tries to