### PR TITLE
fix: update Vite dependency in Vite templates

### DIFF
--- a/packages/template/vite-typescript/tmpl/package.json
+++ b/packages/template/vite-typescript/tmpl/package.json
@@ -7,6 +7,6 @@
     "eslint": "^8.0.1",
     "eslint-plugin-import": "^2.25.0",
     "typescript": "~4.5.4",
-    "vite": "^5.0.12"
+    "vite": "^6.4.2"
   }
 }

--- a/packages/template/vite/tmpl/package.json
+++ b/packages/template/vite/tmpl/package.json
@@ -2,6 +2,6 @@
   "devDependencies": {
     "@electron/fuses": "^1.7.0",
     "@electron-forge/plugin-vite": "ELECTRON_FORGE/VERSION",
-    "vite": "^5.0.12"
+    "vite": "^6.4.2"
   }
 }


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Updated the Vite dependency used by the Electron Forge Vite templates.

The existing templates generate projects with an older Vite/esbuild dependency chain. In some corporate environments, older esbuild versions are blocked by security scanners such as JFrog Xray. Updating the template dependency allows newly generated Electron Forge Vite apps to resolve to a newer esbuild version.

This updates:

- `packages/template/vite/tmpl/package.json`
- `packages/template/vite-typescript/tmpl/package.json`

**Validation:**

Validated locally by generating a new Electron Forge Vite TypeScript app from the updated template and confirming that the app installs and runs successfully.

Commands used:

```sh
npm ls vite
npm ls esbuild
npm start