### PR TITLE
test: remove orphaned e2e specs for deleted typescript template packages

### DIFF
--- a/packages/template/vite-typescript/spec/template-vite-typescript-e2e.slow.verdaccio.spec.ts
+++ b/packages/template/vite-typescript/spec/template-vite-typescript-e2e.slow.verdaccio.spec.ts
@@ -1,6 +1,0 @@
-import { testForgeTemplate } from '@electron-forge/test-utils';
-
-testForgeTemplate({
-  moduleFormats: ['cjs'],
-  templateName: 'vite-typescript',
-});

--- a/packages/template/webpack-typescript/spec/template-webpack-typescript-e2e.slow.verdaccio.spec.ts
+++ b/packages/template/webpack-typescript/spec/template-webpack-typescript-e2e.slow.verdaccio.spec.ts
@@ -1,6 +1,0 @@
-import { testForgeTemplate } from '@electron-forge/test-utils';
-
-testForgeTemplate({
-  moduleFormats: ['cjs'],
-  templateName: 'webpack-typescript',
-});

--- a/packages/utils/test-utils/src/template-tests.ts
+++ b/packages/utils/test-utils/src/template-tests.ts
@@ -8,13 +8,7 @@ import os from 'node:os';
 
 type SupportedPackageManager = 'npm' | 'pnpm' | 'yarn';
 
-const supportedTemplates = [
-  'base',
-  'vite',
-  'vite-typescript',
-  'webpack',
-  'webpack-typescript',
-] as const;
+const supportedTemplates = ['base', 'vite', 'webpack'] as const;
 
 type ModuleFormat = 'es' | 'cjs';
 


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixes the `next` build break introduced by the merge of #4229 ([failing run](https://github.com/electron/forge/actions/runs/34647338472/job/103421159943)).

#4229 removed the `vite-typescript` and `webpack-typescript` template packages, but #4218 (merged to `next` after the PR's last push) had added `template-*-e2e.slow.verdaccio.spec.ts` files inside those packages. The merge kept the specs, so `packages/template/{vite,webpack}-typescript/` still existed with only a `spec/` directory. `tools/utils.ts` walks every `packages/*/*` directory and reads its `package.json`, so both `gen-tsconfigs` and `gen-ts-glue` failed during postinstall (`packages/tsconfig.json` was never written) and `yarn build` failed with TS6053.

Changes:
- Delete the two orphaned e2e specs; they targeted templates that no longer exist.
- Drop `vite-typescript` / `webpack-typescript` from the `supportedTemplates` list in the shared `testForgeTemplate` helper.

Verified locally: `yarn install --immutable` completes without the ENOENT errors and `yarn build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPay5LWxFefZAFQwFSZrW1

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPay5LWxFefZAFQwFSZrW1)_