### PR TITLE
ci: shard the slow tests and drop the dead node-gyp setup step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,19 +101,6 @@ jobs:
           name: dist-files
           path: packages
 
-      # `node-gyp` itself is pinned, but its dependencies are resolved fresh on
-      # every run, so `--before` holds them to the same week-old floor the root
-      # `.yarnrc.yml` applies to Yarn. It does that through `--before` rather
-      # than `min-release-age` because this step runs under the npm bundled with
-      # the Node version in `.nvmrc`, which is older than either age-gate
-      # setting and would ignore both without failing.
-      - name: Windows setup
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          cd "$PROGRAMFILES/nodejs/node_modules/npm/node_modules/@npmcli/run-script"
-          npm install node-gyp@9.4.0 --before "$(date -u -d '7 days ago' +%Y-%m-%d)"
-
       - name: Linux setup
         if: runner.os == 'Linux'
         run: |
@@ -145,6 +132,12 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-22.04, macos-latest]
         arch: [x64, arm64]
+        # The `slow` and `slow-verdaccio` vitest projects run in separate jobs,
+        # and the Verdaccio one, which takes about three times as long, is split
+        # into three shards that run in parallel. Vitest shards by test file and
+        # only balances the file count, not the duration, so check the job
+        # timings before assuming that another shard would help.
+        suite: [slow, verdaccio-1, verdaccio-2, verdaccio-3]
         exclude:
           - os: windows-latest
             arch: arm64
@@ -152,6 +145,13 @@ jobs:
             arch: arm64
           - os: macos-latest
             arch: x64
+        include:
+          - suite: verdaccio-1
+            shard: 1/3
+          - suite: verdaccio-2
+            shard: 2/3
+          - suite: verdaccio-3
+            shard: 3/3
 
     runs-on: ${{ matrix.os }}
 
@@ -186,19 +186,6 @@ jobs:
           name: dist-files
           path: packages
 
-      # `node-gyp` itself is pinned, but its dependencies are resolved fresh on
-      # every run, so `--before` holds them to the same week-old floor the root
-      # `.yarnrc.yml` applies to Yarn. It does that through `--before` rather
-      # than `min-release-age` because this step runs under the npm bundled with
-      # the Node version in `.nvmrc`, which is older than either age-gate
-      # setting and would ignore both without failing.
-      - name: Windows setup
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          cd "$PROGRAMFILES/nodejs/node_modules/npm/node_modules/@npmcli/run-script"
-          npm install node-gyp@9.4.0 --before "$(date -u -d '7 days ago' +%Y-%m-%d)"
-
       - name: Linux setup
         if: runner.os == 'Linux'
         run: |
@@ -229,10 +216,16 @@ jobs:
         run: npm install -g npm@11.19.0
 
       - name: Run slow tests
+        if: matrix.suite == 'slow'
         run: |
           mkdir -p ./reports/out
           yarn test:slow --reporter=default --reporter=junit --outputFile="./reports/out/test_output.xml"
-          yarn test:verdaccio --reporter=default --reporter=junit --outputFile="./reports/out/test_output_verdaccio.xml"
+
+      - name: Run Verdaccio tests
+        if: matrix.suite != 'slow'
+        run: |
+          mkdir -p ./reports/out
+          yarn test:verdaccio --reporter=default --reporter=junit --outputFile="./reports/out/test_output_verdaccio.xml" --shard=${{ matrix.shard }}
 
   required-ci:
     needs:


### PR DESCRIPTION
## Summary

The Windows `slow-tests` job on `next` takes over 22 minutes. On the last green run ([33808826023](https://github.com/electron/forge/actions/runs/33808826023)) it broke down as:

| Step | Time |
|---|---|
| "Windows setup" (installs node-gyp 9.4.0) | 3.1 min |
| `slow` vitest project | 4.6 min |
| `slow-verdaccio` vitest project | 12.7 min |
| Checkout, Node, yarn install, artifacts, pnpm, npm | ~1.5 min |

This PR makes two changes to `ci.yml`.

### Drop the node-gyp setup step

It is left over from CircleCI and no longer does anything:

- It installs node-gyp into `C:\Program Files\nodejs\node_modules\npm\...`, but `actions/setup-node` downloads its own Node into the tool cache and puts it first on `PATH`, so that npm tree is never used.
- The slow job then installs npm 11.19.0 globally, whose bundled node-gyp 12.4 is what actually compiles the webpack native-module fixture (`native-hello-world` runs `node-gyp rebuild` on install) on the current `windows-2025-vs2026` image.
- node-gyp 9.4.0 only knows Visual Studio 2017–2022 and cannot detect VS 2026 (support landed in node-gyp 12.1.0), so if the pin had been in effect, `AssetRelocatorPatch.slow.spec.ts` would already be failing on Windows.

Removing it saves 3 minutes on every Windows job, in both `fast-tests` and `slow-tests`.

### Shard the slow tests

The `slow` and `slow-verdaccio` vitest projects now run in separate jobs, and the Verdaccio project is split into three shards with vitest's `--shard`. Verdaccio startup plus publishing only costs about 16 seconds per job, so the split is cheap. Vitest shards by a hash of the file path; simulated with the real per-file timings from the run above, the Windows shards come out at roughly 295s, 288s, and 172s.

Expected wall clock for `slow-tests`:

| OS | Before | After (est.) |
|---|---|---|
| Windows | 22.5 min | ~7 min |
| Linux | 11.6 min | ~5 min |
| macOS | 13.7 min | ~6 min |

The trade-off is job count: 17 jobs per run instead of 8, with 5 macOS jobs at once instead of 2. If macOS queueing becomes a problem, dropping to two Verdaccio shards is a one-line change to the `suite` list and `include` block, at a cost of about 2 more minutes on the critical path.

## Verification

- `zizmor` reports exactly the same three pre-existing `cache-poisoning` findings for `setup-node` as before, nothing new.
- `oxfmt --check` passes on the workflow.
- The matrix expands to the intended 12 `slow-tests` jobs.
- `vitest list --project slow-verdaccio --shard=N/3` locally matches the simulated split.

The node-gyp removal can only really be validated by this PR's own Windows CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
