### PR TITLE
feat(plugin-vite): enable main process hot restart via exported API

### DIFF
--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -4,6 +4,7 @@ import readline from 'node:readline';
 import {
   getElectronVersion,
   listrCompatibleRebuildHook,
+  onAppRestart,
 } from '@electron-forge/core-utils';
 import {
   ElectronProcess,
@@ -289,6 +290,19 @@ export default autoTrace(
       lastSpawned = spawned;
       return lastSpawned;
     };
+
+    onAppRestart(() => {
+      if (lastSpawned && !lastSpawned.restarted) {
+        console.info(
+          `${chalk.green('✔ ')}${chalk.dim('Restarting Electron app')}`,
+        );
+        lastSpawned.restarted = true;
+        lastSpawned.on('exit', async () => {
+          lastSpawned!.emit('restarted', await forgeSpawnWrapper());
+        });
+        lastSpawned.kill('SIGTERM');
+      }
+    });
 
     if (interactive) {
       process.stdin.on('data', (data) => {

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -307,7 +307,7 @@ export default autoTrace(
 
     if (interactive) {
       process.stdin.on('data', (data) => {
-        if (data.toString().trim() === 'rs') {
+        if (data.toString().trim() === 'rs' && lastSpawned) {
           readline.moveCursor(process.stdout, 0, -1);
           readline.clearLine(process.stdout, 0);
           readline.cursorTo(process.stdout, 0);

--- a/packages/api/core/src/api/start.ts
+++ b/packages/api/core/src/api/start.ts
@@ -5,6 +5,7 @@ import {
   getElectronVersion,
   listrCompatibleRebuildHook,
   onAppRestart,
+  restartApp,
 } from '@electron-forge/core-utils';
 import {
   ElectronProcess,
@@ -306,22 +307,11 @@ export default autoTrace(
 
     if (interactive) {
       process.stdin.on('data', (data) => {
-        if (
-          data.toString().trim() === 'rs' &&
-          lastSpawned &&
-          !lastSpawned.restarted
-        ) {
+        if (data.toString().trim() === 'rs') {
           readline.moveCursor(process.stdout, 0, -1);
           readline.clearLine(process.stdout, 0);
           readline.cursorTo(process.stdout, 0);
-          console.info(
-            `${chalk.green('✔ ')}${chalk.dim('Restarting Electron app')}`,
-          );
-          lastSpawned.restarted = true;
-          lastSpawned.on('exit', async () => {
-            lastSpawned!.emit('restarted', await forgeSpawnWrapper());
-          });
-          lastSpawned.kill('SIGTERM');
+          restartApp();
         }
       });
       process.stdin.resume();

--- a/packages/plugin/vite/package.json
+++ b/packages/plugin/vite/package.json
@@ -18,6 +18,7 @@
     "./forge-vite-env": "./forge-vite-env.d.ts"
   },
   "dependencies": {
+    "@electron-forge/core-utils": "workspace:*",
     "@electron-forge/plugin-base": "workspace:*",
     "@electron-forge/shared-types": "workspace:*",
     "chalk": "^4.0.0",

--- a/packages/plugin/vite/spec/ViteConfig.spec.ts
+++ b/packages/plugin/vite/spec/ViteConfig.spec.ts
@@ -21,6 +21,7 @@ describe('ViteConfigGenerator', () => {
         },
       ],
       renderer: [],
+      hotRestart: true,
     };
     const generator = new ViteConfigGenerator(forgeConfig, configRoot, true);
     const buildConfig = (await generator.getBuildConfigs())[0];

--- a/packages/plugin/vite/src/Config.ts
+++ b/packages/plugin/vite/src/Config.ts
@@ -49,4 +49,10 @@ export interface VitePluginConfig {
    * @defaultValue `true`
    */
   concurrent?: boolean | number;
+
+  /**
+   * Enable hot restart for the main process when its bundle is rebuilt.
+   * @defaultValue false
+   */
+  hotRestart?: boolean;
 }

--- a/packages/plugin/vite/src/config/vite.base.config.ts
+++ b/packages/plugin/vite/src/config/vite.base.config.ts
@@ -1,5 +1,7 @@
 import { builtinModules } from 'node:module';
 
+import { restartApp } from '@electron-forge/core-utils';
+
 import type { AddressInfo } from 'node:net';
 import type { ConfigEnv, Plugin, UserConfig, ViteDevServer } from 'vite';
 
@@ -101,10 +103,7 @@ export function pluginHotRestart(command: 'reload' | 'restart'): Plugin {
           server.ws.send({ type: 'full-reload' });
         }
       } else if (command === 'restart') {
-        // Main process hot restart.
-        // https://github.com/electron/forge/blob/v7.2.0/packages/api/core/src/api/start.ts#L216-L223
-        // TODO: blocked in #3380
-        // process.stdin.emit('data', 'rs');
+        restartApp();
       }
     },
   };

--- a/packages/plugin/vite/src/config/vite.main.config.ts
+++ b/packages/plugin/vite/src/config/vite.main.config.ts
@@ -20,7 +20,9 @@ export function getConfig(
         external: [...external, 'electron/main'],
       },
     },
-    plugins: [pluginHotRestart('restart')],
+    plugins: [
+      ...(forgeEnv.forgeConfig.hotRestart ? [pluginHotRestart('restart')] : []),
+    ],
     define,
     resolve: {
       // Load the Node.js entry.

--- a/packages/utils/core-utils/src/index.ts
+++ b/packages/utils/core-utils/src/index.ts
@@ -4,3 +4,4 @@ export * from './package-manager.js';
 export * from './author-name.js';
 export * from './install-dependencies.js';
 export * from './resolve-working-dir.js';
+export * from './restart.js';

--- a/packages/utils/core-utils/src/restart.ts
+++ b/packages/utils/core-utils/src/restart.ts
@@ -1,0 +1,21 @@
+import { EventEmitter } from 'node:events';
+
+const restartEmitter = new EventEmitter();
+
+/**
+ * Signal the running Electron app to restart.
+ * Called by plugins (e.g. Vite) when the main process bundle is rebuilt.
+ */
+export function restartApp(): void {
+  restartEmitter.emit('restart');
+}
+
+/**
+ * Register a listener for app restart signals.
+ * Called by the `start` API to wire up the actual restart logic.
+ * Replaces any previously registered listener to avoid leaks.
+ */
+export function onAppRestart(listener: () => void): void {
+  restartEmitter.removeAllListeners('restart');
+  restartEmitter.on('restart', listener);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1047,6 +1047,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@electron-forge/plugin-vite@workspace:packages/plugin/vite"
   dependencies:
+    "@electron-forge/core-utils": "workspace:*"
     "@electron-forge/plugin-base": "workspace:*"
     "@electron-forge/shared-types": "workspace:*"
     "@electron/packager": "npm:^19.0.1"


### PR DESCRIPTION
## Summary

Replaces #4168 with a clean branch based on `next`.

- Add `restartApp()`/`onAppRestart()` to `@electron-forge/core-utils` as an explicit API for triggering Electron app restarts
- The Vite plugin calls `restartApp()` in its `closeBundle` hook when the main process bundle is rebuilt
- The `start` API registers the actual restart logic via `onAppRestart()`
- The existing `rs` stdin handler also goes through `restartApp()`, so there's a single restart path
- **Hot restart is opt-in** via `hotRestart: true` in the Vite plugin config

## Background

Main process hot restart for the Vite plugin has been requested and attempted multiple times:

- **#3203** — Initial hot-restart PR using `process.stdin.emit('data', 'rs')`
- **#3326** — Follow-up scoped to hot restart only
- **#3380** — Proposed `EventEmitter`-based approach
- **#3583** (merged) — Added `pluginHotRestart('restart')` but left it commented out

This PR implements the approach suggested in #3380 and unblocks the commented-out code in #3583.

## Test plan

- [x] `ViteConfig.spec.ts` tests pass (hot restart plugin only included when `hotRestart: true`)
- [x] `vite.base.config.spec.ts` tests pass
- [x] Manual test: set `hotRestart: true` in Vite plugin config, modify main process code, verify app restarts
- [x] Manual test: without `hotRestart` config, verify no auto-restart on main process changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)