### PR TITLE
chore: remove Discord links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,6 @@
 blank_issues_enabled: false
 
 contact_links:
-  - name: Question
-    url: https://discord.gg/invite/APGC3k5yaH
-    about: 'Please ask questions about using Electron Forge in the official Electron Discord server, at the #electron-forge channel.'
   - name: Documentation Issues
     url: https://github.com/electron-forge/electron-forge-docs/issues/new
     about: Documentation issues / pull requests should be filed in the website repository.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ## Electron Forge
 
 [![CI](https://github.com/electron/forge/actions/workflows/ci.yml/badge.svg)](https://github.com/electron/forge/actions/workflows/ci.yml)
-[![Discord](https://img.shields.io/discord/745037351163527189?color=blueviolet&logo=discord)](https://discord.com/invite/APGC3k5yaH)
 [![npm version](https://img.shields.io/npm/v/@electron-forge/cli)](https://npm.im/@electron-forge/cli)
 [![license](https://img.shields.io/github/license/electron/forge.svg)](https://github.com/electron/forge/blob/main/LICENSE)
 ![status](https://img.shields.io/badge/Status-%20Ready%20for%20Awesome-red.svg)
@@ -78,4 +77,4 @@ If you are interested in reporting/fixing issues and contributing directly to th
 ## Community
 
 Please report bugs or feature requests in our [issue tracker](https://github.com/electron/forge/issues).
-You can find help for debugging your Electron Forge on the [Support page](https://github.com/electron/forge/blob/main/SUPPORT.md), and ask questions in the [official Electron Discord server](https://discord.gg/invite/APGC3k5yaH), where there is a dedicated channel for Electron Forge.
+You can find help for debugging your Electron Forge on the [Support page](https://github.com/electron/forge/blob/main/SUPPORT.md).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,9 +1,6 @@
 # Support for Electron Forge
 
-If you have questions about usage, we encourage you to browse the [website](https://www.electronforge.io/),
-and visit one of the several [community-driven sites](https://github.com/electron/electron#community),
-including the [official Electron Discord server](https://discord.gg/invite/APGC3k5yaH), where there is a
-dedicated channel for Electron Forge.
+If you have questions about usage, check out the [website](https://www.electronforge.io/).
 
 ## Troubleshooting
 


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [ ] The changes have sufficient test coverage (if applicable).
- [ ] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Clean forward-port of https://github.com/electron/forge/pull/4372 from `main` to `next`, as part of the `next` → `main` transition audit. Removes the Discord badge and links from `README.md`, `SUPPORT.md`, and the issue template contact links. Docs-only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bb2CkBAwF2iaKw1fjfQd9h

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bb2CkBAwF2iaKw1fjfQd9h)_