### PR TITLE
feat(maker-pkg)!: write PKGs to arch subdirectories

### DIFF
--- a/packages/maker/pkg/spec/MakerPKG.spec.ts
+++ b/packages/maker/pkg/spec/MakerPKG.spec.ts
@@ -64,6 +64,31 @@ describe('MakerPKG', () => {
     expect(vi.mocked(notarize)).not.toHaveBeenCalled();
   });
 
+  it('should output to an arch-specific subdirectory to avoid conflicts between parallel makers', async () => {
+    const maker = new MakerPKG({}, []);
+    maker.ensureFile = vi.fn();
+    await maker.prepareConfig(targetArch);
+    const outPaths = await (maker.make as MakeFunction)({
+      packageJSON,
+      dir,
+      makeDir,
+      appName,
+      targetArch,
+      targetPlatform: 'darwin',
+      forgeConfig: makeForgeConfig(),
+    });
+    const expectedPath = path.resolve(
+      makeDir,
+      'pkg',
+      targetArch,
+      `My Test App-1.2.3-${targetArch}.pkg`,
+    );
+    expect(outPaths).toEqual([expectedPath]);
+    expect(vi.mocked(flat)).toHaveBeenCalledWith(
+      expect.objectContaining({ pkg: expectedPath }),
+    );
+  });
+
   it('should throw an error on invalid platform', async () => {
     const maker = new MakerPKG({}, []);
     maker.ensureFile = vi.fn();

--- a/packages/maker/pkg/src/MakerPKG.ts
+++ b/packages/maker/pkg/src/MakerPKG.ts
@@ -33,7 +33,7 @@ export default class MakerPKG extends MakerBase<MakerPKGConfig> {
 
     const name =
       this.config.name || `${appName}-${packageJSON.version}-${targetArch}`;
-    const outPath = path.resolve(makeDir, `${name}.pkg`);
+    const outPath = path.resolve(makeDir, 'pkg', targetArch, `${name}.pkg`);
 
     await this.ensureFile(outPath);
 


### PR DESCRIPTION
BREAKING CHANGE: `maker-pkg` now writes the distributable to arch-specific subdirectories