### PR TITLE
fix(create-electron-app): surface dependency install failures during init

### DIFF
--- a/packages/external/create-electron-app/spec/fast/init.spec.ts
+++ b/packages/external/create-electron-app/spec/fast/init.spec.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { installDependencies } from '@electron-forge/core-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { init } from '../../src/init.js';
+import { initNPM } from '../../src/init-scripts/init-npm.js';
+
+// Stub out everything that would hit the network. Template files are still
+// written to a real temporary directory, since `initializeTemplate` copies them.
+vi.mock(import('@electron-forge/core-utils'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  installDependencies: vi.fn(),
+}));
+
+vi.mock(
+  import('../../src/init-scripts/init-npm.js'),
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    initNPM: vi.fn(),
+  }),
+);
+
+describe('init', () => {
+  let dir: string;
+
+  const runInit = () => init({ dir, skipGit: true, interactive: false });
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'forge-init-spec-'));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(dir, { recursive: true, force: true });
+  });
+
+  it('should resolve when every dependency install succeeds', async () => {
+    await expect(runInit()).resolves.toBeUndefined();
+    expect(vi.mocked(initNPM)).toHaveBeenCalled();
+  });
+
+  // Regression test: these installs used to be marked `exitOnError: false`, so a
+  // failure was swallowed by listr2 and `init` resolved successfully — leaving
+  // behind a scaffolded app with missing dependencies and an exit code of 0.
+  it('should reject when installing common dependencies fails', async () => {
+    vi.mocked(initNPM).mockRejectedValue(new Error('initNPM exploded'));
+
+    await expect(runInit()).rejects.toThrow('initNPM exploded');
+  });
+
+  it('should reject when installing template dependencies fails', async () => {
+    vi.mocked(installDependencies).mockRejectedValue(
+      new Error('registry unreachable'),
+    );
+
+    await expect(runInit()).rejects.toThrow('registry unreachable');
+  });
+});

--- a/packages/external/create-electron-app/src/init.ts
+++ b/packages/external/create-electron-app/src/init.ts
@@ -218,7 +218,6 @@ export async function init({
                     DepVersionRestriction.RANGE,
                   );
                 },
-                exitOnError: false,
               },
               {
                 title: 'Installing development dependencies',
@@ -234,7 +233,6 @@ export async function init({
                     DepType.DEV,
                   );
                 },
-                exitOnError: false,
               },
               {
                 title: 'Finalizing dependencies',
@@ -245,7 +243,6 @@ export async function init({
                       task: async ({ pm }, task) => {
                         await initNPM(pm, dir, ctx.parsedElectronVersion, task);
                       },
-                      exitOnError: false,
                     },
                     {
                       title: 'Linking Forge dependencies to local build',


### PR DESCRIPTION
### Summary

The three dependency-install tasks in `init` were marked `exitOnError: false`. listr2 treats that as "mark this task FAILED but do not rethrow", so a failed install never propagated — `init` resolved, the CLI exited 0, and the parent tasks still rendered a green checkmark over the failed child.

The result is a scaffolded app that is quietly broken. Passing an unresolvable version (which clears `semver.clean` and then fails at install time) leaves `electron` absent from both `devDependencies` and `node_modules`, while still exiting 0:

```
✖ Installing common dependencies [FAILED: ...No candidates found]
✔ Finalizing dependencies
✔ Installing template dependencies
EXIT CODE: 0
```

With an unreachable registry it's worse — zero dependencies, no `node_modules` at all, still exit 0.

Via the programmatic API the failure is **completely invisible**: `interactive` defaults to `false`, so `silentRendererCondition` is true, there is no `✖` line at all, and `init()` simply resolves.

The relevant listr2 code (`Task.run`):

```js
if (this.listr.options.exitOnError !== false && await assertFunctionOrSelf(this.task?.exitOnError, context) !== false) {
  wrapper.report(error, "HAS_FAILED"); this.close(); throw error;
} else if (!this.hasSubtasks()) {
  wrapper.report(error, "HAS_FAILED_WITHOUT_ERROR");  // no rethrow
}
```

The error wasn't recoverable after the fact either: `report()` pushes onto `this.task.listr.errors` — the *innermost* nested list — so top-level `runner.errors.length === 0` and a post-run error check would not have caught it.

### Fix

Removed the option, restoring the default (`exitOnError: true`). This matches the `initLink` sibling in the same list, which already sets `exitOnError: true` explicitly. Failures now travel the same path as every other init error (e.g. an unknown template) and exit non-zero.

I fixed all three sites rather than only the `initNPM` one. The two template-dependency tasks are the same defect and are reachable today, since the webpack and vite templates have non-empty dependency lists. Happy to split them out if you'd prefer a narrower diff.

### Background

This isn't a deliberate design choice. `exitOnError: false` arrived as a list-level option in the async-ora → listr2 port (#3022); the pre-port code propagated these errors. #3219 — titled *"fix(core): silent failures when linking forge dependencies"* — then pushed the option down onto individual tasks and set `exitOnError: true` for `initLink` only, so this exact bug class was recognized and fixed for linking while the installs were left silent.

### Testing

Added `packages/external/create-electron-app/spec/fast/init.spec.ts`. Verified it genuinely catches the regression: with the fix reverted, 2 of the 3 tests fail with `promise resolved "undefined" instead of rejecting`.

- `yarn test:fast` — 56 files, 412 passed
- `yarn lint:js` — clean
- Manual end-to-end: `create-electron-app <dir> --electron-version 999.999.999` now exits 1 instead of 0

### Note for a follow-up

Init failures surface through `terminate.ts`'s `unhandledRejection` handler, so the output reads "An unhandled rejection has occurred inside Forge". That wording is misleading, but it's pre-existing and shared by every init failure path (commander's `.action()` promise is never awaited) — worth a separate cosmetic fix rather than widening this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
