### PR TITLE
feat: add `electron-forge bundle` CLI command

### DIFF
--- a/packages/api/cli/src/electron-forge-bundle.ts
+++ b/packages/api/cli/src/electron-forge-bundle.ts
@@ -1,0 +1,35 @@
+import { initializeProxy } from '@electron/get';
+import { api, BundleOptions } from '@electron-forge/core';
+import { program } from 'commander';
+
+import './util/terminate';
+import packageJSON from '../package.json';
+
+import { resolveWorkingDir } from './util/resolve-working-dir';
+
+program
+  .version(packageJSON.version, '-V, --version', 'Output the current version')
+  .helpOption('-h, --help', 'Output usage information')
+  .argument(
+    '[dir]',
+    'Directory to run the command in. (default: current directory)',
+  )
+  .option('-a, --arch [arch]', 'Target build architecture')
+  .option('-p, --platform [platform]', 'Target build platform')
+  .action(async (dir) => {
+    const workingDir = resolveWorkingDir(dir);
+
+    const options = program.opts();
+
+    initializeProxy();
+
+    const bundleOpts: BundleOptions = {
+      dir: workingDir,
+      interactive: true,
+    };
+    if (options.arch) bundleOpts.arch = options.arch;
+    if (options.platform) bundleOpts.platform = options.platform;
+
+    await api.bundle(bundleOpts);
+  })
+  .parse(process.argv);

--- a/packages/api/cli/src/electron-forge.ts
+++ b/packages/api/cli/src/electron-forge.ts
@@ -33,6 +33,10 @@ program
   )
   .command('package', 'Package the current Electron application.')
   .command(
+    'bundle',
+    'Bundle the current Electron application source code for production.',
+  )
+  .command(
     'make',
     'Generate distributables for the current Electron application.',
   )

--- a/packages/api/core/src/api/bundle.ts
+++ b/packages/api/core/src/api/bundle.ts
@@ -1,0 +1,170 @@
+import { getHostArch } from '@electron/get';
+import {
+  ForgeArch,
+  ForgeListrTaskFn,
+  ForgePlatform,
+  ResolvedForgeConfig,
+} from '@electron-forge/shared-types';
+import { autoTrace, delayTraceTillSignal } from '@electron-forge/tracer';
+import chalk from 'chalk';
+import debug from 'debug';
+import { Listr } from 'listr2';
+
+import getForgeConfig from '../util/forge-config';
+import { getHookListrTasks } from '../util/hook';
+import { readMutatedPackageJson } from '../util/read-package-json';
+import resolveDir from '../util/resolve-dir';
+
+const d = debug('electron-forge:bundle');
+
+type BundleContext = {
+  dir: string;
+  forgeConfig: ResolvedForgeConfig;
+  packageJSON: any;
+};
+
+export interface BundleOptions {
+  /**
+   * The path to the app to bundle
+   */
+  dir?: string;
+  /**
+   * Whether to use sensible defaults or prompt the user visually
+   */
+  interactive?: boolean;
+  /**
+   * The target arch
+   */
+  arch?: ForgeArch;
+  /**
+   * The target platform
+   */
+  platform?: ForgePlatform;
+}
+
+export const listrBundle = (
+  childTrace: typeof autoTrace,
+  {
+    dir: providedDir = process.cwd(),
+    interactive = false,
+    arch = getHostArch() as ForgeArch,
+    platform = process.platform as ForgePlatform,
+  }: BundleOptions,
+) => {
+  d('bundling with options', { providedDir, interactive, arch, platform });
+
+  const runner = new Listr<BundleContext>(
+    [
+      {
+        title: 'Preparing to bundle application',
+        task: childTrace<Parameters<ForgeListrTaskFn<BundleContext>>>(
+          { name: 'bundle-prepare', category: '@electron-forge/core' },
+          async (_, ctx) => {
+            const resolvedDir = await resolveDir(providedDir);
+            if (!resolvedDir) {
+              throw new Error(
+                'Failed to locate compilable Electron application',
+              );
+            }
+            ctx.dir = resolvedDir;
+
+            ctx.forgeConfig = await getForgeConfig(resolvedDir);
+            ctx.packageJSON = await readMutatedPackageJson(
+              resolvedDir,
+              ctx.forgeConfig,
+            );
+
+            if (!ctx.packageJSON.main) {
+              throw new Error(
+                'packageJSON.main must be set to a valid entry point for your Electron app',
+              );
+            }
+          },
+        ),
+      },
+      {
+        title: 'Running bundling hooks',
+        task: childTrace<Parameters<ForgeListrTaskFn<BundleContext>>>(
+          { name: 'run-bundling-hooks', category: '@electron-forge/core' },
+          async (childTrace, { forgeConfig }, task) => {
+            return delayTraceTillSignal(
+              childTrace,
+              task.newListr([
+                {
+                  title: `Running ${chalk.yellow('generateAssets')} hook`,
+                  task: childTrace<Parameters<ForgeListrTaskFn>>(
+                    {
+                      name: 'run-generateAssets-hook',
+                      category: '@electron-forge/core',
+                    },
+                    async (childTrace, _, task) => {
+                      return delayTraceTillSignal(
+                        childTrace,
+                        task.newListr(
+                          await getHookListrTasks(
+                            childTrace,
+                            forgeConfig,
+                            'generateAssets',
+                            platform,
+                            arch,
+                          ),
+                        ),
+                        'run',
+                      );
+                    },
+                  ),
+                },
+                {
+                  title: `Running ${chalk.yellow('prePackage')} hook`,
+                  task: childTrace<Parameters<ForgeListrTaskFn>>(
+                    {
+                      name: 'run-prePackage-hook',
+                      category: '@electron-forge/core',
+                    },
+                    async (childTrace, _, task) => {
+                      return delayTraceTillSignal(
+                        childTrace,
+                        task.newListr(
+                          await getHookListrTasks(
+                            childTrace,
+                            forgeConfig,
+                            'prePackage',
+                            platform,
+                            arch,
+                          ),
+                        ),
+                        'run',
+                      );
+                    },
+                  ),
+                },
+              ]),
+              'run',
+            );
+          },
+        ),
+      },
+    ],
+    {
+      concurrent: false,
+      silentRendererCondition: !interactive,
+      fallbackRendererCondition:
+        Boolean(process.env.DEBUG) || Boolean(process.env.CI),
+      rendererOptions: {
+        collapseSubtasks: false,
+        collapseErrors: false,
+      },
+      ctx: {} as BundleContext,
+    },
+  );
+
+  return runner;
+};
+
+export default autoTrace(
+  { name: 'bundle()', category: '@electron-forge/core' },
+  async (childTrace, opts: BundleOptions): Promise<void> => {
+    const runner = listrBundle(childTrace, opts);
+    await runner.run();
+  },
+);

--- a/packages/api/core/src/api/index.ts
+++ b/packages/api/core/src/api/index.ts
@@ -3,6 +3,7 @@ import { ElectronProcess, ForgeMakeResult } from '@electron-forge/shared-types';
 // eslint-disable-next-line n/no-missing-import
 import ForgeUtils from '../util';
 
+import bundle, { BundleOptions } from './bundle';
 import _import, { ImportOptions } from './import';
 import init, { InitOptions } from './init';
 import make, { MakeOptions } from './make';
@@ -11,6 +12,15 @@ import publish, { PublishOptions } from './publish';
 import start, { StartOptions } from './start';
 
 export class ForgeAPI {
+  /**
+   * Bundle the current Electron application source code using the configured
+   * bundler plugin (e.g. webpack, vite). Runs generateAssets and prePackage
+   * hooks without running @electron/packager.
+   */
+  bundle(opts: BundleOptions): Promise<void> {
+    return bundle(opts);
+  }
+
   /**
    * Attempt to import a given module directory to the Electron Forge standard.
    *
@@ -63,6 +73,7 @@ const api = new ForgeAPI();
 const utils = new ForgeUtils();
 
 export {
+  BundleOptions,
   ForgeMakeResult,
   ElectronProcess,
   ForgeUtils,

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -666,7 +666,10 @@ the generated files). Instead, it is ${JSON.stringify(pj.main)}`);
         return onceResolve(undefined);
       };
       if (watch) {
-        this.watchers.push(compiler.watch({}, cb));
+        const watcher = compiler.watch({}, cb);
+        if (watcher) {
+          this.watchers.push(watcher);
+        }
       } else {
         compiler.run(cb);
       }


### PR DESCRIPTION
## Motivation

Currently, running a production bundling step (webpack/vite) requires running `electron-forge package`, which also invokes `@electron/packager` to download Electron binaries, copy source files, and produce a native app bundle. This is slow and unnecessary when you only need the bundled output — for example:

- **E2E testing with Playwright**: Run production bundles via `electron .` to test against realistic builds, without the overhead of full packaging.
- **Bundle validation in CI**: Quickly verify that the webpack/vite production build doesn't break, without downloading Electron binaries.
- **Custom packaging pipelines**: Produce bundle output to feed into external packaging tools.

## Summary

Add a standalone `bundle` command that runs only the bundling step (`generateAssets` + `prePackage` hooks) without invoking `@electron/packager`.

```bash
electron-forge bundle
electron-forge bundle --arch x64
electron-forge bundle --platform darwin --arch arm64
```

## Open questions

### 1. Should the command include a post-bundling cleanup step?

The webpack plugin's `prePackage` hook moves build output from `.webpack/` into `.webpack/{arch}/` (e.g. `.webpack/x64/main/`). This is designed so `@electron/packager` can copy all arch builds at once and later extract the correct one per target via `packageAfterCopy`.

Without the packager, the output stays at `.webpack/{arch}/main/`, which doesn't match `package.json`'s `main: ".webpack/main"` — so `electron .` won't work directly after `bundle`.

**Options:**
- **(a)** Leave as-is — `bundle` only runs the hooks, users handle the output structure themselves
- **(b)** Add a `postBundle` hook so plugins can clean up their own output (e.g. flatten `.webpack/{arch}/` → `.webpack/`), keeping plugin internals encapsulated
- **(c)** Have `bundle` invoke `packageAfterCopy` — but this hook is designed for a different context (packager's copied build path, not the source project)

### 2. Does the `{arch}` subfolder strategy make sense for `bundle`?

The `{arch}/` subfolder pattern in the webpack plugin was designed for multi-arch packaging where all arches coexist before the packager copies them out. For `bundle` (especially for e2e testing on the current machine), this intermediate structure adds complexity. However, changing `prePackage` behavior based on the calling context would require plumbing new information through the hook system.

### 3. Should `--arch` and `--platform` be kept?

These flags are passed through to `prePackage` and behave identically to `package`. For the primary use case (e2e testing), only the host arch is needed. Removing them would simplify the command but break consistency with other commands (`package`, `make`).

## Test plan

- [ ] Verify `electron-forge bundle` runs `generateAssets` + `prePackage` hooks with webpack plugin
- [ ] Verify `electron-forge bundle` runs `generateAssets` + `prePackage` hooks with vite plugin
- [ ] Verify `--arch` and `--platform` flags are passed through correctly
- [ ] Verify bundle output structure matches expectations

---

- [ ] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [ ] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [ ] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)