### PR TITLE
feat(core-utils): add subpath exports for individual modules

### DIFF
--- a/packages/api/cli/spec/util/check-system.spec.ts
+++ b/packages/api/cli/spec/util/check-system.spec.ts
@@ -1,19 +1,22 @@
 import {
   resolvePackageManager,
   spawnPackageManager,
-} from '@electron-forge/core-utils';
+} from '@electron-forge/core-utils/package-manager';
 import { describe, expect, it, vi } from 'vitest';
 
 import { checkPackageManager } from '../../src/util/check-system';
 
-vi.mock(import('@electron-forge/core-utils'), async (importOriginal) => {
-  const mod = await importOriginal();
-  return {
-    ...mod,
-    resolvePackageManager: vi.fn(),
-    spawnPackageManager: vi.fn(),
-  };
-});
+vi.mock(
+  import('@electron-forge/core-utils/package-manager'),
+  async (importOriginal) => {
+    const mod = await importOriginal();
+    return {
+      ...mod,
+      resolvePackageManager: vi.fn(),
+      spawnPackageManager: vi.fn(),
+    };
+  },
+);
 
 describe('checkPackageManager', () => {
   it('should consider allowlisted versions to be valid', async () => {

--- a/packages/api/cli/src/electron-forge-make.ts
+++ b/packages/api/cli/src/electron-forge-make.ts
@@ -3,7 +3,7 @@ import { styleText } from 'node:util';
 
 import { initializeProxy } from '@electron/get';
 import { api, MakeOptions } from '@electron-forge/core';
-import { resolveWorkingDir } from '@electron-forge/core-utils';
+import { resolveWorkingDir } from '@electron-forge/core-utils/resolve-working-dir';
 import { program } from 'commander';
 
 import './util/terminate.js';

--- a/packages/api/cli/src/electron-forge-package.ts
+++ b/packages/api/cli/src/electron-forge-package.ts
@@ -1,6 +1,6 @@
 import { initializeProxy } from '@electron/get';
 import { api, PackageOptions } from '@electron-forge/core';
-import { resolveWorkingDir } from '@electron-forge/core-utils';
+import { resolveWorkingDir } from '@electron-forge/core-utils/resolve-working-dir';
 import { program } from 'commander';
 
 import './util/terminate.js';

--- a/packages/api/cli/src/electron-forge-release.ts
+++ b/packages/api/cli/src/electron-forge-release.ts
@@ -3,7 +3,7 @@ import { styleText } from 'node:util';
 
 import { initializeProxy } from '@electron/get';
 import { api, ReleaseOptions } from '@electron-forge/core';
-import { resolveWorkingDir } from '@electron-forge/core-utils';
+import { resolveWorkingDir } from '@electron-forge/core-utils/resolve-working-dir';
 import { program } from 'commander';
 
 import './util/terminate.js';

--- a/packages/api/cli/src/electron-forge-start.ts
+++ b/packages/api/cli/src/electron-forge-start.ts
@@ -1,5 +1,5 @@
 import { api, StartOptions } from '@electron-forge/core';
-import { resolveWorkingDir } from '@electron-forge/core-utils';
+import { resolveWorkingDir } from '@electron-forge/core-utils/resolve-working-dir';
 import { ElectronProcess } from '@electron-forge/shared-types';
 import { Option, program } from 'commander';
 

--- a/packages/api/cli/src/util/check-system.ts
+++ b/packages/api/cli/src/util/check-system.ts
@@ -2,13 +2,13 @@ import { exec } from 'node:child_process';
 import os from 'node:os';
 import path from 'node:path';
 
+import { pathExists } from '@electron-forge/core-utils/fs';
 import {
   PACKAGE_MANAGERS,
-  pathExists,
   resolvePackageManager,
   spawnPackageManager,
   SupportedPackageManager,
-} from '@electron-forge/core-utils';
+} from '@electron-forge/core-utils/package-manager';
 import { ForgeListrTask } from '@electron-forge/shared-types';
 import debug from 'debug';
 import semver from 'semver';

--- a/packages/external/create-electron-app/spec/fast/init-scripts/init-npm.spec.ts
+++ b/packages/external/create-electron-app/spec/fast/init-scripts/init-npm.spec.ts
@@ -2,17 +2,20 @@ import {
   DepType,
   DepVersionRestriction,
   installDependencies,
-  PACKAGE_MANAGERS,
-} from '@electron-forge/core-utils';
+} from '@electron-forge/core-utils/install-dependencies';
+import { PACKAGE_MANAGERS } from '@electron-forge/core-utils/package-manager';
 import { ForgeListrTask } from '@electron-forge/shared-types';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { deps, devDeps, initNPM } from '../../../src/init-scripts/init-npm.js';
 
-vi.mock(import('@electron-forge/core-utils'), async (importOriginal) => ({
-  ...(await importOriginal()),
-  installDependencies: vi.fn(),
-}));
+vi.mock(
+  import('@electron-forge/core-utils/install-dependencies'),
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    installDependencies: vi.fn(),
+  }),
+);
 
 describe('init-npm', () => {
   const mockTask = {

--- a/packages/external/create-electron-app/src/create-electron-app.ts
+++ b/packages/external/create-electron-app/src/create-electron-app.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { styleText } from 'node:util';
 
-import { resolveWorkingDir } from '@electron-forge/core-utils';
+import { resolveWorkingDir } from '@electron-forge/core-utils/resolve-working-dir';
 import { confirm, select } from '@inquirer/prompts';
 import { ListrInquirerPromptAdapter } from '@listr2/prompt-adapter-inquirer';
 import { program } from 'commander';

--- a/packages/external/create-electron-app/src/import.ts
+++ b/packages/external/create-electron-app/src/import.ts
@@ -2,17 +2,17 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { styleText } from 'node:util';
 
+import { updateElectronDependency } from '@electron-forge/core-utils/electron-version';
+import { pathExists, readJson, writeJson } from '@electron-forge/core-utils/fs';
 import {
   DepType,
   DepVersionRestriction,
   installDependencies,
-  pathExists,
+} from '@electron-forge/core-utils/install-dependencies';
+import {
   PMDetails,
-  readJson,
   resolvePackageManager,
-  updateElectronDependency,
-  writeJson,
-} from '@electron-forge/core-utils';
+} from '@electron-forge/core-utils/package-manager';
 import { ForgeListrOptions } from '@electron-forge/shared-types';
 import baseTemplate from '@electron-forge/template-base';
 import debug from 'debug';

--- a/packages/external/create-electron-app/src/init-scripts/init-link.ts
+++ b/packages/external/create-electron-app/src/init-scripts/init-link.ts
@@ -2,7 +2,10 @@ import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { PMDetails, spawnPackageManager } from '@electron-forge/core-utils';
+import {
+  PMDetails,
+  spawnPackageManager,
+} from '@electron-forge/core-utils/package-manager';
 import { ForgeListrTask } from '@electron-forge/shared-types';
 import debug from 'debug';
 

--- a/packages/external/create-electron-app/src/init-scripts/init-npm.ts
+++ b/packages/external/create-electron-app/src/init-scripts/init-npm.ts
@@ -1,12 +1,12 @@
 import path from 'node:path';
 
+import { readJsonSync } from '@electron-forge/core-utils/fs';
 import {
   DepType,
   DepVersionRestriction,
   installDependencies,
-  PMDetails,
-  readJsonSync,
-} from '@electron-forge/core-utils';
+} from '@electron-forge/core-utils/install-dependencies';
+import { PMDetails } from '@electron-forge/core-utils/package-manager';
 import { ForgeListrTask } from '@electron-forge/shared-types';
 import debug from 'debug';
 import semver from 'semver';

--- a/packages/external/create-electron-app/src/init.ts
+++ b/packages/external/create-electron-app/src/init.ts
@@ -6,9 +6,11 @@ import {
   DepType,
   DepVersionRestriction,
   installDependencies,
+} from '@electron-forge/core-utils/install-dependencies';
+import {
   PMDetails,
   resolvePackageManager,
-} from '@electron-forge/core-utils';
+} from '@electron-forge/core-utils/package-manager';
 import { ForgeTemplate } from '@electron-forge/shared-types';
 import { spawn } from '@malept/cross-spawn-promise';
 import debug from 'debug';

--- a/packages/maker/appx/src/MakerAppX.ts
+++ b/packages/maker/appx/src/MakerAppX.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { getNameFromAuthor, pathExists } from '@electron-forge/core-utils';
+import { getNameFromAuthor } from '@electron-forge/core-utils/author-name';
+import { pathExists } from '@electron-forge/core-utils/fs';
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 // eslint-disable-next-line n/no-missing-import

--- a/packages/maker/msix/spec/MakerMSIX.spec.ts
+++ b/packages/maker/msix/spec/MakerMSIX.spec.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { move } from '@electron-forge/core-utils';
+import { move } from '@electron-forge/core-utils/fs';
 import { ForgeArch } from '@electron-forge/shared-types';
 import { packageMSIX } from 'electron-windows-msix';
 import { describe, expect, it, vi } from 'vitest';
@@ -28,7 +28,7 @@ vi.mock(import('node:fs/promises'), async (importOriginal) => {
   };
 });
 
-vi.mock(import('@electron-forge/core-utils'), async (importOriginal) => {
+vi.mock(import('@electron-forge/core-utils/fs'), async (importOriginal) => {
   const mod = await importOriginal();
   return {
     ...mod,

--- a/packages/maker/msix/src/MakerMSIX.ts
+++ b/packages/maker/msix/src/MakerMSIX.ts
@@ -2,7 +2,8 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { getNameFromAuthor, move } from '@electron-forge/core-utils';
+import { getNameFromAuthor } from '@electron-forge/core-utils/author-name';
+import { move } from '@electron-forge/core-utils/fs';
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 import { packageMSIX } from 'electron-windows-msix';

--- a/packages/maker/squirrel/src/MakerSquirrel.ts
+++ b/packages/maker/squirrel/src/MakerSquirrel.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
-import { pathExists } from '@electron-forge/core-utils';
+import { pathExists } from '@electron-forge/core-utils/fs';
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 import {

--- a/packages/maker/wix/src/MakerWix.ts
+++ b/packages/maker/wix/src/MakerWix.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { styleText } from 'node:util';
 
-import { getNameFromAuthor } from '@electron-forge/core-utils';
+import { getNameFromAuthor } from '@electron-forge/core-utils/author-name';
 import { MakerBase, type MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 import { MSICreator, type MSICreatorOptions } from 'electron-wix-msi';

--- a/packages/maker/zip/spec/MakerZip.spec.ts
+++ b/packages/maker/zip/spec/MakerZip.spec.ts
@@ -1,7 +1,7 @@
 import os from 'node:os';
 import path from 'node:path';
 
-import { writeJson } from '@electron-forge/core-utils';
+import { writeJson } from '@electron-forge/core-utils/fs';
 import { ForgeArch } from '@electron-forge/shared-types';
 import { zip } from 'cross-zip';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -20,7 +20,7 @@ vi.mock(import('cross-zip'), async (importOriginal) => {
   };
 });
 
-vi.mock(import('@electron-forge/core-utils'), async (importOriginal) => {
+vi.mock(import('@electron-forge/core-utils/fs'), async (importOriginal) => {
   const mod = await importOriginal();
   return {
     ...mod,

--- a/packages/maker/zip/src/MakerZIP.ts
+++ b/packages/maker/zip/src/MakerZIP.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { promisify } from 'node:util';
 
-import { writeJson } from '@electron-forge/core-utils';
+import { writeJson } from '@electron-forge/core-utils/fs';
 import { MakerBase, MakerOptions } from '@electron-forge/maker-base';
 import { ForgePlatform } from '@electron-forge/shared-types';
 import { zip } from 'cross-zip';

--- a/packages/plugin/vite/src/VitePlugin.ts
+++ b/packages/plugin/vite/src/VitePlugin.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { styleText } from 'node:util';
 
-import { readJson, writeJson } from '@electron-forge/core-utils';
+import { readJson, writeJson } from '@electron-forge/core-utils/fs';
 import { namedHookWithTaskFn, PluginBase } from '@electron-forge/plugin-base';
 import debug from 'debug';
 import { Listr, PRESET_TIMER } from 'listr2';

--- a/packages/plugin/webpack/src/WebpackPlugin.ts
+++ b/packages/plugin/webpack/src/WebpackPlugin.ts
@@ -5,13 +5,9 @@ import path from 'node:path';
 import { styleText } from 'node:util';
 import { pipeline } from 'stream/promises';
 
-import {
-  getElectronVersion,
-  listrCompatibleRebuildHook,
-  move,
-  readJson,
-  writeJson,
-} from '@electron-forge/core-utils';
+import { getElectronVersion } from '@electron-forge/core-utils/electron-version';
+import { move, readJson, writeJson } from '@electron-forge/core-utils/fs';
+import { listrCompatibleRebuildHook } from '@electron-forge/core-utils/rebuild';
 import { namedHookWithTaskFn, PluginBase } from '@electron-forge/plugin-base';
 import {
   ForgeArch,

--- a/packages/publisher/snapcraft/src/PublisherSnapcraft.ts
+++ b/packages/publisher/snapcraft/src/PublisherSnapcraft.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { pathExists } from '@electron-forge/core-utils';
+import { pathExists } from '@electron-forge/core-utils/fs';
 import {
   PublisherBase,
   PublisherOptions,

--- a/packages/template/base/src/BaseTemplate.ts
+++ b/packages/template/base/src/BaseTemplate.ts
@@ -4,9 +4,9 @@ import path from 'node:path';
 import {
   readJson,
   readJsonSync,
-  resolvePackageManager,
   writeJson,
-} from '@electron-forge/core-utils';
+} from '@electron-forge/core-utils/fs';
+import { resolvePackageManager } from '@electron-forge/core-utils/package-manager';
 import {
   ForgeListrTaskDefinition,
   ForgeTemplate,

--- a/packages/template/vite-typescript/spec/ViteTypeScriptTemplate.slow.verdaccio.spec.ts
+++ b/packages/template/vite-typescript/spec/ViteTypeScriptTemplate.slow.verdaccio.spec.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import {
   PACKAGE_MANAGERS,
   spawnPackageManager,
-} from '@electron-forge/core-utils';
+} from '@electron-forge/core-utils/package-manager';
 import * as testUtils from '@electron-forge/test-utils';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 

--- a/packages/template/vite-typescript/src/ViteTypeScriptTemplate.ts
+++ b/packages/template/vite-typescript/src/ViteTypeScriptTemplate.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { move, readJson, writeJson } from '@electron-forge/core-utils';
+import { move, readJson, writeJson } from '@electron-forge/core-utils/fs';
 import {
   ForgeListrTaskDefinition,
   InitTemplateOptions,

--- a/packages/template/vite/src/ViteTemplate.ts
+++ b/packages/template/vite/src/ViteTemplate.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 
-import { moveSync } from '@electron-forge/core-utils';
+import { moveSync } from '@electron-forge/core-utils/fs';
 import {
   ForgeListrTaskDefinition,
   InitTemplateOptions,

--- a/packages/template/webpack-typescript/spec/WebpackTypeScript.slow.verdaccio.spec.ts
+++ b/packages/template/webpack-typescript/spec/WebpackTypeScript.slow.verdaccio.spec.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import {
   PACKAGE_MANAGERS,
   spawnPackageManager,
-} from '@electron-forge/core-utils';
+} from '@electron-forge/core-utils/package-manager';
 import * as testUtils from '@electron-forge/test-utils';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 

--- a/packages/template/webpack-typescript/src/WebpackTypeScriptTemplate.ts
+++ b/packages/template/webpack-typescript/src/WebpackTypeScriptTemplate.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-import { readJson, writeJson } from '@electron-forge/core-utils';
+import { readJson, writeJson } from '@electron-forge/core-utils/fs';
 import {
   ForgeListrTaskDefinition,
   InitTemplateOptions,

--- a/packages/utils/core-utils/package.json
+++ b/packages/utils/core-utils/package.json
@@ -6,7 +6,16 @@
   "repository": "https://github.com/electron/forge",
   "author": "Samuel Attard",
   "license": "MIT",
-  "exports": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./author-name": "./dist/author-name.js",
+    "./electron-version": "./dist/electron-version.js",
+    "./fs": "./dist/fs.js",
+    "./install-dependencies": "./dist/install-dependencies.js",
+    "./package-manager": "./dist/package-manager.js",
+    "./rebuild": "./dist/rebuild.js",
+    "./resolve-working-dir": "./dist/resolve-working-dir.js"
+  },
   "typings": "dist/index.d.ts",
   "dependencies": {
     "@electron-forge/shared-types": "workspace:*",


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

`@electron-forge/core-utils` currently declares `"exports": "./dist/index.js"`, so the only way to consume it is through the barrel — which evaluates every module and their transitive dependencies (`semver`, `debug`, `graceful-fs`, `@malept/cross-spawn-promise`, ~40ms per fresh Node process) even when a consumer only needs a tiny helper like `pathExists` or `resolveWorkingDir`.

**Commit 1** replaces the single-string `exports` with an explicit exports map: `"."` still points at the barrel (fully backwards compatible), and each public source module gains its own subpath (`/author-name`, `/electron-version`, `/fs`, `/install-dependencies`, `/package-manager`, `/rebuild`, `/resolve-working-dir`). The list is deliberately explicit rather than a `"./*"` wildcard so `find-up` and `remote-rebuild` stay internal (`ERR_PACKAGE_PATH_NOT_EXPORTED`) and new modules only become public API by being listed. Types resolve from the sibling `.d.ts` files under `node16` module resolution; the `typings` field is kept for the root entry. The dist layout is unchanged, so `rebuild.ts`'s `cp.fork` of `remote-rebuild.js` is unaffected, and `@electron/rebuild` still only appears as a value import in the compiled `remote-rebuild.js`.

**Commit 2** migrates light consumers (makers, templates, publisher-snapcraft, plugin-vite, plugin-webpack, create-electron-app, CLI entry points) to subpath imports. `api/core` keeps importing the barrel since it uses the heavy modules anyway. Spec files that `vi.mock`'d the barrel now mock the specific submodule their subject imports, since vitest intercepts by module specifier.

This also unblocks #4210: its proposed `restart.ts` event-emitter module can ship as a leaf subpath that Vite config files load in build worker subprocesses without pulling in the whole barrel per worker.

Verified locally: `yarn build` (tsgo + `tools/test-dist`) passes, the full `fast` vitest project passes (408 tests), every listed subpath resolves at runtime from a consumer package, and the root barrel import is unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_013dfTZ7AecGYkxBjQ8DGT54)_