### PR TITLE
feat(vite): support nodeIntegration renderer builds

### DIFF
--- a/packages/plugin/vite/README.md
+++ b/packages/plugin/vite/README.md
@@ -36,3 +36,29 @@ module.exports = {
   ]
 };
 ```
+
+### Node integration in renderer builds
+
+If a renderer `BrowserWindow` enables `nodeIntegration: true`, set the matching
+Forge Vite renderer entry to `nodeIntegration: true` as well. This tells the
+plugin to externalize Electron and Node.js built-ins and resolve packages using
+Node-oriented entry points, avoiding fragile manual Vite configuration.
+
+```javascript
+new VitePlugin({
+  build: [
+    {
+      entry: 'src/main.js',
+      config: 'vite.main.config.mjs',
+      target: 'main',
+    },
+  ],
+  renderer: [
+    {
+      name: 'main_window',
+      config: 'vite.renderer.config.mjs',
+      nodeIntegration: true,
+    },
+  ],
+});
+```

--- a/packages/plugin/vite/spec/ViteConfig.spec.ts
+++ b/packages/plugin/vite/spec/ViteConfig.spec.ts
@@ -117,4 +117,26 @@ describe('ViteConfigGenerator', () => {
     expect(rendererConfig.resolve).toEqual({ preserveSymlinks: true });
     expect(rendererConfig.clearScreen).toBe(false);
   });
+
+  it('getRendererConfig:renderer with nodeIntegration', async () => {
+    const forgeConfig = {
+      build: [],
+      renderer: [
+        {
+          name: 'main_window',
+          config: path.join(configRoot, 'vite.renderer.config.mjs'),
+          nodeIntegration: true,
+        },
+      ],
+    };
+    const generator = new ViteConfigGenerator(forgeConfig, configRoot, true);
+    const rendererConfig = (await generator.getRendererConfig())[0];
+
+    expect(rendererConfig.build?.rollupOptions?.external).toEqual(external);
+    expect(rendererConfig.resolve).toEqual({
+      preserveSymlinks: true,
+      conditions: ['node'],
+      mainFields: ['module', 'jsnext:main', 'jsnext'],
+    });
+  });
 });

--- a/packages/plugin/vite/src/Config.ts
+++ b/packages/plugin/vite/src/Config.ts
@@ -25,6 +25,19 @@ export interface VitePluginRendererConfig {
    * Vite config file path.
    */
   config: string;
+  /**
+   * Override the Vite config for this renderer based on whether `nodeIntegration`
+   * for the `BrowserWindow` is enabled.
+   *
+   * When true, Electron and Node.js built-in modules are externalized and Vite
+   * resolves package entry points using Node-oriented conditions and main fields.
+   *
+   * Unfortunately, Forge cannot derive the value from the main process code as it
+   * can be dynamically generated at run-time, while Vite processes at build-time.
+   *
+   * Defaults to `false` (as it is disabled by default in Electron >= 5).
+   */
+  nodeIntegration?: boolean;
 }
 
 export interface VitePluginConfig {

--- a/packages/plugin/vite/src/config/vite.renderer.config.ts
+++ b/packages/plugin/vite/src/config/vite.renderer.config.ts
@@ -1,6 +1,6 @@
 import { type ConfigEnv, mergeConfig, type UserConfig } from 'vite';
 
-import { pluginExposeRenderer } from './vite.base.config';
+import { external, pluginExposeRenderer } from './vite.base.config';
 
 // https://vitejs.dev/config
 export function getConfig(
@@ -9,6 +9,7 @@ export function getConfig(
 ) {
   const { root, mode, forgeConfigSelf } = forgeEnv;
   const name = forgeConfigSelf.name ?? '';
+  const nodeIntegration = forgeConfigSelf.nodeIntegration ?? false;
 
   const config: UserConfig = {
     root,
@@ -21,7 +22,24 @@ export function getConfig(
     plugins: [pluginExposeRenderer(name)],
     resolve: {
       preserveSymlinks: true,
+      ...(nodeIntegration
+        ? {
+            conditions: ['node'],
+            mainFields: ['module', 'jsnext:main', 'jsnext'],
+          }
+        : {}),
     },
+    ...(nodeIntegration
+      ? {
+          build: {
+            copyPublicDir: true,
+            outDir: `.vite/renderer/${name}`,
+            rollupOptions: {
+              external,
+            },
+          },
+        }
+      : {}),
     clearScreen: false,
   };
 


### PR DESCRIPTION
Refs #3961

## Summary
- add a `nodeIntegration` option to `@electron-forge/plugin-vite` renderer entries
- when enabled, externalize Electron/Node built-ins for renderer builds and resolve packages with Node-oriented conditions/main fields
- document the new renderer option in the Vite plugin README
- add ViteConfig coverage for the default renderer path and the new `nodeIntegration: true` path

## Validation
```text
$ npm exec --yes @yarnpkg/cli-dist@4.10.3 -- prettier --write packages/plugin/vite/src/Config.ts packages/plugin/vite/src/config/vite.renderer.config.ts packages/plugin/vite/spec/ViteConfig.spec.ts packages/plugin/vite/README.md --experimental-cli
# passed

$ npm exec --yes @yarnpkg/cli-dist@4.10.3 -- vitest run --project fast packages/plugin/vite/spec/ViteConfig.spec.ts
Test Files  1 passed (1)
Tests  4 passed (4)

$ npm exec --yes @yarnpkg/cli-dist@4.10.3 -- tsc -b packages/plugin/vite
# passed
```

This PR was prepared with AI assistance and manually reviewed before submission.