### PR TITLE
feat(plugin-vite): support custom server host in renderer dev server URL

### DIFF
--- a/packages/plugin/vite/spec/config/vite.base.config.spec.ts
+++ b/packages/plugin/vite/spec/config/vite.base.config.spec.ts
@@ -113,6 +113,47 @@ describe('vite.base.config', () => {
     expect(define1).toEqual(define2);
   });
 
+  it('getBuildDefine:serve with custom server host', async () => {
+    const hosts = ['127.0.0.1', '0.0.0.0'];
+    const servers = await Promise.all(
+      forgeConfig.renderer.map(({ name }, index) =>
+        createServer({
+          publicDir: false,
+          server: { host: hosts[index] },
+          plugins: [pluginExposeRenderer(name)],
+        }),
+      ),
+    );
+    let port = 5183;
+
+    for (const server of servers) {
+      await server.listen(port);
+      port++;
+    }
+
+    const define1 = getBuildDefine({
+      command: 'serve',
+      mode: 'development',
+      root: configRoot,
+      forgeConfig,
+      forgeConfigSelf: forgeConfig.build[0],
+    });
+    const define2 = {
+      // Custom string hosts are exposed as-is.
+      MAIN_WINDOW_VITE_DEV_SERVER_URL: '"http://127.0.0.1:5183"',
+      MAIN_WINDOW_VITE_NAME: '"main_window"',
+      // Wildcard hosts fall back to localhost.
+      SECOND_WINDOW_VITE_DEV_SERVER_URL: '"http://localhost:5184"',
+      SECOND_WINDOW_VITE_NAME: '"second_window"',
+    };
+
+    for (const server of servers) {
+      await server.close();
+    }
+
+    expect(define1).toEqual(define2);
+  });
+
   describe('pluginHotRestart', () => {
     let dispose: (() => void) | undefined;
 

--- a/packages/plugin/vite/src/config/vite.base.config.ts
+++ b/packages/plugin/vite/src/config/vite.base.config.ts
@@ -75,6 +75,20 @@ export function getBuildDefine(env: ConfigEnv<'build'>) {
   return define;
 }
 
+/**
+ * Resolve the host to use in the dev server URL exposed to the main process.
+ * Wildcard hosts (`true`, `0.0.0.0`, `::`) are mapped to `localhost` since the
+ * main process runs on the same machine and wildcard addresses are not
+ * reliably loadable in Chromium.
+ */
+function resolveDevHost(host: string | boolean | undefined): string {
+  if (typeof host !== 'string' || host === '0.0.0.0' || host === '::') {
+    return 'localhost';
+  }
+  // IPv6 literals must be bracketed in URLs.
+  return host.includes(':') ? `[${host}]` : host;
+}
+
 export function pluginExposeRenderer(name: string): Plugin {
   const { VITE_DEV_SERVER_URL } = getDefineKeys([name])[name];
 
@@ -88,7 +102,7 @@ export function pluginExposeRenderer(name: string): Plugin {
         const addressInfo = server.httpServer?.address() as AddressInfo;
         // Expose env constant for main process use.
         viteDevServerUrls[VITE_DEV_SERVER_URL] =
-          `http://localhost:${addressInfo?.port}`;
+          `http://${resolveDevHost(server.config.server.host)}:${addressInfo?.port}`;
       });
     },
   };


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Ports #4030 by @ChenJiaH onto the `next` branch. Credit for the original change goes to @ChenJiaH (also credited via `Co-authored-by` on the commit).

Previously, the Vite plugin hardcoded the development server URL exposed to the main process (via the `<NAME>_VITE_DEV_SERVER_URL` define constant) to `http://localhost:<port>`. This prevented developers from using custom host addresses for the Vite dev server, which is useful for:

- Network debugging across different devices
- Docker container development environments
- Custom network configurations
- Remote development setups

The URL now respects a string `server.host` from the resolved Vite config. On top of the original PR, this port adds:

- Wildcard hosts (`true`, `'0.0.0.0'`, `'::'`) are normalized to `localhost`, since the main process runs on the same machine and wildcard addresses are not reliably loadable in Chromium (`http://:::5173` is not even a valid URL).
- IPv6 literal hosts are wrapped in brackets to form valid URLs.
- Test coverage in `vite.base.config.spec.ts` for both a custom string host and the wildcard fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hunyjnAGo97Vz7v2XgVJt

---
_Generated by [Claude Code](https://claude.ai/code/session_012hunyjnAGo97Vz7v2XgVJt)_