### PR TITLE
fix(maker-squirrel): normalize semver versions for Squirrel.Windows

### DIFF
--- a/packages/maker/squirrel/spec/MakerSquirrel.spec.ts
+++ b/packages/maker/squirrel/spec/MakerSquirrel.spec.ts
@@ -1,0 +1,59 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import { createWindowsInstaller } from 'electron-winstaller';
+import fs from 'fs-extra';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MakerSquirrel } from '../src/MakerSquirrel';
+
+vi.mock(import('electron-winstaller'), async (importOriginal) => {
+  const mod = await importOriginal<typeof import('electron-winstaller')>();
+  return {
+    ...mod,
+    createWindowsInstaller: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+describe('MakerSquirrel', () => {
+  let dir: string;
+  let makeDir: string;
+
+  const makeWithVersion = async (version: string) => {
+    const maker = new MakerSquirrel({}, []);
+    return maker.make({
+      dir,
+      makeDir,
+      targetArch: process.arch,
+      appName: 'My Test App',
+      forgeConfig: { packagerConfig: {} },
+      packageJSON: { version },
+    } as Parameters<typeof maker.make>[0]);
+  };
+
+  beforeEach(async () => {
+    vi.mocked(createWindowsInstaller).mockClear();
+    dir = path.resolve(os.tmpdir(), `forge-squirrel-test-${Date.now()}`);
+    makeDir = path.resolve(os.tmpdir(), `forge-squirrel-make-${Date.now()}`);
+    await fs.ensureDir(dir);
+    await fs.writeJson(path.resolve(dir, 'package.json'), {
+      name: 'my-app',
+      version: '1.0.1-0',
+    });
+  });
+
+  it('normalizes semver prerelease versions to a 4-part version for Squirrel', async () => {
+    await makeWithVersion('1.0.1-0');
+
+    expect(createWindowsInstaller).toHaveBeenCalledTimes(1);
+    const config = vi.mocked(createWindowsInstaller).mock.calls[0][0];
+    expect(config.version).toEqual('1.0.1.0');
+  });
+
+  it('keeps plain 3-part versions working and appends the revision digit', async () => {
+    await makeWithVersion('1.2.3');
+
+    const config = vi.mocked(createWindowsInstaller).mock.calls[0][0];
+    expect(config.version).toEqual('1.2.3.0');
+  });
+});

--- a/packages/maker/squirrel/src/MakerSquirrel.ts
+++ b/packages/maker/squirrel/src/MakerSquirrel.ts
@@ -45,6 +45,10 @@ export default class MakerSquirrel extends MakerBase<MakerSquirrelConfig> {
     await fs.copy(dir, tmpFolder);
 
     try {
+      // Squirrel.Windows (NuGet) only accepts 4-part version numbers, so a
+      // semver prerelease like 1.0.1-0 must be normalized before it reaches
+      // the installer.
+      const version = this.normalizeWindowsVersion(packageJSON.version);
       const winstallerConfig: ElectronWinstallerOptions = {
         name:
           typeof packageJSON.name === 'string'
@@ -55,13 +59,14 @@ export default class MakerSquirrel extends MakerBase<MakerSquirrelConfig> {
         exe: `${forgeConfig.packagerConfig.executableName || appName}.exe`,
         setupExe: `${appName}-${packageJSON.version} Setup.exe`,
         ...this.config,
+        version,
         appDirectory: tmpFolder,
         outputDirectory: outPath,
       };
 
       await createWindowsInstaller(winstallerConfig);
 
-      const nupkgVersion = convertVersion(packageJSON.version);
+      const nupkgVersion = convertVersion(version);
 
       const artifacts = [
         path.resolve(outPath, 'RELEASES'),


### PR DESCRIPTION
#### Description of Change

Squirrel.Windows (NuGet) only accepts 4-part version numbers, so a semver prerelease in package.json (e.g. `1.0.1-0` from `npm version prerelease`) made `createWindowsInstaller` fail with "'1.0.1-0' is not a valid version string".

The base maker already ships `normalizeWindowsVersion()` for exactly this — used by the AppX maker — but the Squirrel maker never picked it up (noted by @erickzhao in #3533). This routes the version passed to electron-winstaller through it, and names the nupkg artifacts from the normalized version.

Tests: added `packages/maker/squirrel/spec/MakerSquirrel.spec.ts` covering the prerelease case (`1.0.1-0` → `1.0.1.0`) and the plain case (`1.2.3` → `1.2.3.0`); red without the fix, green with it.

*Drafted with AI assistance and reviewed by the author.*

#### Issues

Fixes #3533

#### Checklist

- [x] I have built and tested this change
- [x] I have filled out the PR description
- [x] [I have reviewed and verified the changes](https://github.com/electron/governance/blob/main/policy/ai.md)
- [x] tests are [changed or added](https://github.com/electron/forge/blob/main/docs/development/testing.md)
- [x] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples)

#### Release Notes

Notes: Fixed creating Windows Squirrel installers for apps using semver prerelease versions such as `1.0.1-0`.