### PR TITLE
test(core): stub packager arch list in the dropped-arch warning test

### DIFF
--- a/packages/api/core/spec/fast/util/parse-archs.spec.ts
+++ b/packages/api/core/spec/fast/util/parse-archs.spec.ts
@@ -1,6 +1,17 @@
+import { allOfficialArchsForPlatformAndVersion } from '@electron/packager';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import parseArchs from '../../../src/util/parse-archs';
+
+vi.mock(import('@electron/packager'), async (importOriginal) => {
+  const mod = await importOriginal();
+  return {
+    ...mod,
+    allOfficialArchsForPlatformAndVersion: vi.fn(
+      mod.allOfficialArchsForPlatformAndVersion,
+    ),
+  };
+});
 
 describe('parse-archs', () => {
   it('should make an Array out of one arch', () => {
@@ -61,10 +72,20 @@ describe('parse-archs', () => {
     });
 
     it('should warn when filtering a dropped arch out of "all"', () => {
+      // @electron/packager >= 20.3.0 already omits win32/ia32 for Electron
+      // 44, so simulate an older packager that still reports it to make sure
+      // Forge's own filter drops it (with a warning) rather than failing on a
+      // download 404 later.
+      vi.mocked(allOfficialArchsForPlatformAndVersion).mockReturnValueOnce([
+        'ia32',
+        'x64',
+        'arm64',
+      ]);
       const warnSpy = vi
         .spyOn(console, 'warn')
         .mockImplementation(() => undefined);
-      parseArchs('win32', 'all', '44.0.0');
+      expect(parseArchs('win32', 'all', '44.0.0')).toEqual(['x64', 'arm64']);
+      expect(warnSpy).toHaveBeenCalledOnce();
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Skipping win32/ia32'),
       );

--- a/packages/api/core/src/util/parse-archs.ts
+++ b/packages/api/core/src/util/parse-archs.ts
@@ -19,9 +19,9 @@ export default function parseArchs(
       platform as SupportedPlatform,
       electronVersion,
     ) || ['x64'];
-    // `allOfficialArchsForPlatformAndVersion()` (as of @electron/packager
-    // 18.x) still reports architectures that Electron >= 44 no longer
-    // publishes, so filter those out rather than failing on a download 404.
+    // @electron/packager < 20.3.0 still reported architectures that
+    // Electron >= 44 no longer publishes, so filter those out ourselves
+    // rather than failing on a download 404.
     return filterSupportedArchs(platform, archs, electronVersion);
   }
 

--- a/packages/api/core/src/util/supported-archs.ts
+++ b/packages/api/core/src/util/supported-archs.ts
@@ -15,9 +15,10 @@ const FIRST_RELEASE_WITHOUT_IA32_ARMV7L = '44.0.0-alpha.4';
  * longer publishes prebuilt binaries for it.
  *
  * Electron 44.0.0-alpha.4 and later no longer publish win32/ia32 or
- * linux/armv7l builds, but `allOfficialArchsForPlatformAndVersion()` from
- * `@electron/packager` (as of 18.x) still reports them, which would otherwise
- * surface as an opaque download 404.
+ * linux/armv7l builds. `allOfficialArchsForPlatformAndVersion()` from
+ * `@electron/packager` < 20.3.0 still reported them, which would otherwise
+ * surface as an opaque download 404, and an explicit `--arch=ia32` request
+ * still needs a descriptive error either way.
  */
 export function isArchDroppedByElectron44(
   platform: ForgePlatform | string,


### PR DESCRIPTION
- [x] I have read the [contribution documentation](https://github.com/electron/forge/blob/main/CONTRIBUTING.md) for this project.
- [x] I agree to follow the [code of conduct](https://github.com/electron/electron/blob/main/CODE_OF_CONDUCT.md) that this project follows, as appropriate.
- [x] The changes are appropriately documented (if applicable).
- [x] The changes have sufficient test coverage (if applicable).
- [x] The testsuite passes successfully on my local machine (if applicable).

**Summarize your changes:**

Fixes the `fast-tests` failure on `next` from https://github.com/electron/forge/actions/runs/34652320724 (`parse-archs > archs dropped by Electron 44 > should warn when filtering a dropped arch out of "all"`, failing on all three platforms).

#4379 bumped `@electron/packager` to 20.3.0, which already omits `win32/ia32` and `linux/armv7l` from `allOfficialArchsForPlatformAndVersion()` for Electron >= 44.0.0-alpha.4. #4377 landed four minutes later and was tested against the older packager, so its `--arch=all` guard in `parseArchs()` never sees the dropped arches with the pinned packager and never emits the warning the test expects.

This PR:

- stubs the packager arch list in that one test so it exercises Forge's own filter regardless of what the installed packager reports, and also asserts the filtered result and single warning
- updates the two source comments that still described packager 18.x behaviour

No runtime behaviour changes. The explicit `--arch=ia32` / `--arch=armv7l` error path is unaffected.

Verified locally with `yarn build && yarn test:fast` (58 files, 538 tests passing) plus `oxfmt --check` and `oxlint` on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uj4Vx4Acv7PY1MmGq2kf3e

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uj4Vx4Acv7PY1MmGq2kf3e)_