### PR TITLE
fix(init): unbreak interactive force check

### DIFF
--- a/packages/api/cli/src/electron-forge-init.ts
+++ b/packages/api/cli/src/electron-forge-init.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs/promises';
+import fs from 'node:fs';
 
 import { api, InitOptions } from '@electron-forge/core';
 import { confirm, select } from '@inquirer/prompts';
@@ -58,7 +58,8 @@ program
 
             if (
               typeof initOpts.dir === 'string' &&
-              (await fs.readdir(initOpts.dir)).length > 0
+              fs.existsSync(initOpts.dir) &&
+              (await fs.promises.readdir(initOpts.dir)).length > 0
             ) {
               const confirmResult = await prompt.run(confirm, {
                 message: `${chalk.cyan(initOpts.dir)} is not empty. Would you like to continue and overwrite existing files?`,


### PR DESCRIPTION
Follow-up to https://github.com/electron/forge/commit/20823ab9768e25c83a602c4d20aa3aa24b406b6e

Trying to use the interactive mode in a folder that _doesn't_ already exist doesn't work, which is very unfortunate. 😅

